### PR TITLE
chore(tests): clean up compiler warnings

### DIFF
--- a/tests/OrasProject.Oras.Tests/Content/ContentTest.cs
+++ b/tests/OrasProject.Oras.Tests/Content/ContentTest.cs
@@ -20,7 +20,6 @@ namespace OrasProject.Oras.Tests.Content;
 
 public class CalculateDigest
 {
-    
     /// <summary>
     /// This method tests if the digest is calculated properly
     /// </summary>

--- a/tests/OrasProject.Oras.Tests/Content/MemoryStoreTest.cs
+++ b/tests/OrasProject.Oras.Tests/Content/MemoryStoreTest.cs
@@ -172,7 +172,7 @@ public class MemoryStoreTest
         var cancellationToken = new CancellationToken();
         var blobs = new List<byte[]>();
         var descs = new List<Descriptor>();
-        var appendBlob = (string mediaType, byte[] blob) =>
+        void AppendBlob(string mediaType, byte[] blob)
         {
             blobs.Add(blob);
             var desc = new Descriptor
@@ -182,8 +182,8 @@ public class MemoryStoreTest
                 Size = blob.Length
             };
             descs.Add(desc);
-        };
-        var generateManifest = (Descriptor config, List<Descriptor> layers) =>
+        }
+        void GenerateManifest(Descriptor config, List<Descriptor> layers)
         {
             var manifest = new Manifest
             {
@@ -191,28 +191,28 @@ public class MemoryStoreTest
                 Layers = layers
             };
             var manifestBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(manifest));
-            appendBlob(MediaType.ImageManifest, manifestBytes);
-        };
+            AppendBlob(MediaType.ImageManifest, manifestBytes);
+        }
 
-        var generateIndex = (List<Descriptor> manifests) =>
+        void GenerateIndex(List<Descriptor> manifests)
         {
             var index = new Index
             {
                 Manifests = manifests
             };
             var indexBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(index));
-            appendBlob(MediaType.ImageIndex, indexBytes);
-        };
-        var getBytes = (string data) => Encoding.UTF8.GetBytes(data);
-        appendBlob(MediaType.ImageConfig, getBytes("config")); // blob 0
-        appendBlob(MediaType.ImageLayer, getBytes("foo")); // blob 1
-        appendBlob(MediaType.ImageLayer, getBytes("bar")); // blob 2
-        appendBlob(MediaType.ImageLayer, getBytes("hello")); // blob 3
-        generateManifest(descs[0], descs.GetRange(1, 2)); // blob 4
-        generateManifest(descs[0], new() { descs[3] }); // blob 5
-        generateManifest(descs[0], descs.GetRange(1, 3)); // blob 6
-        generateIndex(descs.GetRange(4, 2)); // blob 7
-        generateIndex(new() { descs[6] }); // blob 8
+            AppendBlob(MediaType.ImageIndex, indexBytes);
+        }
+        byte[] GetBytes(string data) => Encoding.UTF8.GetBytes(data);
+        AppendBlob(MediaType.ImageConfig, GetBytes("config")); // blob 0
+        AppendBlob(MediaType.ImageLayer, GetBytes("foo")); // blob 1
+        AppendBlob(MediaType.ImageLayer, GetBytes("bar")); // blob 2
+        AppendBlob(MediaType.ImageLayer, GetBytes("hello")); // blob 3
+        GenerateManifest(descs[0], descs.GetRange(1, 2)); // blob 4
+        GenerateManifest(descs[0], [descs[3]]); // blob 5
+        GenerateManifest(descs[0], descs.GetRange(1, 3)); // blob 6
+        GenerateIndex(descs.GetRange(4, 2)); // blob 7
+        GenerateIndex([descs[6]]); // blob 8
 
         for (var i = 0; i < blobs.Count; i++)
         {

--- a/tests/OrasProject.Oras.Tests/CopyTest.cs
+++ b/tests/OrasProject.Oras.Tests/CopyTest.cs
@@ -33,7 +33,8 @@ public class CopyTest
         var cancellationToken = new CancellationToken();
         var blobs = new List<byte[]>();
         var descs = new List<Descriptor>();
-        var appendBlob = (string mediaType, byte[] blob) =>
+
+        void AppendBlob(string mediaType, byte[] blob)
         {
             blobs.Add(blob);
             var desc = new Descriptor
@@ -43,8 +44,9 @@ public class CopyTest
                 Size = blob.Length
             };
             descs.Add(desc);
-        };
-        var generateManifest = (Descriptor config, List<Descriptor> layers) =>
+        }
+
+        void GenerateManifest(Descriptor config, List<Descriptor> layers)
         {
             var manifest = new Manifest
             {
@@ -52,18 +54,19 @@ public class CopyTest
                 Layers = layers
             };
             var manifestBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(manifest));
