### PR TITLE
bump!: target .net 8.0

### DIFF
--- a/src/OrasProject.Oras/OrasProject.Oras.csproj
+++ b/src/OrasProject.Oras/OrasProject.Oras.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<PackageId>OrasProject.Oras</PackageId>
 		<Version>0.0.0-dev</Version>
 		<RepositoryUrl>https://github.com/oras-project/oras-dotnet</RepositoryUrl>
@@ -9,6 +9,7 @@
 		<PackageTags>OCI, ORAS, Registry, Container, Image, Artifacts</PackageTags>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<OutputType>Library</OutputType>
 	</PropertyGroup>
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
@@ -16,10 +17,9 @@
 		</AssemblyAttribute>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="7.0.2" />
+		<PackageReference Include="System.Text.Json" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup>
-    	<None Include="README.md" Pack="true" PackagePath="/"/>
+    	<None Include="README.md" Pack="true" PackagePath="/" />
   	</ItemGroup>
 </Project>
-

--- a/tests/OrasProject.Oras.Tests/Oras.Tests.csproj
+++ b/tests/OrasProject.Oras.Tests/Oras.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
### What this PR does / why we need it
Target to `.NET 8.0` as this is a new resuable library.

### Which issue(s) this PR resolves / fixes
Resolves #73

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [x] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have an appropriate license header?
