### PR TITLE
fix: use existing query params from blobstore response 

### DIFF
--- a/src/OrasProject.Oras/Content/Digest.cs
+++ b/src/OrasProject.Oras/Content/Digest.cs
@@ -20,8 +20,8 @@ namespace OrasProject.Oras.Content;
 
 internal static class Digest
 {
-    private const string digestRegexPattern = @"[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+";
-    private static readonly Regex digestRegex = new Regex(digestRegexPattern, RegexOptions.Compiled);
+    private const string _digestRegexPattern = @"[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+";
+    private static readonly Regex _digestRegex = new Regex(_digestRegexPattern, RegexOptions.Compiled);
 
     /// <summary>
     /// Verifies the digest header and throws an exception if it is invalid.
@@ -29,7 +29,7 @@ internal static class Digest
     /// <param name="digest"></param>
     internal static string Validate(string? digest)
     {
-        if (string.IsNullOrEmpty(digest) || !digestRegex.IsMatch(digest))
+        if (string.IsNullOrEmpty(digest) || !_digestRegex.IsMatch(digest))
         {
             throw new InvalidDigestException($"Invalid digest: {digest}");
         }

--- a/src/OrasProject.Oras/Content/Digest.cs
+++ b/src/OrasProject.Oras/Content/Digest.cs
@@ -13,6 +13,7 @@
 
 using OrasProject.Oras.Exceptions;
 using System;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 
@@ -22,6 +23,9 @@ internal static class Digest
 {
     private const string _digestRegexPattern = @"[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+";
     private static readonly Regex _digestRegex = new Regex(_digestRegexPattern, RegexOptions.Compiled);
+
+    // List of registered and supported algorithms as per the specification
+    private static readonly HashSet<string> _supportedAlgorithms = new HashSet<string> { "sha256", "sha512" };
 
     /// <summary>
     /// Verifies the digest header and throws an exception if it is invalid.
@@ -33,6 +37,13 @@ internal static class Digest
         {
             throw new InvalidDigestException($"Invalid digest: {digest}");
         }
+
+        var algorithm = digest.Split(':')[0];
+        if (!_supportedAlgorithms.Contains(algorithm))
+        {
+            throw new InvalidDigestException($"Unrecognized, unregistered or unsupported digest algorithm: {algorithm}");
+        }
+
         return digest;
     }
 

--- a/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
+++ b/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
@@ -152,7 +152,7 @@ public class BlobStore(Repository repository) : IBlobStore
         // add digest key to query string with expected digest value
         var req = new HttpRequestMessage(HttpMethod.Put, new UriBuilder(url)
         {
-            Query = $"digest={HttpUtility.UrlEncode(expected.Digest)}"
+            Query = $"{url.Query}&digest={HttpUtility.UrlEncode(expected.Digest)}"
         }.Uri);
         req.Content = new StreamContent(content);
         req.Content.Headers.ContentLength = expected.Size;

--- a/src/OrasProject.Oras/Registry/Remote/HttpResponseMessageExtensions.cs
+++ b/src/OrasProject.Oras/Registry/Remote/HttpResponseMessageExtensions.cs
@@ -25,6 +25,8 @@ namespace OrasProject.Oras.Registry.Remote;
 
 internal static class HttpResponseMessageExtensions
 {
+    private const string _dockerContentDigestHeader = "Docker-Content-Digest";
+
     /// <summary>
     /// Parses the error returned by the remote registry.
     /// </summary>
@@ -75,7 +77,7 @@ internal static class HttpResponseMessageExtensions
     /// <exception cref="NotImplementedException"></exception>
     public static void VerifyContentDigest(this HttpResponseMessage response, string expected)
     {
-        if (!response.Content.Headers.TryGetValues("Docker-Content-Digest", out var digestValues))
+        if (!response.Headers.TryGetValues(_dockerContentDigestHeader, out var digestValues))
         {
             return;
         }
@@ -154,7 +156,7 @@ internal static class HttpResponseMessageExtensions
 
         // 4. Validate Server Digest (if present)
         string? serverDigest = null;
-        if (response.Content.Headers.TryGetValues("Docker-Content-Digest", out var serverHeaderDigest))
+        if (response.Headers.TryGetValues(_dockerContentDigestHeader, out var serverHeaderDigest))
         {
             serverDigest = serverHeaderDigest.FirstOrDefault();
             if (!string.IsNullOrEmpty(serverDigest))

--- a/tests/OrasProject.Oras.Tests/Content/ContentTest.cs
+++ b/tests/OrasProject.Oras.Tests/Content/ContentTest.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 using OrasProject.Oras.Content;
+using OrasProject.Oras.Exceptions;
 using System.Text;
 using Xunit;
 
@@ -19,6 +20,7 @@ namespace OrasProject.Oras.Tests.Content;
 
 public class CalculateDigest
 {
+    
     /// <summary>
     /// This method tests if the digest is calculated properly
     /// </summary>
@@ -29,5 +31,40 @@ public class CalculateDigest
         var content = Encoding.UTF8.GetBytes("helloWorld");
         var calculateHelloWorldDigest = Digest.ComputeSHA256(content);
         Assert.Equal(helloWorldDigest, calculateHelloWorldDigest);
+    }
+
+    /// <summary>
+    /// This method tests if the digest validation passes for registered algorithms
+    /// </summary>
+    [Theory]
+    [InlineData("sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b")]
+    [InlineData("sha512:401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b372742c513925d98f76b340d9e59a4efdc45db9f5c640a21831b3d08be")]
+    public void Validate_ReturnsDigest_ForRegisteredAlgorithms(string validDigest)
+    {
+        var result = Digest.Validate(validDigest);
+        Assert.Equal(validDigest, result);
+    }
+
+    /// <summary>
+    /// This method tests if the digest validation throws an exception for unregistered or unsupported algorithms
+    /// </summary>
+    [Theory]
+    [InlineData("md5:098f6bcd4621d373cade4e832627b4f6")] // MD5, unregistered digest
+    [InlineData("sha1:3b8b5a6b79f6d1114a7b7e95b3e3bc74dd1b6a2a")] // SHA-1, unregistered digest
+    [InlineData("multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8")] // Multihash, unregistered digest
+    public void Validate_ThrowsException_ForUnregisteredAlgorithms(string invalidDigest)
+    {
+        Assert.Throws<InvalidDigestException>(() => Digest.Validate(invalidDigest));
+    }
+
+    /// <summary>
+    /// This method tests if the digest validation throws an exception for various invalid digest formats
+    /// </summary>
+    [Theory]
+    [InlineData("sha256:")] // Missing encoded portion
+    [InlineData("sha256+b64u!LCa0a2j_xo_5m0U8HTBBNBNCLXBkg7-g-YpeiGJm564")] // Invalid character in encoded portion
+    public void Validate_ThrowsException_ForInvalidDigestFormats(string invalidDigest)
+    {
+        Assert.Throws<InvalidDigestException>(() => Digest.Validate(invalidDigest));
     }
 }

--- a/tests/OrasProject.Oras.Tests/Remote/RepositoryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Remote/RepositoryTest.cs
@@ -42,10 +42,11 @@ public class RepositoryTest
         public bool errExpectedOnGET;
     }
 
-    private byte[] theAmazingBanClan = "Ban Gu, Ban Chao, Ban Zhao"u8.ToArray();
-    private const string theAmazingBanDigest = "b526a4f2be963a2f9b0990c001255669eab8a254ab1a6e3f84f1820212ac7078";
+    private byte[] _theAmazingBanClan = "Ban Gu, Ban Chao, Ban Zhao"u8.ToArray();
+    private const string _theAmazingBanDigest = "b526a4f2be963a2f9b0990c001255669eab8a254ab1a6e3f84f1820212ac7078";
 
-    private const string dockerContentDigestHeader = "Docker-Content-Digest";
+    private const string _dockerContentDigestHeader = "Docker-Content-Digest";
+
     // The following truth table aims to cover the expected GET/HEAD request outcome
     // for all possible permutations of the client/server "containing a digest", for
     // both Manifests and Blobs.  Where the results between the two differ, the index
@@ -85,7 +86,7 @@ public class RepositoryTest
     /// <returns></returns>
     public static Dictionary<string, TestIOStruct> GetTestIOStructMapForGetDescriptorClass()
     {
-        string correctDigest = $"sha256:{theAmazingBanDigest}";
+        string correctDigest = $"sha256:{_theAmazingBanDigest}";
         string incorrectDigest = $"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
         return new Dictionary<string, TestIOStruct>
@@ -194,7 +195,7 @@ public class RepositoryTest
             {
                 resp.Content = new ByteArrayContent(blob);
                 resp.Content.Headers.Add("Content-Type", "application/octet-stream");
-                resp.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                resp.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 return resp;
             }
 
@@ -209,7 +210,7 @@ public class RepositoryTest
 
                 resp.Content = new ByteArrayContent(index);
                 resp.Content.Headers.Add("Content-Type", indexDesc.MediaType);
-                resp.Content.Headers.Add("Docker-Content-Digest", indexDesc.Digest);
+                resp.Headers.Add(_dockerContentDigestHeader, indexDesc.Digest);
                 return resp;
             }
 
@@ -289,7 +290,7 @@ public class RepositoryTest
 
                 var stream = req.Content!.ReadAsStream(cancellationToken);
                 stream.Read(gotBlob);
-                resp.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                resp.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 resp.StatusCode = HttpStatusCode.Created;
                 return resp;
 
@@ -307,7 +308,7 @@ public class RepositoryTest
 
                 var stream = req.Content!.ReadAsStream(cancellationToken);
                 stream.Read(gotIndex);
-                resp.Content.Headers.Add("Docker-Content-Digest", indexDesc.Digest);
+                resp.Headers.Add(_dockerContentDigestHeader, indexDesc.Digest);
                 resp.StatusCode = HttpStatusCode.Created;
                 return resp;
             }
@@ -364,7 +365,7 @@ public class RepositoryTest
             {
                 res.Content.Headers.Add("Content-Type", "application/octet-stream");
                 res.Content.Headers.Add("Content-Length", blobDesc.Size.ToString());
-                res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 return res;
             }
 
@@ -378,7 +379,7 @@ public class RepositoryTest
 
                 res.Content.Headers.Add("Content-Type", indexDesc.MediaType);
                 res.Content.Headers.Add("Content-Length", indexDesc.Size.ToString());
-                res.Content.Headers.Add("Docker-Content-Digest", indexDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, indexDesc.Digest);
                 return res;
             }
 
@@ -432,7 +433,7 @@ public class RepositoryTest
             if (req.RequestUri!.AbsolutePath == "/v2/test/blobs/" + blobDesc.Digest)
             {
                 blobDeleted = true;
-                res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 res.StatusCode = HttpStatusCode.Accepted;
                 return res;
             }
@@ -440,7 +441,7 @@ public class RepositoryTest
             if (req.RequestUri!.AbsolutePath == "/v2/test/manifests/" + indexDesc.Digest)
             {
                 indexDeleted = true;
-                // no "Docker-Content-Digest" header for manifest deletion
+                // no dockerContentDigestHeader header for manifest deletion
                 res.StatusCode = HttpStatusCode.Accepted;
                 return res;
             }
@@ -509,7 +510,7 @@ public class RepositoryTest
 
                 res.Content.Headers.Add("Content-Type", indexDesc.MediaType);
                 res.Content.Headers.Add("Content-Length", indexDesc.Size.ToString());
-                res.Content.Headers.Add("Docker-Content-Digest", indexDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, indexDesc.Digest);
                 return res;
             }
 