-            appendBlob(MediaType.ImageManifest, manifestBytes);
-        };
-        var getBytes = (string data) => Encoding.UTF8.GetBytes(data);
-        appendBlob(MediaType.ImageConfig, getBytes("config")); // blob 0
-        appendBlob(MediaType.ImageLayer, getBytes("foo")); // blob 1
-        appendBlob(MediaType.ImageLayer, getBytes("bar")); // blob 2
-        generateManifest(descs[0], descs.GetRange(1, 2)); // blob 3
+            AppendBlob(MediaType.ImageManifest, manifestBytes);
+        }
+
+        byte[] GetBytes(string data) => Encoding.UTF8.GetBytes(data);
+
+        AppendBlob(MediaType.ImageConfig, GetBytes("config")); // blob 0
+        AppendBlob(MediaType.ImageLayer, GetBytes("foo")); // blob 1
+        AppendBlob(MediaType.ImageLayer, GetBytes("bar")); // blob 2
+        GenerateManifest(descs[0], descs.GetRange(1, 2)); // blob 3
 
         for (var i = 0; i < blobs.Count; i++)
         {
             await sourceTarget.PushAsync(descs[i], new MemoryStream(blobs[i]), cancellationToken);
-
         }
 
         var root = descs[3];
@@ -96,7 +99,8 @@ public class CopyTest
         var cancellationToken = new CancellationToken();
         var blobs = new List<byte[]>();
         var descs = new List<Descriptor>();
-        var appendBlob = (string mediaType, byte[] blob) =>
+
+        void AppendBlob(string mediaType, byte[] blob)
         {
             blobs.Add(blob);
             var desc = new Descriptor
@@ -106,8 +110,9 @@ public class CopyTest
                 Size = blob.Length
             };
             descs.Add(desc);
-        };
-        var generateManifest = (Descriptor config, List<Descriptor> layers) =>
+        }
+
+        void GenerateManifest(Descriptor config, List<Descriptor> layers)
         {
             var manifest = new Manifest
             {
@@ -115,19 +120,21 @@ public class CopyTest
                 Layers = layers
             };
             var manifestBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(manifest));
-            appendBlob(MediaType.ImageManifest, manifestBytes);
-        };
-        var getBytes = (string data) => Encoding.UTF8.GetBytes(data);
-        appendBlob(MediaType.ImageConfig, getBytes("config")); // blob 0
-        appendBlob(MediaType.ImageLayer, getBytes("foo")); // blob 1
-        appendBlob(MediaType.ImageLayer, getBytes("bar")); // blob 2
-        generateManifest(descs[0], descs.GetRange(1, 2)); // blob 3
+            AppendBlob(MediaType.ImageManifest, manifestBytes);
+        }
+
+        byte[] GetBytes(string data) => Encoding.UTF8.GetBytes(data);
+
+        AppendBlob(MediaType.ImageConfig, GetBytes("config")); // blob 0
+        AppendBlob(MediaType.ImageLayer, GetBytes("foo")); // blob 1
+        AppendBlob(MediaType.ImageLayer, GetBytes("bar")); // blob 2
+        GenerateManifest(descs[0], descs.GetRange(1, 2)); // blob 3
 
         for (var i = 0; i < blobs.Count; i++)
         {
             await sourceTarget.PushAsync(descs[i], new MemoryStream(blobs[i]), cancellationToken);
-
         }
+
         var root = descs[3];
         var destinationTarget = new MemoryStore();
         await sourceTarget.CopyGraphAsync(destinationTarget, root, cancellationToken);
@@ -139,7 +146,6 @@ public class CopyTest
             await fetchContent.CopyToAsync(memoryStream);
             var bytes = memoryStream.ToArray();
             Assert.Equal(blobs[i], bytes);
-
         }
     }
 }

--- a/tests/OrasProject.Oras.Tests/Exceptions/ExceptionTest.cs
+++ b/tests/OrasProject.Oras.Tests/Exceptions/ExceptionTest.cs
@@ -49,7 +49,7 @@ public class ExceptionTest
         await Assert.ThrowsAsync<NotFoundException>(() => throw new NotFoundException("Not found"));
         await Assert.ThrowsAsync<NotFoundException>(() => throw new NotFoundException("Not found", null));
     }
-    
+
     [Fact]
     public async Task ReferrersSupportLevelAlreadySetException()
     {
@@ -67,7 +67,7 @@ public class ExceptionTest
         await Assert.ThrowsAsync<InvalidResponseException>(() =>
             throw new InvalidResponseException("Invalid response", null));
     }
-    
+
     [Fact]
     public async Task SizeLimitExceededException()
     {

--- a/tests/OrasProject.Oras.Tests/Oci/IndexTest.cs
+++ b/tests/OrasProject.Oras.Tests/Oci/IndexTest.cs
@@ -57,7 +57,7 @@ public class IndexTest
         Assert.Equal(MediaType.ImageIndex, generatedIndex.MediaType);
         Assert.Equal(2, generatedIndex.SchemaVersion);
     }
