### PR TITLE
docs(oci): add documentation with OCI image spec v1.1.0 references

### DIFF
--- a/src/OrasProject.Oras/Oci/Descriptor.cs
+++ b/src/OrasProject.Oras/Oci/Descriptor.cs
@@ -17,6 +17,10 @@ using System.Text.Json.Serialization;
 
 namespace OrasProject.Oras.Oci;
 
+/// <summary>
+/// Descriptor describes a content addressable blob.
+/// Specification: https://github.com/opencontainers/image-spec/blob/v1.1.0/descriptor.md
+/// </summary>
 public class Descriptor
 {
     [JsonPropertyName("mediaType")]

--- a/src/OrasProject.Oras/Oci/Index.cs
+++ b/src/OrasProject.Oras/Oci/Index.cs
@@ -18,6 +18,10 @@ using System.Text.Json.Serialization;
 
 namespace OrasProject.Oras.Oci;
 
+/// <summary>
+/// Index is a higher-level manifest which points to specific image manifests, ideal for one or more platforms.
+/// Specification: https://github.com/opencontainers/image-spec/blob/v1.1.0/image-index.md
+/// </summary>
 public class Index : Versioned
 {
     // MediaType specifies the type of this document data structure e.g. `application/vnd.oci.image.index.v1+json`

--- a/src/OrasProject.Oras/Oci/Manifest.cs
+++ b/src/OrasProject.Oras/Oci/Manifest.cs
@@ -16,6 +16,10 @@ using System.Text.Json.Serialization;
 
 namespace OrasProject.Oras.Oci;
 
+/// <summary>
+/// Manifest describes an image or artifact.
+/// Specification: https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md
+/// </summary>
 public class Manifest : Versioned
 {
     [JsonPropertyName("mediaType")]

--- a/src/OrasProject.Oras/Oci/MediaType.cs
+++ b/src/OrasProject.Oras/Oci/MediaType.cs
@@ -13,6 +13,10 @@
 
 namespace OrasProject.Oras.Oci;
 
+/// <summary>
+/// MediaType constants for OCI image specification.
+/// Specification: https://github.com/opencontainers/image-spec/blob/v1.1.0/media-types.md
+/// </summary>
 public static class MediaType
 {
     /// <summary>

--- a/src/OrasProject.Oras/Oci/Platform.cs
+++ b/src/OrasProject.Oras/Oci/Platform.cs
@@ -16,6 +16,11 @@ using System.Text.Json.Serialization;
 
 namespace OrasProject.Oras.Oci;
 
+/// <summary>
+/// Platform describes the platform which the image in the manifest runs on.
+/// This should only be used when referring to a manifest.
+/// Specification: https://github.com/opencontainers/image-spec/blob/v1.1.0/image-index.md#platform-object
+/// </summary>
 public class Platform
 {
     [JsonPropertyName("architecture")]

--- a/src/OrasProject.Oras/Oci/Versioned.cs
+++ b/src/OrasProject.Oras/Oci/Versioned.cs
@@ -15,6 +15,10 @@ using System.Text.Json.Serialization;
 
 namespace OrasProject.Oras.Oci;
 
+/// <summary>
+/// Versioned provides the base structure for versioned schema definitions.
+/// Specification: https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md#image-manifest-property-descriptions
+/// </summary>
 public class Versioned
 {
     [JsonPropertyName("schemaVersion")]


### PR DESCRIPTION
### What this PR does / why we need it
Adds links to specification for OCI types. 

### Which issue(s) this PR resolves / fixes
This is only a documentation fix. 

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [X] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have an appropriate license header?