@@ -583,7 +584,7 @@ public class RepositoryTest
 
                 res.Content = new ByteArrayContent(index);
                 res.Content.Headers.Add("Content-Type", indexDesc.MediaType);
-                res.Content.Headers.Add("Docker-Content-Digest", indexDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, indexDesc.Digest);
                 return res;
             }
 
@@ -601,7 +602,7 @@ public class RepositoryTest
                 {
                     gotIndex = await req.Content.ReadAsByteArrayAsync(cancellationToken);
                 }
-                res.Content.Headers.Add("Docker-Content-Digest", indexDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, indexDesc.Digest);
                 res.StatusCode = HttpStatusCode.Created;
                 return res;
             }
@@ -656,7 +657,7 @@ public class RepositoryTest
                 {
                     gotIndex = await req.Content.ReadAsByteArrayAsync();
                 }
-                res.Content.Headers.Add("Docker-Content-Digest", indexDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, indexDesc.Digest);
                 res.StatusCode = HttpStatusCode.Created;
                 return res;
             }
@@ -723,7 +724,7 @@ public class RepositoryTest
 
                 res.Content = new ByteArrayContent(index);
                 res.Content.Headers.Add("Content-Type", indexDesc.MediaType);
-                res.Content.Headers.Add("Docker-Content-Digest", indexDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, indexDesc.Digest);
                 return res;
             }
 