-    
+
     [Fact]
     public void GenerateIndex_CorrectlyGeneratesIndexDescriptorWithEmptyManifests()
     {

--- a/tests/OrasProject.Oras.Tests/Oci/PlatformTest.cs
+++ b/tests/OrasProject.Oras.Tests/Oci/PlatformTest.cs
@@ -1,0 +1,57 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using OrasProject.Oras.Oci;
+using System.Text.Json;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Oci
+{
+    public class PlatformTest
+    {
+        [Fact]
+        public void PlatformSerialization()
+        {
+            var platform = new Platform
+            {
+                Architecture = "amd64",
+                Os = "linux",
+                OsVersion = "5.4.0-42-generic",
+                OsFeatures = ["feature1", "feature2"],
+                Variant = "v8"
+            };
+            var json = JsonSerializer.Serialize(platform);
+            Assert.Contains("\"architecture\":\"amd64\"", json);
+            Assert.Contains("\"os\":\"linux\"", json);
+            Assert.Contains("\"os.version\":\"5.4.0-42-generic\"", json);
+            Assert.Contains("\"os.features\":[\"feature1\",\"feature2\"]", json);
+            Assert.Contains("\"variant\":\"v8\"", json);
+        }
+
+        [Fact]
+        public void Serialization_OmitsDefaultFields()
+        {
+            var platform = new Platform
+            {
+                Architecture = "amd64",
+                Os = "linux"
+            };
+            var json = System.Text.Json.JsonSerializer.Serialize(platform);
+            Assert.Contains("\"architecture\":\"amd64\"", json);
+            Assert.Contains("\"os\":\"linux\"", json);
+            Assert.DoesNotContain("\"os.version\"", json);
+            Assert.DoesNotContain("\"os.features\"", json);
+            Assert.DoesNotContain("\"variant\"", json);
+        }
+    }
+}

--- a/tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj
+++ b/tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj
@@ -9,6 +9,8 @@
     
     <!-- Disable requiring ConfigureAwait(false) for awaited tasks -->
     <NoWarn>CA2007</NoWarn>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OrasProject.Oras.Tests/PackerTest.cs
+++ b/tests/OrasProject.Oras.Tests/PackerTest.cs
@@ -127,7 +127,7 @@ public class PackerTest
         var cancellationToken = new CancellationToken();
         var blobs = new List<byte[]>();
         var descs = new List<Descriptor>();
-        var appendBlob = (string mediaType, byte[] blob) =>
+        void AppendBlob(string mediaType, byte[] blob)
         {
             blobs.Add(blob);
             var desc = new Descriptor
@@ -137,29 +137,20 @@ public class PackerTest
                 Size = blob.Length
             };
             descs.Add(desc);
-        };
-        var generateManifest = (Descriptor config, List<Descriptor> layers) =>
-        {
-            var manifest = new Manifest
-            {
-                Config = config,
-                Layers = layers
-            };
-            var manifestBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(manifest));
-            appendBlob(MediaType.ImageManifest, manifestBytes);
-        };
-        var getBytes = (string data) => Encoding.UTF8.GetBytes(data);
-        appendBlob(MediaType.ImageConfig, getBytes("config")); // blob 0
-        appendBlob(MediaType.ImageLayer, getBytes("hello world")); // blob 1
-        appendBlob(MediaType.ImageLayer, getBytes("goodbye world")); // blob 2
+        }
+
+        byte[] GetBytes(string data) => Encoding.UTF8.GetBytes(data);
+        AppendBlob(MediaType.ImageConfig, GetBytes("config")); // blob 0
+        AppendBlob(MediaType.ImageLayer, GetBytes("hello world")); // blob 1
+        AppendBlob(MediaType.ImageLayer, GetBytes("goodbye world")); // blob 2
         var layers = descs.GetRange(1, 2);
         var configBytes = Encoding.UTF8.GetBytes("{}");
         var configDesc = new Descriptor
-                            {
-                                MediaType = "application/vnd.test.config",
-                                Digest = Digest.ComputeSha256(configBytes),
-                                Size = configBytes.Length
-                            };
+        {
+            MediaType = "application/vnd.test.config",
+            Digest = Digest.ComputeSha256(configBytes),
+            Size = configBytes.Length
+        };
         var configAnnotations = new Dictionary<string, string> { { "foo", "bar" } };
         var annotations = new Dictionary<string, string>
         {
@@ -197,13 +188,13 @@ public class PackerTest
 
         // Verify descriptor
         var expectedManifestDesc = new Descriptor
-                                        {
-                                            MediaType = expectedManifest.MediaType,
-                                            Digest = Digest.ComputeSha256(expectedManifestBytes),
-                                            Size = expectedManifestBytes.Length
+        {
+            MediaType = expectedManifest.MediaType,
+            Digest = Digest.ComputeSha256(expectedManifestBytes),
+            Size = expectedManifestBytes.Length,
+            ArtifactType = expectedManifest.Config.MediaType,
+            Annotations = expectedManifest.Annotations
         };
-        expectedManifestDesc.ArtifactType = expectedManifest.Config.MediaType;
-        expectedManifestDesc.Annotations = expectedManifest.Annotations;
         var expectedManifestDescBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(expectedManifestDesc));
         var manifestDescBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(manifestDesc));
         Assert.Equal(expectedManifestDescBytes, manifestDescBytes);
