### PR TITLE
chore: add editorconfig to enforce private and public member naming convention 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,16 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -25,8 +25,8 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
-insert_final_newline = false
+end_of_line = lf
+insert_final_newline = true
 
 #### .NET Coding Conventions ####
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,40 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Naming Rules
+dotnet_naming_rule.private_fields_should_start_with_underscore.severity = error
+dotnet_naming_rule.private_fields_should_start_with_underscore.symbols = private_fields
+dotnet_naming_rule.private_fields_should_start_with_underscore.style = private_underscore_style
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_fields.required_modifiers = 
+
+dotnet_naming_style.private_underscore_style.capitalization = camel_case
+dotnet_naming_style.private_underscore_style.required_prefix = _
+
+dotnet_naming_rule.public_members_should_start_with_uppercase.severity = error
+dotnet_naming_rule.public_members_should_start_with_uppercase.symbols = public_members
+dotnet_naming_rule.public_members_should_start_with_uppercase.style = public_uppercase_style
+
+dotnet_naming_symbols.public_members.applicable_kinds = property, field, method
+dotnet_naming_symbols.public_members.applicable_accessibilities = public
+dotnet_naming_symbols.public_members.required_modifiers = 
+
+dotnet_naming_style.public_uppercase_style.capitalization = pascal_case

--- a/tests/OrasProject.Oras.Tests/Remote/RepositoryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Remote/RepositoryTest.cs
@@ -35,11 +35,11 @@ public class RepositoryTest
 {
     public struct TestIOStruct
     {
-        public bool isTag;
-        public bool errExpectedOnHEAD;
-        public string serverCalculatedDigest;
-        public string clientSuppliedReference;
-        public bool errExpectedOnGET;
+        public bool IsTag;
+        public bool ErrExpectedOnHEAD;
+        public string ServerCalculatedDigest;
+        public string ClientSuppliedReference;
+        public bool ErrExpectedOnGET;
     }
 
     private byte[] _theAmazingBanClan = "Ban Gu, Ban Chao, Ban Zhao"u8.ToArray();
@@ -93,34 +93,34 @@ public class RepositoryTest
         {
             ["1. Client:Tag & Server:DigestMissing"] = new TestIOStruct
             {
-                isTag = true,
-                errExpectedOnHEAD = true
+                IsTag = true,
+                ErrExpectedOnHEAD = true
             },
             ["2. Client:Tag & Server:DigestValid"] = new TestIOStruct
             {
-                isTag = true,
-                serverCalculatedDigest = correctDigest
+                IsTag = true,
+                ServerCalculatedDigest = correctDigest
             },
             ["3. Client:Tag & Server:DigestWrongButSyntacticallyValid"] = new TestIOStruct
             {
-                isTag = true,
-                serverCalculatedDigest = incorrectDigest
+                IsTag = true,
+                ServerCalculatedDigest = incorrectDigest
             },
             ["4. Client:DigestValid & Server:DigestMissing"] = new TestIOStruct
             {
-                clientSuppliedReference = correctDigest
+                ClientSuppliedReference = correctDigest
             },
             ["5. Client:DigestValid & Server:DigestValid"] = new TestIOStruct
             {
-                clientSuppliedReference = correctDigest,
-                serverCalculatedDigest = correctDigest
+                ClientSuppliedReference = correctDigest,
+                ServerCalculatedDigest = correctDigest
             },
             ["6. Client:DigestValid & Server:DigestWrongButSyntacticallyValid"] = new TestIOStruct
             {
-                clientSuppliedReference = correctDigest,
-                serverCalculatedDigest = incorrectDigest,
-                errExpectedOnHEAD = true,
-                errExpectedOnGET = true
+                ClientSuppliedReference = correctDigest,
+                ServerCalculatedDigest = incorrectDigest,
+                ErrExpectedOnHEAD = true,
+                ErrExpectedOnGET = true
             }
         };
     }