@@ -887,7 +888,7 @@ public class RepositoryTest
             {
                 res.Content = new ByteArrayContent(blob);
                 res.Content.Headers.Add("Content-Type", "application/octet-stream");
-                res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 return res;
             }
 
@@ -950,7 +951,7 @@ public class RepositoryTest
                     res.StatusCode = HttpStatusCode.OK;
                     res.Content = new ByteArrayContent(blob);
                     res.Content.Headers.Add("Content-Type", "application/octet-stream");
-                    res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                    res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                     return res;
                 }
 
@@ -977,12 +978,12 @@ public class RepositoryTest
                 res.StatusCode = HttpStatusCode.PartialContent;
                 res.Content = new ByteArrayContent(blob[(int)start..(int)end]);
                 res.Content.Headers.Add("Content-Type", "application/octet-stream");
-                res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 return res;
             }
 
             res.Content.Headers.Add("Content-Type", "application/octet-stream");
-            res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+            res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
             res.StatusCode = HttpStatusCode.NotFound;
             return res;
         };
@@ -1044,7 +1045,7 @@ public class RepositoryTest
                 }
 
                 res.Content.Headers.Add("Content-Type", "application/octet-stream");
-                res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 return res;
             }
 
@@ -1108,7 +1109,7 @@ public class RepositoryTest
                 // read content into buffer
                 var stream = req.Content!.ReadAsStream(cancellationToken);
                 stream.Read(gotBlob);