@@ -218,12 +209,12 @@ public class PackerTest
         manifestDesc = await Packer.PackManifestAsync(memoryTarget, Packer.ManifestVersion.Version1_0, artifactType, opts, cancellationToken);
 
         var expectedConfigDesc = new Descriptor
-                                    {
-                                        MediaType = artifactType,
-                                        Digest = Digest.ComputeSha256(configBytes),
-                                        Annotations = configAnnotations,
-                                        Size = configBytes.Length
-                                    };
+        {
+            MediaType = artifactType,
+            Digest = Digest.ComputeSha256(configBytes),
+            Annotations = configAnnotations,
+            Size = configBytes.Length
+        };
         expectedManifest = new Manifest
         {
             SchemaVersion = 2,
@@ -242,13 +233,13 @@ public class PackerTest
 
         // Verify descriptor
         expectedManifestDesc = new Descriptor
-                                {
-                                    MediaType = expectedManifest.MediaType,
-                                    Digest = Digest.ComputeSha256(expectedManifestBytes),
-                                    Size = expectedManifestBytes.Length
-                                };
-        expectedManifestDesc.ArtifactType = expectedManifest.Config.MediaType;
-        expectedManifestDesc.Annotations = expectedManifest.Annotations;
+        {
+            MediaType = expectedManifest.MediaType,
+            Digest = Digest.ComputeSha256(expectedManifestBytes),
+            Size = expectedManifestBytes.Length,
+            ArtifactType = expectedManifest.Config.MediaType,
+            Annotations = expectedManifest.Annotations
+        };
         Assert.Equal(JsonSerializer.SerializeToUtf8Bytes(expectedManifestDesc), JsonSerializer.SerializeToUtf8Bytes(manifestDesc));
     }
 
@@ -296,7 +287,7 @@ public class PackerTest
         Manifest? manifest = await JsonSerializer.DeserializeAsync<Manifest>(rc);
 
         // Verify artifact type and config media type
-        
+
         Assert.Equal(Packer.MediaTypeUnknownConfig, manifestDesc.ArtifactType);
         Assert.Equal(Packer.MediaTypeUnknownConfig, manifest!.Config.MediaType);
     }
@@ -311,11 +302,11 @@ public class PackerTest
         string artifactType = "random";
         byte[] configBytes = System.Text.Encoding.UTF8.GetBytes("{}");
         var configDesc = new Descriptor