@@ -1489,25 +1489,25 @@ public class RepositoryTest
         var tests = GetTestIOStructMapForGetDescriptorClass();
         foreach ((string testName, TestIOStruct dcdIOStruct) in tests)
         {
-            if (dcdIOStruct.isTag)
+            if (dcdIOStruct.IsTag)
             {
                 continue;
             }
             HttpMethod[] methods = new HttpMethod[] { HttpMethod.Get, HttpMethod.Head };
             foreach ((int i, HttpMethod method) in methods.Select((value, i) => (i, value)))
             {
-                reference.ContentReference = dcdIOStruct.clientSuppliedReference;
+                reference.ContentReference = dcdIOStruct.ClientSuppliedReference;
                 var resp = new HttpResponseMessage();
                 if (method == HttpMethod.Get)
                 {
                     resp.Content = new ByteArrayContent(_theAmazingBanClan);
                     resp.Content.Headers.Add("Content-Type", new string[] { "application/vnd.docker.distribution.manifest.v2+json" });
-                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
+                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.ServerCalculatedDigest });
                 }
                 if (!resp.Headers.TryGetValues(_dockerContentDigestHeader, out IEnumerable<string>? values))
                 {
                     resp.Content.Headers.Add("Content-Type", new string[] { "application/vnd.docker.distribution.manifest.v2+json" });
-                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
+                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.ServerCalculatedDigest });
                     resp.RequestMessage = new HttpRequestMessage()
                     {
                         Method = method
@@ -1533,12 +1533,12 @@ public class RepositoryTest
                         $"[Blob.{method}] {testName}; got digest from a tag reference unexpectedly");
                 }
 
-                var errExpected = new bool[] { dcdIOStruct.errExpectedOnGET, dcdIOStruct.errExpectedOnHEAD }[i];
+                var errExpected = new bool[] { dcdIOStruct.ErrExpectedOnGET, dcdIOStruct.ErrExpectedOnHEAD }[i];
                 if (d.Length == 0)
                 {
                     // To avoid an otherwise impossible scenario in the tested code
                     // path, we set d so that verifyContentDigest does not break.
-                    d = dcdIOStruct.serverCalculatedDigest;
+                    d = dcdIOStruct.ServerCalculatedDigest;
                 }
 
                 var err = false;
@@ -2238,25 +2238,25 @@ public class RepositoryTest
             var s = new ManifestStore(repo);
             foreach ((int i, HttpMethod method) in methods.Select((value, i) => (i, value)))
             {
-                reference.ContentReference = dcdIOStruct.clientSuppliedReference;
+                reference.ContentReference = dcdIOStruct.ClientSuppliedReference;
                 var resp = new HttpResponseMessage();
                 if (method == HttpMethod.Get)
                 {
                     resp.Content = new ByteArrayContent(_theAmazingBanClan);
                     resp.Content.Headers.Add("Content-Type", new string[] { "application/vnd.docker.distribution.manifest.v2+json" });
-                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
+                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.ServerCalculatedDigest });
                 }
                 else
                 {
                     resp.Content.Headers.Add("Content-Type", new string[] { "application/vnd.docker.distribution.manifest.v2+json" });
-                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.serverCalculatedDigest });
+                    resp.Headers.Add(_dockerContentDigestHeader, new string[] { dcdIOStruct.ServerCalculatedDigest });
                 }
                 resp.RequestMessage = new HttpRequestMessage()
                 {
                     Method = method
                 };
 
-                var errExpected = new bool[] { dcdIOStruct.errExpectedOnGET, dcdIOStruct.errExpectedOnHEAD }[i];
+                var errExpected = new bool[] { dcdIOStruct.ErrExpectedOnGET, dcdIOStruct.ErrExpectedOnHEAD }[i];
 
                 var err = false;
                 try


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds a editorconfig file which will enforce good naming convention when using support IDEs.  Thankfully most private/public members already conform to this standard. 
Private = _camalCase
Public = PascalCase

### Which issue(s) this PR resolves / fixes
N/A

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test? No
- [ ] Does this change require a documentation update? No
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version? No
- [ ] Do all new files have an appropriate license header? No
