### PR TITLE
build: configure centralized code analysis with Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,22 @@
+<!--
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <Project>
   <PropertyGroup>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrasProject.Oras/OrasProject.Oras.csproj
+++ b/src/OrasProject.Oras/OrasProject.Oras.csproj
@@ -1,3 +1,17 @@
+<!--
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>

--- a/src/OrasProject.Oras/OrasProject.Oras.csproj
+++ b/src/OrasProject.Oras/OrasProject.Oras.csproj
@@ -16,7 +16,6 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<OutputType>Library</OutputType>
 		<Nullable>enable</Nullable>
-		<AnalysisLevel>latest</AnalysisLevel>
 	</PropertyGroup>
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj
+++ b/tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj
@@ -4,13 +4,10 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     
     <!-- Disable requiring ConfigureAwait(false) for awaited tasks -->
     <NoWarn>CA2007</NoWarn>
-    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
-    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj
+++ b/tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj
@@ -1,3 +1,17 @@
+<!--
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>


### PR DESCRIPTION
### What this PR does / why we need it
Adding `Directory.Build.props file` to unify analyzers for tests and main assembly. 

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have an appropriate license header?

The props file is similar to the project files and have no header. 