-                            {
-                                MediaType = "application/vnd.test.config",
-                                Digest = Digest.ComputeSha256(configBytes),
-                                Size = configBytes.Length
-                            };
+        {
+            MediaType = "application/vnd.test.config",
+            Digest = Digest.ComputeSha256(configBytes),
+            Size = configBytes.Length
+        };
         var opts = new PackManifestOptions
         {
             Config = configDesc
@@ -333,11 +324,11 @@ public class PackerTest
         // Test invalid config media type + valid artifact type
         artifactType = "application/vnd.test";
         configDesc = new Descriptor
-                            {
-                                MediaType = "random",
-                                Digest = Digest.ComputeSha256(configBytes),
-                                Size = configBytes.Length
-                            };
+        {
+            MediaType = "random",
+            Digest = Digest.ComputeSha256(configBytes),
+            Size = configBytes.Length
+        };
         opts = new PackManifestOptions
         {
             Config = configDesc
@@ -387,7 +378,7 @@ public class PackerTest
         // Test PackManifest
         var artifactType = "application/vnd.test";
         var manifestDesc = await Packer.PackManifestAsync(memoryTarget, Packer.ManifestVersion.Version1_1, artifactType, new PackManifestOptions(), cancellationToken);
-        
+
         // Fetch and decode the manifest
         var rc = await memoryTarget.FetchAsync(manifestDesc, cancellationToken);
         Manifest? manifest;
@@ -398,7 +389,6 @@ public class PackerTest
         }
 
         // Verify layers
-        var emptyConfigBytes = Encoding.UTF8.GetBytes("{}");
         var emptyJson = Descriptor.Empty;
         var expectedLayers = new List<Descriptor> { emptyJson };
         Assert.Equal(JsonSerializer.SerializeToUtf8Bytes(expectedLayers), JsonSerializer.SerializeToUtf8Bytes(manifest!.Layers));
@@ -408,7 +398,7 @@ public class PackerTest
     public async Task TestPackManifestImageV1_1WithoutPassingOptions()
     {
         var memoryTarget = new MemoryStore();
-        
+
         // Test PackManifest
         var artifactType = "application/vnd.test";
         var manifestDesc = await Packer.PackManifestAsync(memoryTarget, Packer.ManifestVersion.Version1_1, artifactType);
@@ -446,15 +436,13 @@ public class PackerTest
         byte[] goodbyeBytes = System.Text.Encoding.UTF8.GetBytes("goodbye world");
         var layers = new List<Descriptor>
         {
-            new Descriptor
-            {
+            new() {
                 MediaType = "test",
                 Data = hellogBytes,
                 Digest = Digest.ComputeSha256(hellogBytes),
                 Size = hellogBytes.Length
             },
-            new Descriptor
-            {
+            new() {
                 MediaType = "test",
                 Data = goodbyeBytes,
                 Digest = Digest.ComputeSha256(goodbyeBytes),
@@ -494,7 +482,7 @@ public class PackerTest
             ManifestAnnotations = annotations
         };
         var manifestDesc = await Packer.PackManifestAsync(memoryTarget, Packer.ManifestVersion.Version1_1, artifactType, opts, cancellationToken);
-        
+
         var expectedManifest = new Manifest
         {
             SchemaVersion = 2, // Historical value, doesn't pertain to OCI or Docker version
@@ -513,17 +501,17 @@ public class PackerTest
 
         // Verify descriptor
         var expectedManifestDesc = new Descriptor
-                                        {
-                                            MediaType = expectedManifest.MediaType,
-                                            Digest = Digest.ComputeSha256(expectedManifestBytes),
-                                            Size = expectedManifestBytes.Length
+        {
+            MediaType = expectedManifest.MediaType,
+            Digest = Digest.ComputeSha256(expectedManifestBytes),
+            Size = expectedManifestBytes.Length,
+            ArtifactType = expectedManifest.Config.MediaType,
+            Annotations = expectedManifest.Annotations
         };
-        expectedManifestDesc.ArtifactType = expectedManifest.Config.MediaType;
-        expectedManifestDesc.Annotations = expectedManifest.Annotations;
         var expectedManifestDescBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(expectedManifestDesc));
         var manifestDescBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(manifestDesc));
         Assert.Equal(expectedManifestDescBytes, manifestDescBytes);
-        
+
         // Test PackManifest with ConfigDescriptor, but without artifactType
         opts = new PackManifestOptions
         {
@@ -543,12 +531,12 @@ public class PackerTest
         Assert.Equal(expectedManifestBytes, got2);
 
         expectedManifestDesc = new Descriptor
-                                {
-                                    MediaType = expectedManifest.MediaType,
-                                    Digest = Digest.ComputeSha256(expectedManifestBytes),
-                                    Size = expectedManifestBytes.Length
-                                };
-        expectedManifestDesc.Annotations = expectedManifest.Annotations;
+        {
+            MediaType = expectedManifest.MediaType,
+            Digest = Digest.ComputeSha256(expectedManifestBytes),
+            Size = expectedManifestBytes.Length,
+            Annotations = expectedManifest.Annotations
+        };
         Assert.Equal(JsonSerializer.SerializeToUtf8Bytes(expectedManifestDesc), JsonSerializer.SerializeToUtf8Bytes(manifestDesc));
 
         // Test Pack without ConfigDescriptor
@@ -562,14 +550,14 @@ public class PackerTest
 
         manifestDesc = await Packer.PackManifestAsync(memoryTarget, Packer.ManifestVersion.Version1_1, artifactType, opts, cancellationToken);
         var emptyConfigBytes = Encoding.UTF8.GetBytes("{}");
-        var emptyJson = new Descriptor
-                            {
-                                MediaType = "application/vnd.oci.empty.v1+json",
-                                Digest = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
-                                Size = emptyConfigBytes.Length,
-                                Data = emptyConfigBytes
-                            };
-        var expectedConfigDesc = emptyJson;
+        var emptyJSON = new Descriptor
+        {
+            MediaType = "application/vnd.oci.empty.v1+json",
+            Digest = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+            Size = emptyConfigBytes.Length,
+            Data = emptyConfigBytes
+        };
+        var expectedConfigDesc = emptyJSON;
         expectedManifest.ArtifactType = artifactType;
         expectedManifest.Config = expectedConfigDesc;
         expectedManifestBytes = JsonSerializer.SerializeToUtf8Bytes(expectedManifest);
@@ -579,13 +567,13 @@ public class PackerTest
         Assert.Equal(expectedManifestBytes, got3);
 
         expectedManifestDesc = new Descriptor
-                                {
-                                    MediaType = expectedManifest.MediaType,
-                                    Digest = Digest.ComputeSha256(expectedManifestBytes),
-                                    Size = expectedManifestBytes.Length
-                                };
-        expectedManifestDesc.ArtifactType = artifactType;
-        expectedManifestDesc.Annotations = expectedManifest.Annotations;
+        {
+            MediaType = expectedManifest.MediaType,
+            Digest = Digest.ComputeSha256(expectedManifestBytes),
+            Size = expectedManifestBytes.Length,
+            ArtifactType = artifactType,
+            Annotations = expectedManifest.Annotations
+        };
         Assert.Equal(JsonSerializer.SerializeToUtf8Bytes(expectedManifestDesc), JsonSerializer.SerializeToUtf8Bytes(manifestDesc));
     }
 
@@ -637,11 +625,11 @@ public class PackerTest
         var artifactType = "random";
         byte[] configBytes = System.Text.Encoding.UTF8.GetBytes("{}");
         var configDesc = new Descriptor
-                            {
-                                MediaType = "application/vnd.test.config",
-                                Digest = Digest.ComputeSha256(configBytes),
-                                Size = configBytes.Length
-                            };
+        {
+            MediaType = "application/vnd.test.config",
+            Digest = Digest.ComputeSha256(configBytes),
+            Size = configBytes.Length
+        };
         var opts = new PackManifestOptions
         {
             Config = configDesc
@@ -659,11 +647,11 @@ public class PackerTest
         // Test invalid config media type + valid artifact type
         artifactType = "application/vnd.test";
         configDesc = new Descriptor
-                            {
-                                MediaType = "random",
-                                Digest = Digest.ComputeSha256(configBytes),
-                                Size = configBytes.Length
-                            };
+        {
+            MediaType = "random",
+            Digest = Digest.ComputeSha256(configBytes),
+            Size = configBytes.Length
+        };
         opts = new PackManifestOptions
         {
             Config = configDesc
@@ -676,7 +664,7 @@ public class PackerTest
         catch (Exception ex)
         {
             Assert.True(ex is InvalidMediaTypeException, $"Expected InvalidMediaTypeException but got {ex.GetType().Name}");
-        }    
+        }
     }
 
     [Fact]

--- a/tests/OrasProject.Oras.Tests/Remote/AuthTest.cs
+++ b/tests/OrasProject.Oras.Tests/Remote/AuthTest.cs
@@ -42,7 +42,7 @@ public class AuthTest
     {
         var username = "test_user";
         var password = "test_password";
-        var func = (HttpRequestMessage req, CancellationToken cancellationToken) =>
+        HttpResponseMessage func(HttpRequestMessage req, CancellationToken cancellationToken)
         {
             var res = new HttpResponseMessage
             {
@@ -63,7 +63,7 @@ public class AuthTest
                 return res;
             }
             return new HttpResponseMessage(HttpStatusCode.OK);
-        };
+        }
         var client = CustomClient(func, username, password);
         var response = await client.GetAsync("http://localhost:5000");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/tests/OrasProject.Oras.Tests/Remote/ReferrersTest.cs
+++ b/tests/OrasProject.Oras.Tests/Remote/ReferrersTest.cs
@@ -26,11 +26,10 @@ public class ReferrersTest
     public void BuildReferrersTag_ShouldReturnReferrersTagSuccessfully()
     {
         var desc = RandomDescriptor();
-        var index = desc.Digest.IndexOf(':');
-        var expected = desc.Digest.Substring(0, index) + "-" + desc.Digest.Substring(index + 1);
+        var expected = desc.Digest.Replace(":", "-");
         Assert.Equal(expected, Referrers.BuildReferrersTag(desc));
     }
-    
+
     [Fact]
     public void BuildReferrersTag_ShouldThrowInvalidDigestException()
     {
@@ -38,7 +37,7 @@ public class ReferrersTest
         desc.Digest = "sha123321";
         Assert.Throws<InvalidDigestException>(() => Referrers.BuildReferrersTag(desc));
     }
-    
+
     [Fact]
     public void ApplyReferrerChanges_ShouldAddNewReferrers()
     {
@@ -58,19 +57,19 @@ public class ReferrersTest
             newDescriptor,
         };
         var referrerChange = new Referrers.ReferrerChange(
-            newDescriptor, 
+            newDescriptor,
             Referrers.ReferrerOperation.Add
         );
 
         var (updatedReferrers, updateRequired) = Referrers.ApplyReferrerChanges(oldReferrers, referrerChange);
-        Assert.Equal(3, updatedReferrers.Count); 
+        Assert.Equal(3, updatedReferrers.Count);
         for (var i = 0; i < updatedReferrers.Count; ++i)
         {
             Assert.True(AreDescriptorsEqual(updatedReferrers[i], expectedReferrers[i]));
         }
         Assert.True(updateRequired);
     }
-    
+
     [Fact]
     public void ApplyReferrerChanges_ShouldDeleteReferrers()
     {
@@ -91,20 +90,20 @@ public class ReferrersTest
             oldDescriptor3
         };
         var referrerChange = new Referrers.ReferrerChange(
-            oldDescriptor2, 
+            oldDescriptor2,
             Referrers.ReferrerOperation.Delete
         );
 
         var (updatedReferrers, updateRequired) = Referrers.ApplyReferrerChanges(oldReferrers, referrerChange);
-        Assert.Equal(2, updatedReferrers.Count); 
+        Assert.Equal(2, updatedReferrers.Count);
         for (var i = 0; i < updatedReferrers.Count; ++i)
         {
             Assert.True(AreDescriptorsEqual(updatedReferrers[i], expectedReferrers[i]));
         }
         Assert.True(updateRequired);
     }
-    
-    
+
+
     [Fact]
     public void ApplyReferrerChanges_ShouldDeleteReferrersWithDuplicates()
     {
@@ -128,19 +127,19 @@ public class ReferrersTest
             oldDescriptor2
         };
         var referrerChange = new Referrers.ReferrerChange(
-            oldDescriptor3, 
+            oldDescriptor3,
             Referrers.ReferrerOperation.Delete
         );
 
         var (updatedReferrers, updateRequired) = Referrers.ApplyReferrerChanges(oldReferrers, referrerChange);
-        Assert.Equal(2, updatedReferrers.Count); 
+        Assert.Equal(2, updatedReferrers.Count);
         for (var i = 0; i < updatedReferrers.Count; ++i)
         {
             Assert.True(AreDescriptorsEqual(updatedReferrers[i], expectedReferrers[i]));
         }
         Assert.True(updateRequired);
     }
-    
+
     [Fact]
     public void ApplyReferrerChanges_ShouldNotDeleteReferrersWhenNoUpdateRequired()
     {
@@ -160,19 +159,19 @@ public class ReferrersTest
             oldDescriptor2,
         };
         var referrerChange = new Referrers.ReferrerChange(
-            oldDescriptor3, 
+            oldDescriptor3,
             Referrers.ReferrerOperation.Delete
         );
 
         var (updatedReferrers, updateRequired) = Referrers.ApplyReferrerChanges(oldReferrers, referrerChange);
-        Assert.Equal(2, updatedReferrers.Count); 
+        Assert.Equal(2, updatedReferrers.Count);
         for (var i = 0; i < updatedReferrers.Count; ++i)
         {
             Assert.True(AreDescriptorsEqual(updatedReferrers[i], expectedReferrers[i]));
         }
         Assert.False(updateRequired);
     }
-    
+
     [Fact]
     public void ApplyReferrerChanges_ShouldDiscardDuplicateReferrers()
     {
@@ -200,14 +199,14 @@ public class ReferrersTest
         );
 
         var (updatedReferrers, updateRequired) = Referrers.ApplyReferrerChanges(oldReferrers, referrerChange);
-        Assert.Equal(3, updatedReferrers.Count); 
+        Assert.Equal(3, updatedReferrers.Count);
         for (var i = 0; i < updatedReferrers.Count; ++i)
         {
             Assert.True(AreDescriptorsEqual(updatedReferrers[i], expectedReferrers[i]));
         }
         Assert.True(updateRequired);
     }
