### PR TITLE
ci(codecov): change codecov argument due to upgrade to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./tests/OrasProject.Oras.Tests/coverage.opencover.xml
+          files: ./tests/OrasProject.Oras.Tests/coverage.opencover.xml


### PR DESCRIPTION
### What this PR does / why we need it
<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues directly to https://github.com/oras-project/oras/blob/main/OWNERS.md. -->

This PR is to change the Codecov argument from `file` to `files` to accommodate the breaking change in Codecov V5

### Which issue(s) this PR resolves / fixes
<!-- Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->
Resolves / Fixes #<issue_id>

This PR updates the Codecov arguments manually to accommodate the changes introduced in [#158](https://github.com/oras-project/oras-dotnet/pull/158), which upgrades the Codecov version to V5.

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have an appropriate license header?
