### PR TITLE
feat: make `ReadAllAsync` public

### DIFF
--- a/src/OrasProject.Oras/Content/Extensions.cs
+++ b/src/OrasProject.Oras/Content/Extensions.cs
@@ -30,7 +30,7 @@ public static class Extensions
     /// <param name="node"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public static async Task<IEnumerable<Descriptor>> GetSuccessorsAsync(this IFetchable fetcher, Descriptor node, CancellationToken cancellationToken)
+    public static async Task<IEnumerable<Descriptor>> GetSuccessorsAsync(this IFetchable fetcher, Descriptor node, CancellationToken cancellationToken = default)
     {
         switch (node.MediaType)
         {
@@ -71,7 +71,7 @@ public static class Extensions
     /// <param name="desc"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public static async Task<byte[]> FetchAllAsync(this IFetchable fetcher, Descriptor desc, CancellationToken cancellationToken)
+    public static async Task<byte[]> FetchAllAsync(this IFetchable fetcher, Descriptor desc, CancellationToken cancellationToken = default)
     {
         var stream = await fetcher.FetchAsync(desc, cancellationToken).ConfigureAwait(false);
         return await stream.ReadAllAsync(desc, cancellationToken).ConfigureAwait(false);
@@ -86,7 +86,7 @@ public static class Extensions
     /// <exception cref="InvalidDescriptorSizeException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     /// <exception cref="MismatchedDigestException"></exception>
-    internal static async Task<byte[]> ReadAllAsync(this Stream stream, Descriptor descriptor, CancellationToken cancellationToken)
+    public static async Task<byte[]> ReadAllAsync(this Stream stream, Descriptor descriptor, CancellationToken cancellationToken = default)
     {
         if (descriptor.Size < 0)
         {


### PR DESCRIPTION
### What this PR does / why we need it
`ReadAllAsync` is necessary for the pulling scenario.

### Which issue(s) this PR resolves / fixes
N/A

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have an appropriate license header?
