### PR TITLE
docs: fix toc links again

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,4 +1,4 @@
 - name: Home
-  href: /
+  href: /oras-dotnet/
 - name: Documentation
-  href: /api/
+  href: /oras-dotnet/api/


### PR DESCRIPTION
### What this PR does / why we need it
Fix the links in toc again. Looks like we still need the `/oras-dotnet/` prefix.

### Which issue(s) this PR resolves / fixes
<!-- Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->
Fixes #264, fixes #258

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have an appropriate license header?
