### PR TITLE
docs: add missing XML documentation for FetchReferrersAsync methods

### DIFF
--- a/src/OrasProject.Oras/Registry/IRepository.cs
+++ b/src/OrasProject.Oras/Registry/IRepository.cs
@@ -44,27 +44,45 @@ public interface IRepository : ITarget, IReferenceFetchable, IReferencePushable,
 
     /// <summary>
     /// FetchReferrersAsync retrieves referrers for the given descriptor
-    /// and return a streaming of descriptors asynchronously for consumption.
-    /// If referrers API is not supported, the function falls back to a tag schema for retrieving referrers.
+    /// and returns a stream of descriptors asynchronously for consumption.
+    /// If referrers API is not supported, the function falls back to a tag
+    /// schema for retrieving referrers.
     /// If the referrers are supported via an API, the state is updated accordingly.
     /// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
     /// </summary>
-    /// <param name="descriptor"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    IAsyncEnumerable<Descriptor> FetchReferrersAsync(Descriptor descriptor, CancellationToken cancellationToken = default);
+    /// <param name="descriptor">
+    /// The target descriptor whose referrers are to be retrieved.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// An asynchronous enumerable of Descriptor objects representing the referrers.
+    /// </returns>
+    IAsyncEnumerable<Descriptor> FetchReferrersAsync(
+        Descriptor descriptor,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// FetchReferrersAsync retrieves referrers for the given descriptor and artifact type
-    /// and return a streaming of descriptors asynchronously for consumption.
-    /// If referrers API is not supported, the function falls back to a tag schema for retrieving referrers.
+    /// and returns a stream of descriptors asynchronously for consumption.
+    /// If referrers API is not supported, the function falls back to a tag
+    /// schema for retrieving referrers.
     /// If the referrers are supported via an API, the state is updated accordingly.
     /// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
     /// </summary>
-    /// <param name="descriptor"></param>
-    /// <param name="artifactType"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    IAsyncEnumerable<Descriptor> FetchReferrersAsync(Descriptor descriptor, string? artifactType, CancellationToken cancellationToken = default);
+    /// <param name="descriptor">
+    /// The target descriptor whose referrers are to be retrieved.
+    /// </param>
+    /// <param name="artifactType">
+    /// Filters referrers by the specified artifact type.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// An asynchronous enumerable of Descriptor objects representing the referrers
+    /// filtered by artifact type.
+    /// </returns>
+    IAsyncEnumerable<Descriptor> FetchReferrersAsync(
+        Descriptor descriptor,
+        string? artifactType,
+        CancellationToken cancellationToken = default);
 
 }


### PR DESCRIPTION
Addresses review comments from PR #322 that were missed before merge:

- Fix grammar: 'return a streaming' -> 'returns a stream'
- Add parameter descriptions for descriptor, artifactType, cancellationToken
- Add returns descriptions for both method overloads
- Wrap long lines to stay under 100 characters

### Please check the following list
- [ ] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x] Do all new files have an appropriate license header?