### PR TITLE
chore: fix trailing whitespace lint errors

### DIFF
--- a/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
+++ b/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
@@ -257,7 +257,7 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
         ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull);
         var remoteReference = Repository.ParseReferenceFromDigest(target.Digest);
         var url = new UriFactory(remoteReference, Repository.Options.PlainHttp).BuildRepositoryBlob();
-        
+
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         using var response = await Repository.Options.Client.SendAsync(request, allowAutoRedirect: false, cancellationToken).ConfigureAwait(false);
 
@@ -265,7 +265,7 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
         // If response.RequestMessage.RequestUri differs from the original request URI,
         // it means the provided HttpClient had AllowAutoRedirect=true, which breaks this API.
         var requestUri = response.RequestMessage?.RequestUri;
-        if (requestUri != null && 
+        if (requestUri != null &&
             !string.Equals(requestUri.ToString(), url.ToString(), StringComparison.OrdinalIgnoreCase))
         {
             throw new ArgumentException(

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs
@@ -1150,7 +1150,7 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
             Size = blob.Length
         };
         var redirectLocation = "https://storage.example.com/blob";
-        
+
         // Test case 1: Redirect with absolute URI
         HttpResponseMessage MockHandlerRedirect(HttpRequestMessage req, CancellationToken cancellationToken = default)
         {
@@ -1248,7 +1248,7 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
             PlainHttp = true,
         });
         var store = new BlobStore(repo);
-        
+
         await Assert.ThrowsAsync<NotFoundException>(async () =>
             await store.GetBlobLocationAsync(blobDesc, cancellationToken));
 
@@ -1279,7 +1279,7 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
             PlainHttp = true,
         });
         store = new BlobStore(repo);
-        
+
         var exception = await Assert.ThrowsAsync<HttpIOException>(async () =>
             await store.GetBlobLocationAsync(blobDesc, cancellationToken));
         Assert.Contains("Location header", exception.Message);
@@ -1312,7 +1312,7 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
             PlainHttp = false, // HTTPS is required
         });
         store = new BlobStore(repo);
-        
+
         exception = await Assert.ThrowsAsync<HttpIOException>(async () =>
             await store.GetBlobLocationAsync(blobDesc, cancellationToken));
         Assert.Contains("HTTPS", exception.Message);
@@ -1345,7 +1345,7 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
             PlainHttp = true,
         });
         store = new BlobStore(repo);
-        
+
         exception = await Assert.ThrowsAsync<HttpIOException>(async () =>
             await store.GetBlobLocationAsync(blobDesc, cancellationToken));
         Assert.Contains("absolute URI", exception.Message);


### PR DESCRIPTION
Remove trailing whitespace on blank lines in `BlobStore.cs` and `RepositoryTest.cs` flagged by super-linter.

### Files changed
- **`src/OrasProject.Oras/Registry/Remote/BlobStore.cs`**: Removed trailing whitespace on 2 lines (260, 268)
- **`tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs`**: Removed trailing whitespace on 6 lines (1153, 1154, 1251, 1282, 1315, 1348)