-                res.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 res.StatusCode = HttpStatusCode.Created;
                 return res;
             }
@@ -1161,7 +1162,7 @@ public class RepositoryTest
             if (req.RequestUri?.AbsolutePath == $"/v2/test/blobs/{blobDesc.Digest}")
             {
                 res.Content.Headers.Add("Content-Type", "application/octet-stream");
-                res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 res.Content.Headers.Add("Content-Length", blobDesc.Size.ToString());
                 return res;
             }
@@ -1210,7 +1211,7 @@ public class RepositoryTest
             if (req.RequestUri?.AbsolutePath == $"/v2/test/blobs/{blobDesc.Digest}")
             {
                 blobDeleted = true;
-                res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 res.StatusCode = HttpStatusCode.Accepted;
                 return res;
             }
@@ -1265,7 +1266,7 @@ public class RepositoryTest
             if (req.RequestUri?.AbsolutePath == $"/v2/test/blobs/{blobDesc.Digest}")
             {
                 res.Content.Headers.Add("Content-Type", "application/octet-stream");
-                res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 res.Content.Headers.Add("Content-Length", blobDesc.Size.ToString());
                 return res;
             }
@@ -1327,7 +1328,7 @@ public class RepositoryTest
             {
                 res.Content = new ByteArrayContent(blob);
                 res.Content.Headers.Add("Content-Type", "application/octet-stream");
-                res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 return res;
             }
 
@@ -1411,7 +1412,7 @@ public class RepositoryTest
                     res.StatusCode = HttpStatusCode.OK;
                     res.Content = new ByteArrayContent(blob);
                     res.Content.Headers.Add("Content-Type", "application/octet-stream");
-                    res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                    res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                     return res;
                 }
 
@@ -1426,12 +1427,12 @@ public class RepositoryTest
                 res.StatusCode = HttpStatusCode.PartialContent;
                 res.Content = new ByteArrayContent(blob[(int)start..]);
                 res.Content.Headers.Add("Content-Type", "application/octet-stream");
-                res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
                 return res;
             }
 
             res.Content.Headers.Add("Content-Type", "application/octet-stream");