-    
+
     [Fact]
     public void ApplyReferrerChanges_ShouldNotAddNewDuplicateReferrers()
     {
@@ -223,10 +222,10 @@ public class ReferrersTest
             Referrers.ReferrerOperation.Add
         );
         var (updatedReferrers, updateRequired) = Referrers.ApplyReferrerChanges(oldReferrers, referrerChange);
-        Assert.Equal(2, updatedReferrers.Count); 
+        Assert.Equal(2, updatedReferrers.Count);
         Assert.False(updateRequired);
     }
-    
+
     [Fact]
     public void ApplyReferrerChanges_ShouldNotKeepOldEmptyReferrers()
     {
@@ -238,7 +237,7 @@ public class ReferrersTest
         {
             emptyDesc1,
             emptyDesc2!,
-        };        
+        };
         var expectedReferrers = new List<Descriptor>
         {
             newDescriptor,
@@ -247,27 +246,27 @@ public class ReferrersTest
             newDescriptor,
             Referrers.ReferrerOperation.Add
         );
-        
+
         var (updatedReferrers, updateRequired) = Referrers.ApplyReferrerChanges(oldReferrers, referrerChange);
-        Assert.Single(updatedReferrers); 
+        Assert.Single(updatedReferrers);
         for (var i = 0; i < updatedReferrers.Count; ++i)
         {
             Assert.True(AreDescriptorsEqual(updatedReferrers[i], expectedReferrers[i]));
         }
         Assert.True(updateRequired);
     }
