### PR TITLE
build(deps): downgrade dependencies to 8.* versions for max compatibility

### DIFF
--- a/src/OrasProject.Oras/OrasProject.Oras.csproj
+++ b/src/OrasProject.Oras/OrasProject.Oras.csproj
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
### What this PR does / why we need it

Dependencies in the 9.* series support .NET 8 and .NET 9, while 8.* supports .NET 6–8. As a library, sticking with 8.* ensures broader compatibility.

### Which issue(s) this PR resolves / fixes

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have an appropriate license header?
