### PR TITLE
fix: use Go-compatible JSON encoding for OCI manifests

### DIFF
--- a/src/OrasProject.Oras/Content/CopyGraphOptions.cs
+++ b/src/OrasProject.Oras/Content/CopyGraphOptions.cs
@@ -26,10 +26,11 @@ namespace OrasProject.Oras;
 public class CopyGraphOptions
 {
     private const int _defaultConcurrency = 3;
-    private const long _defaultMaxMetadataBytes = 4 * 1024 * 1024; // 4 MiB
 
     private int _concurrency = _defaultConcurrency;
-    private long _maxMetadataBytes = _defaultMaxMetadataBytes;
+    // Defaults to the OCI manifest size limit since manifests are
+    // the primary metadata cached during copy operations.
+    private long _maxMetadataBytes = OciLimits.MaxManifestBytes;
 
     /// <summary>
     /// Concurrency limits the maximum number of concurrent copy tasks.

--- a/src/OrasProject.Oras/Content/FetchableExtensions.cs
+++ b/src/OrasProject.Oras/Content/FetchableExtensions.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 using OrasProject.Oras.Oci;
+using OrasProject.Oras.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -38,7 +39,7 @@ public static class FetchableExtensions
             case MediaType.ImageManifest:
                 {
                     var content = await fetcher.FetchAllAsync(node, cancellationToken).ConfigureAwait(false);
-                    var manifest = JsonSerializer.Deserialize<Manifest>(content) ??
+                    var manifest = OciJsonSerializer.Deserialize<Manifest>(content) ??
                                         throw new JsonException("Failed to deserialize manifest");
 
                     var descriptors = new List<Descriptor>();
@@ -55,7 +56,7 @@ public static class FetchableExtensions
             case MediaType.ImageIndex:
                 {
                     var content = await fetcher.FetchAllAsync(node, cancellationToken).ConfigureAwait(false);
-                    var index = JsonSerializer.Deserialize<Index>(content) ??
+                    var index = OciJsonSerializer.Deserialize<Index>(content) ??
                                         throw new JsonException("Failed to deserialize index manifest");
                     var descriptors = new List<Descriptor>();
                     if (index.Subject != null)

--- a/src/OrasProject.Oras/Content/OciLimits.cs
+++ b/src/OrasProject.Oras/Content/OciLimits.cs
@@ -1,0 +1,29 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace OrasProject.Oras.Content;
+
+/// <summary>
+/// OciLimits defines shared constants for OCI content size limits.
+/// The OCI Distribution Spec states that registries SHOULD enforce a
+/// manifest size limit. 4 MiB aligns with oras-go's default.
+/// See: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md
+/// </summary>
+internal static class OciLimits
+{
+    /// <summary>
+    /// MaxManifestBytes specifies the default limit on the size of
+    /// serialized manifests and metadata responses. 4 MiB.
+    /// </summary>
+    internal const long MaxManifestBytes = 4 * 1024 * 1024;
+}

--- a/src/OrasProject.Oras/Oci/Index.cs
+++ b/src/OrasProject.Oras/Oci/Index.cs
@@ -13,8 +13,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 using System.Text.Json.Serialization;
+using OrasProject.Oras.Serialization;
 
 namespace OrasProject.Oras.Oci;
 
@@ -56,10 +56,11 @@ public class Index : Versioned
         SchemaVersion = 2;
     }
 
-    internal static (Descriptor, byte[]) GenerateIndex(IList<Descriptor> manifests)
+    internal static (Descriptor Descriptor, byte[] Content) GenerateIndex(
+        IList<Descriptor> manifests)
     {
         var index = new Index(manifests);
-        var indexContent = JsonSerializer.SerializeToUtf8Bytes(index);
+        var indexContent = OciJsonSerializer.SerializeToUtf8Bytes(index);
         return (Descriptor.Create(indexContent, Oci.MediaType.ImageIndex), indexContent);
     }
 }

--- a/src/OrasProject.Oras/Packer.cs
+++ b/src/OrasProject.Oras/Packer.cs
@@ -14,6 +14,7 @@
 using OrasProject.Oras.Oci;
 using OrasProject.Oras.Content;
 using OrasProject.Oras.Exceptions;
+using OrasProject.Oras.Serialization;
 
 using System;
 using System.Collections.Generic;
@@ -235,7 +236,7 @@ public static partial class Packer
     /// <returns></returns>
     private static async Task<Descriptor> PushManifestAsync(IPushable pusher, object manifest, string mediaType, string? artifactType, IDictionary<string, string>? annotations, CancellationToken cancellationToken = default)
     {
-        var manifestJson = JsonSerializer.SerializeToUtf8Bytes(manifest);
+        var manifestJson = OciJsonSerializer.SerializeToUtf8Bytes(manifest);
         var manifestDesc = Descriptor.Create(manifestJson, mediaType);
         manifestDesc.ArtifactType = artifactType;
         manifestDesc.Annotations = annotations;

--- a/src/OrasProject.Oras/Registry/Remote/Error.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Error.cs
@@ -15,6 +15,7 @@ namespace OrasProject.Oras.Registry.Remote;
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using OrasProject.Oras.Serialization;
 
 public enum ErrorCode
 {
@@ -52,7 +53,7 @@ public class Error
         {
             try
             {
-                var detailJson = JsonSerializer.Serialize(detailValue);
+                var detailJson = OciJsonSerializer.FormatErrorDetail(detailValue);
                 return $"{result} (Detail: {detailJson})";
             }
             catch

--- a/src/OrasProject.Oras/Registry/Remote/Exceptions/ResponseException.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Exceptions/ResponseException.cs
@@ -17,8 +17,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Text.Json;
 using System.Text.Json.Serialization;
+using OrasProject.Oras.Serialization;
 
 namespace OrasProject.Oras.Registry.Remote.Exceptions;
 
@@ -81,7 +81,7 @@ public class ResponseException : HttpRequestException
         {
             try
             {
-                var errorResponse = JsonSerializer.Deserialize<ErrorResponse>(responseBody);
+                var errorResponse = OciJsonSerializer.Deserialize<ErrorResponse>(responseBody);
                 errors = errorResponse?.Errors;
             }
             catch

--- a/src/OrasProject.Oras/Registry/Remote/ManifestStore.cs
+++ b/src/OrasProject.Oras/Registry/Remote/ManifestStore.cs
@@ -13,6 +13,7 @@
 
 using OrasProject.Oras.Exceptions;
 using OrasProject.Oras.Oci;
+using OrasProject.Oras.Serialization;
 using System;
 using System.IO;
 using System.Net;
@@ -259,8 +260,10 @@ public class ManifestStore(Repository repository) : IManifestStore
         switch (desc.MediaType)
         {
             case MediaType.ImageIndex:
-                var indexManifest = JsonSerializer.Deserialize<Index>(content)
-                                        ?? throw new JsonException("Failed to deserialize index");
+                var indexManifest = await OciJsonSerializer
+                    .DeserializeAsync<Index>(content, cancellationToken)
+                    .ConfigureAwait(false)
+                    ?? throw new JsonException("Failed to deserialize index");
                 if (indexManifest.Subject == null)
                 {
                     return;
@@ -270,8 +273,10 @@ public class ManifestStore(Repository repository) : IManifestStore
                 desc.Annotations = indexManifest.Annotations;
                 break;
             case MediaType.ImageManifest:
-                var imageManifest = JsonSerializer.Deserialize<Manifest>(content) ??
-                                        throw new JsonException("Failed to deserialize manifest");
+                var imageManifest = await OciJsonSerializer
+                    .DeserializeAsync<Manifest>(content, cancellationToken)
+                    .ConfigureAwait(false)
+                    ?? throw new JsonException("Failed to deserialize manifest");
                 if (imageManifest.Subject == null)
                 {
                     return;
@@ -479,7 +484,9 @@ public class ManifestStore(Repository repository) : IManifestStore
         switch (target.MediaType)
         {
             case MediaType.ImageManifest:
-                var imageManifest = JsonSerializer.Deserialize<Manifest>(manifestContent);
+                var imageManifest = await OciJsonSerializer
+                    .DeserializeAsync<Manifest>(manifestContent, cancellationToken)
+                    .ConfigureAwait(false);
                 if (imageManifest?.Subject == null)
                 {
                     // no subject, no indexing needed
@@ -488,7 +495,9 @@ public class ManifestStore(Repository repository) : IManifestStore
                 subject = imageManifest.Subject;
                 break;
             case MediaType.ImageIndex:
-                var imageIndex = JsonSerializer.Deserialize<Index>(manifestContent);
+                var imageIndex = await OciJsonSerializer
+                    .DeserializeAsync<Index>(manifestContent, cancellationToken)
+                    .ConfigureAwait(false);
                 if (imageIndex?.Subject == null)
                 {
                     // no subject, no indexing needed

--- a/src/OrasProject.Oras/Registry/Remote/Registry.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Registry.cs
@@ -17,12 +17,12 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using OrasProject.Oras.Registry.Remote.Auth;
+using OrasProject.Oras.Serialization;
 
 namespace OrasProject.Oras.Registry.Remote;
 
@@ -144,7 +144,7 @@ public class Registry : IRegistry
             throw await response.ParseErrorResponseAsync(cancellationToken).ConfigureAwait(false);
         }
         var data = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        var repositories = JsonSerializer.Deserialize<RepositoryList>(data);
+        var repositories = OciJsonSerializer.Deserialize<RepositoryList>(data);
         return (repositories.Repositories ?? Array.Empty<string>(), response.ParseLink());
     }
 

--- a/src/OrasProject.Oras/Registry/Remote/Repository.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Repository.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 using System.Web;
 using OrasProject.Oras.Content;
 using OrasProject.Oras.Registry.Remote.Auth;
+using OrasProject.Oras.Serialization;
 using Index = OrasProject.Oras.Oci.Index;
 
 namespace OrasProject.Oras.Registry.Remote;
@@ -318,7 +319,7 @@ public class Repository : IRepository
         }
         using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         var limitedStreamContent = await stream.ReadStreamWithLimitAsync(_opts.MaxMetadataBytes, cancellationToken).ConfigureAwait(false);
-        var tagList = JsonSerializer.Deserialize<TagList>(limitedStreamContent);
+        var tagList = OciJsonSerializer.Deserialize<TagList>(limitedStreamContent);
         return (tagList.Tags ?? Array.Empty<string>(), response.ParseLink());
     }
 
@@ -595,10 +596,12 @@ public class Repository : IRepository
             }
 
             using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-            var limitedStreamContent = await stream.ReadStreamWithLimitAsync(_opts.MaxMetadataBytes, cancellationToken).ConfigureAwait(false);
-            var referrersIndex = JsonSerializer.Deserialize<Index>(limitedStreamContent) ??
-                                    throw new InvalidResponseException(
-                                        $"{response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}: failed to decode response");
+            var limitedStreamContent = await stream.ReadStreamWithLimitAsync(
+                _opts.MaxMetadataBytes, cancellationToken).ConfigureAwait(false);
+            var referrersIndex = OciJsonSerializer.Deserialize<Index>(limitedStreamContent)
+                ?? throw new InvalidResponseException(
+                    $"{response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}"
+                    + ": failed to decode response");
 
             // Set ReferrerState to Supported
             SetReferrersState(true);
@@ -683,8 +686,9 @@ public class Repository : IRepository
             result.Descriptor.LimitSize(Options.MaxMetadataBytes);
             using var stream = result.Stream;
             var indexBytes = await stream.ReadAllAsync(result.Descriptor, cancellationToken).ConfigureAwait(false);
-            var index = JsonSerializer.Deserialize<Index>(indexBytes) ?? throw new JsonException(
-                $"error when deserialize index manifest for referrersTag {referrersTag}");
+            var index = OciJsonSerializer.Deserialize<Index>(indexBytes)
+                ?? throw new JsonException(
+                    $"Error deserializing index manifest for referrersTag {referrersTag}");
             return (result.Descriptor, index.Manifests);
         }
         catch (NotFoundException)

--- a/src/OrasProject.Oras/Registry/Remote/RepositoryOptions.cs
+++ b/src/OrasProject.Oras/Registry/Remote/RepositoryOptions.cs
@@ -13,6 +13,7 @@
 
 using System;
 using System.Collections.Generic;
+using OrasProject.Oras.Content;
 using OrasProject.Oras.Registry.Remote.Auth;
 
 namespace OrasProject.Oras.Registry.Remote;
@@ -93,7 +94,7 @@ public struct RepositoryOptions
     /// </summary>
     public long MaxMetadataBytes
     {
-        get => _maxMetadataBytes == 0 ? _defaultMaxMetadataBytes : _maxMetadataBytes;
+        get => _maxMetadataBytes == 0 ? OciLimits.MaxManifestBytes : _maxMetadataBytes;
         set
         {
             if (value <= 0)
@@ -105,11 +106,4 @@ public struct RepositoryOptions
     }
 
     private long _maxMetadataBytes;
-
-    /// <summary>
-    /// _defaultMaxMetadataBytes specifies the default limit on how many response
-    /// bytes are allowed in the server's response to the metadata APIs.
-    /// See also: Repository.MaxMetadataBytes
-    /// </summary>
-    private const long _defaultMaxMetadataBytes = 4 * 1024 * 1024; // 4 MiB
 }

--- a/src/OrasProject.Oras/Serialization/OciDictionaryConverter.cs
+++ b/src/OrasProject.Oras/Serialization/OciDictionaryConverter.cs
@@ -1,0 +1,101 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OrasProject.Oras.Serialization;
+
+/// <summary>
+/// OciDictionaryConverter serializes IDictionary&lt;string, string&gt;
+/// with Go-compatible escaping for both keys and values.
+/// JsonConverter&lt;string&gt; is not called for dictionary keys,
+/// so this converter handles the full dictionary serialization.
+/// </summary>
+internal sealed class OciDictionaryConverter
+    : JsonConverter<IDictionary<string, string>>
+{
+    // Sorts keys by UTF-8 byte sequence to match Go's encoding/json.Marshal,
+    // which sorts map keys using Go string comparison (bytewise over UTF-8).
+    // StringComparer.Ordinal compares UTF-16 code units, which diverges from
+    // UTF-8 byte order for non-BMP characters (surrogate pairs).
+    private static readonly Comparison<KeyValuePair<string, string>>
+        Utf8KeyComparison = (a, b) =>
+    {
+        var aBytes = Encoding.UTF8.GetBytes(a.Key);
+        var bBytes = Encoding.UTF8.GetBytes(b.Key);
+        return aBytes.AsSpan().SequenceCompareTo(bBytes);
+    };
+
+    // Token ordering (PropertyName after StartObject, no truncation)
+    // is enforced by Utf8JsonReader before this method is called.
+    // Only the value type check is needed — annotations must be strings.
+    public override IDictionary<string, string>? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        var dict = new Dictionary<string, string>();
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                return dict;
+            }
+
+            var key = reader.GetString()!;
+            reader.Read();
+
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new JsonException(
+                    $"Expected string value, got {reader.TokenType}.");
+            }
+
+            dict[key] = reader.GetString()!;
+        }
+
+        throw new JsonException("Unexpected end of JSON.");
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        IDictionary<string, string> value,
+        JsonSerializerOptions options)
+    {
+        var sb = new StringBuilder();
+        sb.Append('{');
+        var first = true;
+        var sorted = value.ToList();
+        sorted.Sort(Utf8KeyComparison);
+        foreach (var kvp in sorted)
+        {
+            if (!first)
+            {
+                sb.Append(',');
+            }
+            first = false;
+            sb.Append('"');
+            sb.Append(OciJsonSerializer.EscapeJsonString(kvp.Key));
+            sb.Append("\":\"");
+            sb.Append(OciJsonSerializer.EscapeJsonString(kvp.Value));
+            sb.Append('"');
+        }
+        sb.Append('}');
+        writer.WriteRawValue(sb.ToString());
+    }
+}

--- a/src/OrasProject.Oras/Serialization/OciJsonSerializer.cs
+++ b/src/OrasProject.Oras/Serialization/OciJsonSerializer.cs
@@ -1,0 +1,169 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using OrasProject.Oras.Content;
+using OrasProject.Oras.Exceptions;
+
+namespace OrasProject.Oras.Serialization;
+
+/// <summary>
+/// OciJsonSerializer provides JSON serialization for OCI content
+/// with Go-compatible encoding (literal '+' instead of '\u002B').
+/// </summary>
+internal static class OciJsonSerializer
+{
+    private static readonly JsonSerializerOptions s_options = CreateOptions();
+
+    /// <summary>
+    /// Serializes the value to a UTF-8 JSON byte array with
+    /// Go-compatible string escaping. Throws if the result exceeds
+    /// <see cref="OciLimits.MaxManifestBytes"/>.
+    /// </summary>
+    /// <remarks>
+    /// The full byte array is materialized before the size check.
+    /// This is acceptable because OCI manifests are bounded in
+    /// practice, but callers constructing adversarially large
+    /// objects will allocate before the guard fires.
+    /// </remarks>
+    internal static byte[] SerializeToUtf8Bytes<T>(T value)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(value, s_options);
+        if (bytes.Length > OciLimits.MaxManifestBytes)
+        {
+            throw new SizeLimitExceededException(
+                $"Serialized size {bytes.Length} bytes exceeds"
+                + $" limit of {OciLimits.MaxManifestBytes} bytes.");
+        }
+        return bytes;
+    }
+
+    /// <summary>
+    /// Deserializes a UTF-8 JSON byte array to the specified type.
+    /// </summary>
+    internal static T? Deserialize<T>(byte[] utf8Json)
+    {
+        return JsonSerializer.Deserialize<T>(utf8Json, s_options);
+    }
+
+    /// <summary>
+    /// Deserializes a JSON string to the specified type.
+    /// </summary>
+    internal static T? Deserialize<T>(string json)
+    {
+        return JsonSerializer.Deserialize<T>(json, s_options);
+    }
+
+    /// <summary>
+    /// Deserializes a UTF-8 JSON stream to the specified type.
+    /// </summary>
+    internal static async Task<T?> DeserializeAsync<T>(
+        Stream utf8Json,
+        CancellationToken cancellationToken)
+    {
+        return await JsonSerializer.DeserializeAsync<T>(
+            utf8Json, s_options, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Formats a JsonElement as a JSON string for error display.
+    /// </summary>
+    internal static string FormatErrorDetail(JsonElement detail)
+    {
+        return JsonSerializer.Serialize(detail, s_options);
+    }
+
+    /// <summary>
+    /// Escapes a JSON string value.
+    /// Escapes: ", \, control chars, &lt;, &gt;, &amp;, U+2028, U+2029.
+    /// Does NOT escape '+', matching Go's encoding/json.Marshal for
+    /// cross-runtime content-addressable storage compatibility.
+    /// </summary>
+    internal static string EscapeJsonString(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            switch (ch)
+            {
+                // JSON structural characters
+                case '"':
+                    sb.Append("\\\"");
+                    break;
+                case '\\':
+                    sb.Append("\\\\");
+                    break;
+                // Named control character escapes
+                case '\b':
+                    sb.Append("\\b");
+                    break;
+                case '\f':
+                    sb.Append("\\f");
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case '\t':
+                    sb.Append("\\t");
+                    break;
+                // HTML-sensitive characters (Go escapes these)
+                case '<':
+                    sb.Append("\\u003c");
+                    break;
+                case '>':
+                    sb.Append("\\u003e");
+                    break;
+                case '&':
+                    sb.Append("\\u0026");
+                    break;
+                // Unicode line/paragraph separators (Go escapes these)
+                case '\u2028':
+                    sb.Append("\\u2028");
+                    break;
+                case '\u2029':
+                    sb.Append("\\u2029");
+                    break;
+                default:
+                    // Escape remaining control chars (U+0000–U+001F)
+                    // as \uXXXX; pass all other characters through
+                    // literally, including '+'.
+                    if (ch <= '\u001F')
+                    {
+                        sb.Append($"\\u{(int)ch:x4}");
+                    }
+                    else
+                    {
+                        sb.Append(ch);
+                    }
+                    break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static JsonSerializerOptions CreateOptions()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new OciStringConverter());
+        options.Converters.Add(new OciDictionaryConverter());
+        return options;
+    }
+}

--- a/src/OrasProject.Oras/Serialization/OciStringConverter.cs
+++ b/src/OrasProject.Oras/Serialization/OciStringConverter.cs
@@ -1,0 +1,42 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OrasProject.Oras.Serialization;
+
+/// <summary>
+/// OciStringConverter serializes string values using Go-compatible
+/// escaping, bypassing .NET's default encoder which escapes '+'.
+/// </summary>
+internal sealed class OciStringConverter : JsonConverter<string>
+{
+    public override string? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        return reader.GetString();
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        string value,
+        JsonSerializerOptions options)
+    {
+        var escaped = OciJsonSerializer.EscapeJsonString(value);
+        writer.WriteRawValue($"\"{escaped}\"");
+    }
+}

--- a/tests/OrasProject.Oras.Tests/Serialization/ManifestSerializationTest.cs
+++ b/tests/OrasProject.Oras.Tests/Serialization/ManifestSerializationTest.cs
@@ -1,0 +1,410 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Text;
+using OrasProject.Oras.Exceptions;
+using OrasProject.Oras.Oci;
+using OrasProject.Oras.Serialization;
+using Xunit;
+using OciIndex = OrasProject.Oras.Oci.Index;
+
+namespace OrasProject.Oras.Tests.Serialization;
+
+public class ManifestSerializationTest
+{
+    /// <summary>
+    /// Deserialize fully defined JSON manifest strings and verify
+    /// all fields are preserved including plus signs.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(JsonManifestFixtures))]
+    public void Deserialize_Manifest_PreservesAllFields(
+        string json,
+        string expectedMediaType,
+        string? expectedArtifactType,
+        int expectedLayerCount,
+        bool hasSubject,
+        bool hasAnnotations)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var m = OciJsonSerializer.Deserialize<Manifest>(bytes)!;
+
+        Assert.Equal(2, m.SchemaVersion);
+        Assert.Equal(expectedMediaType, m.MediaType);
+        Assert.Equal(expectedArtifactType, m.ArtifactType);
+        Assert.Equal(expectedLayerCount, m.Layers.Count);
+
+        if (hasSubject)
+        {
+            Assert.NotNull(m.Subject);
+        }
+        else
+        {
+            Assert.Null(m.Subject);
+        }
+
+        if (hasAnnotations)
+        {
+            Assert.NotNull(m.Annotations);
+            Assert.NotEmpty(m.Annotations!);
+        }
+    }
+
+    /// <summary>
+    /// Verify annotations with '+' in both keys and values survive
+    /// deserialization from raw JSON strings.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(JsonAnnotationFixtures))]
+    public void Deserialize_Manifest_AnnotationsPreserved(
+        string json,
+        string expectedKey,
+        string expectedValue)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var m = OciJsonSerializer.Deserialize<Manifest>(bytes)!;
+
+        Assert.NotNull(m.Annotations);
+        Assert.True(
+            m.Annotations!.ContainsKey(expectedKey),
+            $"Missing annotation key: {expectedKey}");
+        Assert.Equal(expectedValue, m.Annotations[expectedKey]);
+    }
+
+    /// <summary>
+    /// Deserialize fully defined JSON index strings and verify
+    /// manifest list and annotations are preserved.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(JsonIndexFixtures))]
+    public void Deserialize_Index_PreservesAllFields(
+        string json,
+        int expectedManifestCount,
+        bool hasAnnotations)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var idx = OciJsonSerializer.Deserialize<OciIndex>(bytes)!;
+
+        Assert.Equal(2, idx.SchemaVersion);
+        Assert.Equal(expectedManifestCount, idx.Manifests.Count);
+
+        if (hasAnnotations)
+        {
+            Assert.NotNull(idx.Annotations);
+            Assert.NotEmpty(idx.Annotations!);
+        }
+
+        foreach (var desc in idx.Manifests)
+        {
+            Assert.False(string.IsNullOrEmpty(desc.MediaType));
+            Assert.False(string.IsNullOrEmpty(desc.Digest));
+            Assert.True(desc.Size > 0);
+        }
+    }
+
+    /// <summary>
+    /// Deserialize → re-serialize round-trip: output must contain
+    /// no escaped '+' and be semantically equivalent to input.
+    /// Also verifies byte-level idempotency: serializing the
+    /// deserialized object twice produces identical bytes.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(JsonRoundTripFixtures))]
+    public void RoundTrip_NoEscapedPlus_Equivalent(
+        string json, bool isIndex)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+
+        byte[] reserialized;
+        if (isIndex)
+        {
+            var idx = OciJsonSerializer.Deserialize<OciIndex>(bytes)!;
+            reserialized = OciJsonSerializer.SerializeToUtf8Bytes(idx);
+        }
+        else
+        {
+            var m = OciJsonSerializer.Deserialize<Manifest>(bytes)!;
+            reserialized = OciJsonSerializer.SerializeToUtf8Bytes(m);
+        }
+
+        var output = Encoding.UTF8.GetString(reserialized);
+        Assert.DoesNotContain("\\u002B", output);
+        Assert.Contains("+", output);
+
+        // Verify byte-level idempotency: a second round-trip must
+        // produce byte-identical output for CAS compatibility.
+        byte[] reserialized2;
+        if (isIndex)
+        {
+            var idx2 =
+                OciJsonSerializer.Deserialize<OciIndex>(reserialized)!;
+            reserialized2 =
+                OciJsonSerializer.SerializeToUtf8Bytes(idx2);
+        }
+        else
+        {
+            var m2 =
+                OciJsonSerializer.Deserialize<Manifest>(reserialized)!;
+            reserialized2 =
+                OciJsonSerializer.SerializeToUtf8Bytes(m2);
+        }
+        Assert.Equal(reserialized, reserialized2);
+    }
+
+    [Fact]
+    public void Serialize_ThrowsWhenExceedingMaxSize()
+    {
+        var m = new Manifest
+        {
+            SchemaVersion = 2,
+            MediaType = MediaType.ImageManifest,
+            Config = Descriptor.Empty,
+            Layers = new List<Descriptor>(),
+            Annotations = new Dictionary<string, string>()
+        };
+        var big = new string('x', 1024 * 1024);
+        for (var i = 0; i < 5; i++)
+        {
+            m.Annotations[$"key{i}"] = big;
+        }
+
+        Assert.Throws<SizeLimitExceededException>(
+            () => OciJsonSerializer.SerializeToUtf8Bytes(m));
+    }
+
+    #region Fixture Providers
+
+    public static IEnumerable<object[]> JsonManifestFixtures()
+    {
+        yield return new object[]
+        {
+            MinimalManifestJson,
+            "application/vnd.oci.image.manifest.v1+json",
+            null!,
+            1, false, false
+        };
+        yield return new object[]
+        {
+            FullManifestJson,
+            "application/vnd.oci.image.manifest.v1+json",
+            "application/vnd.example+type",
+            2, true, true
+        };
+        yield return new object[]
+        {
+            DockerManifestJson,
+            "application/vnd.docker.distribution.manifest.v2+json",
+            null!,
+            1, false, false
+        };
+    }
+
+    public static IEnumerable<object[]> JsonAnnotationFixtures()
+    {
+        yield return new object[]
+        {
+            FullManifestJson,
+            "org.example+custom/key+1",
+            "value+with+plus"
+        };
+        yield return new object[]
+        {
+            FullManifestJson,
+            "org.opencontainers.image.created",
+            "2026-01-01T00:00:00Z"
+        };
+        yield return new object[]
+        {
+            LayerAnnotationManifestJson,
+            "org.layer+anno/key",
+            "layer+value"
+        };
+    }
+
+    public static IEnumerable<object[]> JsonIndexFixtures()
+    {
+        yield return new object[]
+            { MinimalIndexJson, 2, false };
+        yield return new object[]
+            { FullIndexJson, 2, true };
+    }
+
+    public static IEnumerable<object[]> JsonRoundTripFixtures()
+    {
+        yield return new object[]
+            { MinimalManifestJson, false };
+        yield return new object[]
+            { FullManifestJson, false };
+        yield return new object[]
+            { DockerManifestJson, false };
+        yield return new object[]
+            { MinimalIndexJson, true };
+        yield return new object[]
+            { FullIndexJson, true };
+    }
+
+    #endregion
+
+    #region JSON String Constants
+
+    private const string MinimalManifestJson = """
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.oci.empty.v1+json",
+                "digest": "sha256:44136fa355b311bfa706c319d8f39c36e47d288aca2e1cc38b1c",
+                "size": 2
+            },
+            "layers": [
+                {
+                    "mediaType": "application/vnd.oci.empty.v1+json",
+                    "digest": "sha256:44136fa355b311bfa706c319d8f39c36e47d288aca2e1cc38b1c",
+                    "size": 2
+                }
+            ]
+        }
+        """;
+
+    private const string FullManifestJson = """
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "artifactType": "application/vnd.example+type",
+            "config": {
+                "mediaType": "application/vnd.oci.empty.v1+json",
+                "digest": "sha256:44136fa355b311bfa706c319d8f39c36e47d288aca2e1cc38b1c",
+                "size": 2
+            },
+            "layers": [
+                {
+                    "mediaType": "application/vnd.oci.empty.v1+json",
+                    "digest": "sha256:44136fa355b311bfa706c319d8f39c36e47d288aca2e1cc38b1c",
+                    "size": 2
+                },
+                {
+                    "mediaType": "application/vnd.custom+layer",
+                    "digest": "sha256:aaa111bbb222ccc333ddd444eee555fff666aaa111bbb222ccc333",
+                    "size": 100
+                }
+            ],
+            "subject": {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                "size": 1234
+            },
+            "annotations": {
+                "org.example+custom/key+1": "value+with+plus",
+                "org.opencontainers.image.created": "2026-01-01T00:00:00Z"
+            }
+        }
+        """;
+
+    private const string DockerManifestJson = """
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "config": {
+                "mediaType": "application/vnd.docker.container.image.v1+json",
+                "digest": "sha256:aaa111bbb222ccc333ddd444eee555fff666aaa111bbb222ccc333",
+                "size": 1024
+            },
+            "layers": [
+                {
+                    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                    "digest": "sha256:bbb222ccc333ddd444eee555fff666aaa111bbb222ccc333ddd444",
+                    "size": 2048
+                }
+            ]
+        }
+        """;
+
+    private const string LayerAnnotationManifestJson = """
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.oci.empty.v1+json",
+                "digest": "sha256:44136fa355b311bfa706c319d8f39c36e47d288aca2e1cc38b1c",
+                "size": 2
+            },
+            "layers": [
+                {
+                    "mediaType": "application/vnd.custom+layer",
+                    "digest": "sha256:aaa111bbb222ccc333ddd444eee555fff666aaa111bbb222ccc333",
+                    "size": 100,
+                    "annotations": {
+                        "org.layer+anno/key": "layer+value"
+                    }
+                }
+            ],
+            "annotations": {
+                "org.layer+anno/key": "layer+value"
+            }
+        }
+        """;
+
+    private const string MinimalIndexJson = """
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "sha256:aaa111bbb222ccc333ddd444eee555fff666aaa111bbb222ccc333",
+                    "size": 500
+                },
+                {
+                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                    "digest": "sha256:bbb222ccc333ddd444eee555fff666aaa111bbb222ccc333ddd444",
+                    "size": 600
+                }
+            ]
+        }
+        """;
+
+    private const string FullIndexJson = """
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "sha256:aaa111bbb222ccc333ddd444eee555fff666aaa111bbb222ccc333",
+                    "size": 500,
+                    "platform": {
+                        "architecture": "amd64",
+                        "os": "linux"
+                    }
+                },
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "sha256:bbb222ccc333ddd444eee555fff666aaa111bbb222ccc333ddd444",
+                    "size": 600,
+                    "platform": {
+                        "architecture": "arm64",
+                        "os": "linux",
+                        "variant": "v8"
+                    }
+                }
+            ],
+            "annotations": {
+                "org.opencontainers.image.ref.name": "latest",
+                "org.example+index/key+1": "index+value"
+            }
+        }
+        """;
+
+    #endregion
+}