-    
+
     [Fact]
     public void ApplyReferrerChanges_NoUpdateWhenOldAndNewReferrersAreEmpty()
     {
         var oldReferrers = new List<Descriptor>();
         var referrerChange = new Referrers.ReferrerChange(ZeroDescriptor(), Referrers.ReferrerOperation.Add);
-        
+
         var (updatedReferrers, updateRequired) = Referrers.ApplyReferrerChanges(oldReferrers, referrerChange);
-        Assert.Empty(updatedReferrers); 
+        Assert.Empty(updatedReferrers);
         Assert.False(updateRequired);
     }
-    
+
     [Fact]
     public void IsReferrersFilterApplied_AppliedFiltersNull_ReturnsFalse()
     {
@@ -276,7 +275,7 @@ public class ReferrersTest
         var result = Referrers.IsReferrersFilterApplied(appliedFilters!, requestedFilter);
         Assert.False(result);
     }
-    
+
     [Fact]
     public void IsReferrersFilterApplied_AppliedFiltersEmpty_ReturnsFalse()
     {
@@ -285,7 +284,7 @@ public class ReferrersTest
         var result = Referrers.IsReferrersFilterApplied(appliedFilters, requestedFilter);
         Assert.False(result);
     }
-    
+
     [Fact]
     public void IsReferrersFilterApplied_RequestedFilterNull_ReturnsFalse()
     {
@@ -303,7 +302,7 @@ public class ReferrersTest
         var result = Referrers.IsReferrersFilterApplied(appliedFilters, requestedFilter);
         Assert.False(result);
     }