-            res.Content.Headers.Add("Docker-Content-Digest", blobDesc.Digest);
+            res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
             res.StatusCode = HttpStatusCode.NotFound;
             return res;
         };
@@ -1493,14 +1494,14 @@ public class RepositoryTest
                 var resp = new HttpResponseMessage();
                 if (method == HttpMethod.Get)
                 {
-                    resp.Content = new ByteArrayContent(theAmazingBanClan);
+                    resp.Content = new ByteArrayContent(_theAmazingBanClan);
                     resp.Content.Headers.Add("Content-Type", new string[] { "application/vnd.docker.distribution.manifest.v2+json" });
-                    resp.Content.Headers.Add(dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
+                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
                 }
-                if (!resp.Content.Headers.TryGetValues(dockerContentDigestHeader, out IEnumerable<string>? values))
+                if (!resp.Headers.TryGetValues(_dockerContentDigestHeader, out IEnumerable<string>? values))
                 {
                     resp.Content.Headers.Add("Content-Type", new string[] { "application/vnd.docker.distribution.manifest.v2+json" });
-                    resp.Content.Headers.Add(dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
+                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
                     resp.RequestMessage = new HttpRequestMessage()
                     {
                         Method = method
@@ -1590,7 +1591,7 @@ public class RepositoryTest
                 }
                 res.Content = new ByteArrayContent(manifest);
                 res.Content.Headers.Add("Content-Type", new string[] { MediaType.ImageManifest });
-                res.Content.Headers.Add("Docker-Content-Digest", new string[] { manifestDesc.Digest });
+                res.Headers.Add(_dockerContentDigestHeader, new string[] { manifestDesc.Digest });
                 return res;
             }
             return new HttpResponseMessage(HttpStatusCode.NotFound);
@@ -1688,7 +1689,7 @@ public class RepositoryTest
                     (await req.Content.ReadAsByteArrayAsync()).CopyTo(buf, 0);
                     gotManifest = buf;
                 }
-                res.Content.Headers.Add("Docker-Content-Digest", new string[] { manifestDesc.Digest });
+                res.Headers.Add(_dockerContentDigestHeader, new string[] { manifestDesc.Digest });
                 res.StatusCode = HttpStatusCode.Created;
                 return res;
             }
@@ -1737,7 +1738,7 @@ public class RepositoryTest
                 {
                     return new HttpResponseMessage(HttpStatusCode.BadRequest);
                 }
-                res.Content.Headers.Add("Docker-Content-Digest", new string[] { manifestDesc.Digest });
+                res.Headers.Add(_dockerContentDigestHeader, new string[] { manifestDesc.Digest });
                 res.Content.Headers.Add("Content-Type", new string[] { MediaType.ImageManifest });
                 res.Content.Headers.Add("Content-Length", new string[] { manifest.Length.ToString() });
                 return res;
@@ -1802,7 +1803,7 @@ public class RepositoryTest
                     return new HttpResponseMessage(HttpStatusCode.BadRequest);
                 }
                 res.Content = new ByteArrayContent(manifest);
-                res.Content.Headers.Add("Docker-Content-Digest", new string[] { manifestDesc.Digest });
+                res.Headers.Add(_dockerContentDigestHeader, new string[] { manifestDesc.Digest });
                 res.Content.Headers.Add("Content-Type", new string[] { MediaType.ImageManifest });
                 return res;
             }
@@ -1858,7 +1859,7 @@ public class RepositoryTest
                 {
                     return new HttpResponseMessage(HttpStatusCode.BadRequest);
                 }
-                res.Content.Headers.Add("Docker-Content-Digest", new string[] { manifestDesc.Digest });
+                res.Headers.Add(_dockerContentDigestHeader, new string[] { manifestDesc.Digest });
                 res.Content.Headers.Add("Content-Type", new string[] { MediaType.ImageManifest });
                 res.Content.Headers.Add("Content-Length", new string[] { manifest.Length.ToString() });
                 return res;
@@ -1928,7 +1929,7 @@ public class RepositoryTest
                     return new HttpResponseMessage(HttpStatusCode.BadRequest);
                 }
                 res.Content = new ByteArrayContent(manifest);