--- a/tests/OrasProject.Oras.Tests/Serialization/OciDictionaryConverterTest.cs
+++ b/tests/OrasProject.Oras.Tests/Serialization/OciDictionaryConverterTest.cs
@@ -1,0 +1,218 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using OrasProject.Oras.Oci;
+using OrasProject.Oras.Serialization;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Serialization;
+
+public class OciDictionaryConverterTest
+{
+    private static string SerializeDict(
+        IDictionary<string, string> dict)
+    {
+        var bytes = OciJsonSerializer.SerializeToUtf8Bytes(dict);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    [Theory]
+    [InlineData("k+ey", "val+ue", "+", "\\u002B")]
+    [InlineData("k<ey", "val&ue", "\\u003c", "<")]
+    [InlineData("k\u2028", "v\u2029", "\\u2028", null)]
+    public void Serialize_ShouldEscapeKeysAndValues(
+        string key, string value, string expected, string? forbidden)
+    {
+        var dict = new Dictionary<string, string> { [key] = value };
+        var json = SerializeDict(dict);
+        Assert.Contains(expected, json);
+        if (forbidden != null)
+        {
+            Assert.DoesNotContain(forbidden, json);
+        }
+    }
+
+    [Fact]
+    public void EmptyDictionary_ShouldSerializeAsEmptyObject()
+    {
+        var json = SerializeDict(new Dictionary<string, string>());
+        Assert.Equal("{}", json);
+    }
+
+    [Fact]
+    public void Deserialize_NullAnnotations_ReturnsNull()
+    {
+        var json = """
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "config": {
+                    "mediaType": "application/vnd.oci.empty.v1+json",
+                    "digest": "sha256:44136fa355b311bfa706c319d8f39c36e47d288aca2e1cc38b1c",
+                    "size": 2
+                },
+                "layers": [],
+                "annotations": null
+            }
+            """;
+        var manifest = OciJsonSerializer.Deserialize<Manifest>(
+            Encoding.UTF8.GetBytes(json))!;
+        Assert.Null(manifest.Annotations);
+    }
+
+    [Theory]
+    [InlineData("""{"annotationKey": 123}""")]
+    [InlineData("""{"annotationKey": [1,2]}""")]
+    [InlineData("""{"annotationKey": {"nested": true}}""")]
+    [InlineData("""{"annotationKey": null}""")]
+    [InlineData("""{"annotationKey": "value" """)]
+    public void Deserialize_InvalidDictionaryJson_Throws(string json)
+    {
+        Assert.ThrowsAny<JsonException>(() =>
+            OciJsonSerializer
+                .Deserialize<IDictionary<string, string>>(
+                    Encoding.UTF8.GetBytes(json)));
+    }
+
+    [Fact]
+    public void Read_ConverterHandlesEdgeCases()
+    {
+        var converter = new OciDictionaryConverter();
+        var opts = new JsonSerializerOptions();
+        var type = typeof(IDictionary<string, string>);
+
+        // Non-string value throws
+        Assert.ThrowsAny<JsonException>(() =>
+            ReadDict("""{"annotationKey": 42}"""));
+
+        // Empty object returns empty dict
+        var empty = new Utf8JsonReader("{}"u8);
+        empty.Read();
+        var emptyResult = converter.Read(ref empty, type, opts);
+        Assert.NotNull(emptyResult);
+        Assert.Empty(emptyResult!);
+
+        // Valid pair preserves values
+        var valid = new Utf8JsonReader(
+            """{"a+b": "c+d"}"""u8);
+        valid.Read();
+        var result = converter.Read(ref valid, type, opts);
+        Assert.Equal("c+d", result!["a+b"]);
+
+        static IDictionary<string, string>? ReadDict(string json)
+        {
+            var c = new OciDictionaryConverter();
+            var r = new Utf8JsonReader(
+                Encoding.UTF8.GetBytes(json));
+            r.Read();
+            return c.Read(
+                ref r, typeof(IDictionary<string, string>),
+                new JsonSerializerOptions());
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(RoundTripData))]
+    public void RoundTrip_ShouldPreserveKeyValues(
+        Dictionary<string, string> dict)
+    {
+        IDictionary<string, string> idict = dict;
+        var bytes = OciJsonSerializer.SerializeToUtf8Bytes(idict);
+        var result = OciJsonSerializer
+            .Deserialize<IDictionary<string, string>>(bytes);
+        Assert.NotNull(result);
+        foreach (var kvp in dict)
+        {
+            Assert.Equal(kvp.Value, result![kvp.Key]);
+        }
+    }
+
+    /// <summary>
+    /// Verifies keys are sorted by UTF-8 byte order, matching
+    /// Go's encoding/json.Marshal. UTF-16 ordinal comparison
+    /// (StringComparer.Ordinal) gives a different order for
+    /// non-BMP characters because surrogate pairs (0xD800–0xDFFF)
+    /// compare lower than high BMP code points.
+    ///
+    /// U+E000 (UTF-8: EE 80 80) vs U+10000 (UTF-8: F0 90 80 80):
+    ///   UTF-16 ordinal: U+10000 first (\uD800 &lt; \uE000)
+    ///   UTF-8 bytewise: U+E000 first  (0xEE &lt; 0xF0)
+    /// Go uses UTF-8 order, so U+E000 must come first.
+    /// </summary>
+    [Fact]
+    public void Write_ShouldSortKeysByUtf8ByteOrder()
+    {
+        // U+E000 = Private Use Area (UTF-8: EE 80 80)
+        // U+10000 = Linear B Syllabary (UTF-8: F0 90 80 80)
+        // UTF-16 ordinal: "\uD800\uDC00" < "\uE000" (wrong)
+        // UTF-8 bytewise: 0xEE < 0xF0 (correct Go order)
+        var dict = new Dictionary<string, string>
+        {
+            ["\U00010000"] = "non-bmp",
+            ["\uE000"] = "private-use"
+        };
+        IDictionary<string, string> idict = dict;
+        var json = SerializeDict(idict);
+
+        var e000Idx = json.IndexOf("\\uE000", System.StringComparison.Ordinal);
+        var tenKIdx = json.IndexOf("non-bmp", System.StringComparison.Ordinal);
+        Assert.True(
+            e000Idx < tenKIdx,
+            $"U+E000 (idx {e000Idx}) should appear before "
+            + $"U+10000 (idx {tenKIdx}) in UTF-8 byte order");
+    }
+
+    /// <summary>
+    /// Verifies ASCII keys are sorted correctly (common case).
+    /// </summary>
+    [Fact]
+    public void Write_ShouldSortAsciiKeysAlphabetically()
+    {
+        var dict = new Dictionary<string, string>
+        {
+            ["z-last"] = "3",
+            ["a-first"] = "1",
+            ["m-middle"] = "2"
+        };
+        IDictionary<string, string> idict = dict;
+        var json = SerializeDict(idict);
+
+        var aIdx = json.IndexOf("a-first", System.StringComparison.Ordinal);
+        var mIdx = json.IndexOf("m-middle", System.StringComparison.Ordinal);
+        var zIdx = json.IndexOf("z-last", System.StringComparison.Ordinal);
+        Assert.True(aIdx < mIdx, "a-first before m-middle");
+        Assert.True(mIdx < zIdx, "m-middle before z-last");
+    }
+
+    public static IEnumerable<object[]> RoundTripData()
+    {
+        yield return new object[]
+        {
+            new Dictionary<string, string>
+            {
+                ["org.example+custom"] = "value+plus"
+            }
+        };
+        yield return new object[]
+        {
+            new Dictionary<string, string>
+            {
+                ["<html>"] = "&value",
+                ["normal"] = "normal"
+            }
+        };
+    }
+}

--- a/tests/OrasProject.Oras.Tests/Serialization/OciStringConverterTest.cs
+++ b/tests/OrasProject.Oras.Tests/Serialization/OciStringConverterTest.cs
@@ -1,0 +1,65 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+using OrasProject.Oras.Serialization;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Serialization;
+
+public class OciStringConverterTest
+{
+    private static string Serialize(string value)
+    {
+        var bytes = OciJsonSerializer.SerializeToUtf8Bytes(value);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    [Theory]
+    [InlineData("application/vnd.oci.image.manifest.v1+json",
+        "+", "\\u002B")]
+    [InlineData("<script>&foo</script>",
+        "\\u003c", "<")]
+    [InlineData("line\u2028para\u2029end",
+        "\\u2028", null)]
+    [InlineData("a\u0001z\u001Fc",
+        "\\u0001", null)]
+    [InlineData("\t\n\r\b\f",
+        "\\t", null)]
+    [InlineData("\b", "\\b", null)]
+    [InlineData("\f", "\\f", null)]
+    [InlineData("say \"hello\" \\ world",
+        "\\\"", null)]
+    public void Serialize_ShouldEscapeCorrectly(
+        string input, string expected, string? forbidden)
+    {
+        var json = Serialize(input);
+        Assert.Contains(expected, json);
+        if (forbidden != null)
+        {
+            Assert.DoesNotContain(forbidden, json);
+        }
+    }
+
+    [Theory]
+    [InlineData("application/vnd.oci.image.manifest.v1+json")]
+    [InlineData("application/vnd.oci.empty.v1+json")]
+    [InlineData("with <html> & special + chars")]
+    [InlineData("line\u2028para\u2029end")]
+    public void RoundTrip_ShouldPreserveValue(string value)
+    {
+        var bytes = OciJsonSerializer.SerializeToUtf8Bytes(value);
+        var result = OciJsonSerializer.Deserialize<string>(bytes);
+        Assert.Equal(value, result);
+    }
+}


### PR DESCRIPTION
## Fix: `+` escaped as `\u002B` in JSON serialization

Fixes #346

### Problem

`System.Text.Json`'s default `JavaScriptEncoder` escapes `+` as `\u002B`. OCI media types like `application/vnd.oci.image.manifest.v1+json` become `...v1\u002Bjson`, producing different digests than oras-go and breaking CAS interoperability.

**Root cause:** `JavaScriptEncoder.Default` hardcodes `+` on its block list. `AllowCharacter('+')` doesn't work. `UnsafeRelaxedJsonEscaping` fixes `+` but stops escaping `<>&` — unsafe.

### Solution

Custom `JsonConverter` classes with `Utf8JsonWriter.WriteRawValue()` and a Go-compatible escape function matching `encoding/json.Marshal` semantics.

### Design

```
Call Sites
  Packer · ManifestStore · Repository · Registry
  FetchableExtensions · ResponseException · Error
        |
        v
  OciJsonSerializer (internal)
    SerializeToUtf8Bytes()  <- size guard (4 MiB)
    Deserialize(byte[])
    Deserialize(string)
    DeserializeAsync(Stream)
    FormatErrorDetail()
    EscapeJsonString()      <- Go compat escaping
        |
        | registers
    +---+---+
    v       v
  OciStringConverter    OciDictionaryConverter
  (string values)       (annotation dict keys+values)
                        (UTF-8 bytewise key sort)
```

**Why two converters?** `JsonConverter<string>` is NOT invoked for dictionary keys — only values. `OciDictionaryConverter` handles annotation dictionaries where both keys and values may contain `+`.

### Escaping Rules (Go `encoding/json.Marshal` compatible)

| Input | Output | Input | Output |
|-------|--------|-------|--------|
| `"` | `\"` | `\` | `\\` |
| `\b \f \n \r \t` | `\b \f \n \r \t` | `< > &` | `\u003c \u003e \u0026` |
| U+2028, U+2029 | `\u2028 \u2029` | 0x00–0x1F (other) | `\uXXXX` |
| **`+`** | **`+` (literal — the fix)** | all other | literal |

### Changes

**New files (all `internal`):**
- `Serialization/OciJsonSerializer.cs` — single entry point for all JSON ops
- `Serialization/OciStringConverter.cs` — string value converter
- `Serialization/OciDictionaryConverter.cs` — annotation dictionary converter (UTF-8 bytewise key sort for Go compatibility)
- `Content/OciLimits.cs` — shared `MaxManifestBytes` constant (4 MiB)

**Modified call sites:**
- `Packer.cs`, `ManifestStore.cs`, `Repository.cs`, `Registry.cs`, `FetchableExtensions.cs`, `ResponseException.cs`, `Error.cs` — all JSON through `OciJsonSerializer`
- `Index.cs` — `GenerateIndex()` now delegates to `OciJsonSerializer.SerializeToUtf8Bytes`
- `CopyGraphOptions.cs`, `RepositoryOptions.cs` — use shared `OciLimits.MaxManifestBytes`

**Tests (17 new test methods, 438 total passing):**
- `OciStringConverterTest.cs` — escape branch coverage + round-trip
- `OciDictionaryConverterTest.cs` — keys, values, empty, null, invalid types, round-trip, UTF-8 key sort order
- `ManifestSerializationTest.cs` — JSON fixture deserialization, annotation fidelity, index, round-trip, size limit
- `PackerTest.cs` — 2 regression tests checking raw bytes for literal `+`

### Key Design Decisions
- **Layered architecture**: All JSON serialization AND deserialization goes through `OciJsonSerializer`
- **Domain types clean**: `Index.GenerateIndex()` stays on `Index` but delegates to `OciJsonSerializer` for encoding
- **Internal only**: Zero public API surface added
- **Size guard**: 4 MiB limit on serialized output (matches oras-go)
- **Shared constant**: `OciLimits.MaxManifestBytes` replaces duplicate private consts
- **UTF-8 key sort**: `OciDictionaryConverter` sorts annotation keys by UTF-8 byte sequence (not UTF-16 ordinal) to match Go's `encoding/json.Marshal` behavior
