### PR TITLE
build: clean version for dev

### DIFF
--- a/src/OrasProject.Oras/OrasProject.Oras.csproj
+++ b/src/OrasProject.Oras/OrasProject.Oras.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<PackageId>OrasProject.Oras</PackageId>
-		<PackageVersion>0.2.0-dev</PackageVersion>
+		<PackageVersion>0.0.0-dev</PackageVersion>
 		<Authors>Oras Project</Authors>
 		<Description>Oras package provides API to work with OCI</Description>
 		<Copyright>Copyright (c) ORAS Project 2024</Copyright>


### PR DESCRIPTION
### What this PR does / why we need it
Make `v0.0.0-dev` as the default version.

> [!NOTE]
> The package version will be override by the tagged version for nuget publishing

### Which issue(s) this PR resolves / fixes
Related to #55 

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have an appropriate license header?