-    
+
     [Fact]
     public void IsReferrersFilterApplied_RequestedFilterMatches_ReturnsTrue()
     {
@@ -313,7 +312,7 @@ public class ReferrersTest
         var result = Referrers.IsReferrersFilterApplied(appliedFilters, requestedFilter);
         Assert.True(result);
     }
-    
+
     [Fact]
     public void IsReferrersFilterApplied_SingleAppliedFiltersRequestedFilterMatches_ReturnsTrue()
     {
@@ -322,7 +321,7 @@ public class ReferrersTest
         var result = Referrers.IsReferrersFilterApplied(appliedFilters, requestedFilter);
         Assert.True(result);
     }
-    
+
     [Fact]
     public void IsReferrersFilterApplied_RequestedFilterDoesNotMatch_ReturnsFalse()
     {
@@ -331,7 +330,7 @@ public class ReferrersTest
         var result = Referrers.IsReferrersFilterApplied(appliedFilters, requestedFilter);
         Assert.False(result);
     }
-    
+
     [Fact]
     public void FilterReferrers_WithNullOrEmptyArtifactType_ShouldReturnAllReferrers()
     {
@@ -345,13 +344,13 @@ public class ReferrersTest
         var result = Referrers.FilterReferrers(referrers, artifactType);
         Assert.Equal(3, result.Count);
         Assert.Equal(referrers, result);
-        
+
         artifactType = "";
         result = Referrers.FilterReferrers(referrers, artifactType);
         Assert.Equal(3, result.Count);
         Assert.Equal(referrers, result);
     }
-    
+
     [Fact]
     public void FilterReferrers_WithValidArtifactType_ShouldReturnMatchingReferrers()
     {
@@ -368,7 +367,7 @@ public class ReferrersTest
         Assert.Equal(2, result.Count);
         Assert.True(result.All(r => r.ArtifactType == artifactType));
     }
-    
+
     [Fact]
     public void FilterReferrers_WithArtifactTypeThatDoesNotExist_ShouldReturnEmptyList()
     {
@@ -381,7 +380,7 @@ public class ReferrersTest
         };
         const string artifactType = "NonExistentType";
         var result = Referrers.FilterReferrers(referrers, artifactType);
-        Assert.Empty(result); 
+        Assert.Empty(result);
     }
-    
+
 }

--- a/tests/OrasProject.Oras.Tests/Remote/UriFactoryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Remote/UriFactoryTest.cs
@@ -27,13 +27,13 @@ public class UriFactoryTest
 
         var reference = Reference.Parse("localhost:5000/test");
         reference.ContentReference = desc.Digest;
-        
+
         const string artifactType = "doc/example";
         var expectedPath = $"referrers/{reference.ContentReference}";
         const string expectedQuery = "artifactType=doc%2fexample";
         var result = new UriFactory(reference).BuildReferrersUrl(artifactType);
         Assert.Equal($"https://localhost:5000/v2/test/{expectedPath}?{expectedQuery}", result.ToString());
-    }    
+    }
 
     [Fact]
     public void BuildReferrersUrl_WithoutArtifactType()
@@ -44,5 +44,5 @@ public class UriFactoryTest
         var expectedPath = $"referrers/{reference.ContentReference}";
         var result = new UriFactory(reference).BuildReferrersUrl();
         Assert.Equal($"https://localhost:5000/v2/test/{expectedPath}", result.ToString());
-    }   
+    }
 }

--- a/tests/OrasProject.Oras.Tests/Remote/Util/Util.cs
+++ b/tests/OrasProject.Oras.Tests/Remote/Util/Util.cs
@@ -14,6 +14,7 @@
 using Moq;
 using Moq.Protected;
 using OrasProject.Oras.Oci;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OrasProject.Oras.Tests.Remote.Util;
 
@@ -25,11 +26,22 @@ public class Util
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static bool AreDescriptorsEqual(Descriptor a, Descriptor b)
+    public static bool AreDescriptorsEqual([AllowNull] Descriptor a, [AllowNull] Descriptor b)
     {
-        return a.MediaType == b.MediaType && a.Digest == b.Digest && a.Size == b.Size;
+        if (a == null && b == null)
+        {
+            return true;
+        }
+        else if (a != null && b != null)
+        {
+            return a.MediaType == b.MediaType &&
+                   a.Digest == b.Digest &&
+                   a.Size == b.Size;
+        }
+
+        return false;
     }
-    
+
     public static HttpClient CustomClient(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> func)
     {
         var moqHandler = new Mock<DelegatingHandler>();


### PR DESCRIPTION
### What this PR does / why we need it
Improves tests. 

### Which issue(s) this PR resolves / fixes
Addressed compiler warnings and also applied dotnet format for the library tests.
Referrer tests and SDK warnings haven't been addressed.  

### Please check the following list
- [X] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [X] Do all new files have an appropriate license header?