-                res.Content.Headers.Add("Docker-Content-Digest", new string[] { manifestDesc.Digest });
+                res.Headers.Add(_dockerContentDigestHeader, new string[] { manifestDesc.Digest });
                 res.Content.Headers.Add("Content-Type", new string[] { MediaType.ImageManifest });
                 return res;
             }
@@ -2019,7 +2020,7 @@ public class RepositoryTest
                     return new HttpResponseMessage(HttpStatusCode.BadRequest);
                 }
                 res.Content = new ByteArrayContent(index);
-                res.Content.Headers.Add("Docker-Content-Digest", new string[] { indexDesc.Digest });
+                res.Headers.Add(_dockerContentDigestHeader, new string[] { indexDesc.Digest });
                 res.Content.Headers.Add("Content-Type", new string[] { indexDesc.MediaType });
                 return res;
             }
@@ -2037,7 +2038,7 @@ public class RepositoryTest
                     gotIndex = buf;
                 }
 
-                res.Content.Headers.Add("Docker-Content-Digest", new string[] { indexDesc.Digest });
+                res.Headers.Add(_dockerContentDigestHeader, new string[] { indexDesc.Digest });
                 res.StatusCode = HttpStatusCode.Created;
                 return res;
             }
@@ -2102,7 +2103,7 @@ public class RepositoryTest
                     gotIndex = buf;
                 }
 
-                res.Content.Headers.Add("Docker-Content-Digest", new string[] { indexDesc.Digest });
+                res.Headers.Add(_dockerContentDigestHeader, new string[] { indexDesc.Digest });
                 res.StatusCode = HttpStatusCode.Created;
                 return res;
             }
@@ -2168,12 +2169,12 @@ public class RepositoryTest
                 {
                     res.Content = new ByteArrayContent(exampleManifest);
                     res.Content.Headers.Add("Content-Type", MediaType.Descriptor);
-                    res.Content.Headers.Add("Docker-Content-Digest", exampleManifestDescriptor.Digest);
+                    res.Headers.Add(_dockerContentDigestHeader, exampleManifestDescriptor.Digest);
                     res.Content.Headers.Add("Content-Length", exampleManifest.Length.ToString());
                     return res;
                 }
                 res.Content.Headers.Add("Content-Type", MediaType.Descriptor);
-                res.Content.Headers.Add("Docker-Content-Digest", exampleManifestDescriptor.Digest);
+                res.Headers.Add(_dockerContentDigestHeader, exampleManifestDescriptor.Digest);
                 res.Content.Headers.Add("Content-Length", exampleManifest.Length.ToString());
                 return res;
             }
@@ -2193,7 +2194,7 @@ public class RepositoryTest
                     res.Content.Headers.Add("Content-Length", content.Length.ToString());
                 }
 
-                res.Content.Headers.Add("Docker-Content-Digest", digest);
+                res.Headers.Add(_dockerContentDigestHeader, digest);
 
                 return res;
             }
@@ -2235,14 +2236,14 @@ public class RepositoryTest
                 var resp = new HttpResponseMessage();
                 if (method == HttpMethod.Get)
                 {
-                    resp.Content = new ByteArrayContent(theAmazingBanClan);
+                    resp.Content = new ByteArrayContent(_theAmazingBanClan);
                     resp.Content.Headers.Add("Content-Type", new string[] { "application/vnd.docker.distribution.manifest.v2+json" });
-                    resp.Content.Headers.Add(dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
+                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
                 }
                 else
                 {
                     resp.Content.Headers.Add("Content-Type", new string[] { "application/vnd.docker.distribution.manifest.v2+json" });
-                    resp.Content.Headers.Add(dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
+                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
                 }
                 resp.RequestMessage = new HttpRequestMessage()
                 {


### PR DESCRIPTION
### What this PR does / why we need it
This resolves an issue when pushing to a docker registry, it responses with a _state query param, this must be part of the put request.  This PR, takes the query params from the response and appends the digest to the put request.

### Which issue(s) this PR resolves / fixes
Resolves / Fixes #132 

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test? yes
- [ ] Does this change require a documentation update? No
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version? no
- [ ] Do all new files have an appropriate license header? yes
