### PR TITLE
feat: add OCI Annotations constants

### DIFF
--- a/src/OrasProject.Oras/Oci/Annotations.cs
+++ b/src/OrasProject.Oras/Oci/Annotations.cs
@@ -1,0 +1,105 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace OrasProject.Oras.Oci;
+
+/// <summary>
+/// Standard OCI annotation keys.
+/// Specification: https://github.com/opencontainers/image-spec/blob/v1.1.1/annotations.md
+/// </summary>
+public static class Annotations
+{
+    /// <summary>
+    /// Created is the annotation key for the date and time on which the
+    /// image was built (date-time string as defined by RFC 3339).
+    /// </summary>
+    public const string Created = "org.opencontainers.image.created";
+
+    /// <summary>
+    /// Authors is the annotation key for the contact details of the
+    /// people or organization responsible for the image (freeform string).
+    /// </summary>
+    public const string Authors = "org.opencontainers.image.authors";
+
+    /// <summary>
+    /// Url is the annotation key for the URL to find more information
+    /// on the image.
+    /// </summary>
+    public const string Url = "org.opencontainers.image.url";
+
+    /// <summary>
+    /// Documentation is the annotation key for the URL to get
+    /// documentation on the image.
+    /// </summary>
+    public const string Documentation = "org.opencontainers.image.documentation";
+
+    /// <summary>
+    /// Source is the annotation key for the URL to get source code for
+    /// building the image.
+    /// </summary>
+    public const string Source = "org.opencontainers.image.source";
+
+    /// <summary>
+    /// Version is the annotation key for the version of the packaged
+    /// software.
+    /// </summary>
+    public const string Version = "org.opencontainers.image.version";
+
+    /// <summary>
+    /// Revision is the annotation key for the source control revision
+    /// identifier for the packaged software.
+    /// </summary>
+    public const string Revision = "org.opencontainers.image.revision";
+
+    /// <summary>
+    /// Vendor is the annotation key for the name of the distributing
+    /// entity, organization or individual.
+    /// </summary>
+    public const string Vendor = "org.opencontainers.image.vendor";
+
+    /// <summary>
+    /// Licenses is the annotation key for the license(s) under which
+    /// contained software is distributed as an SPDX License Expression.
+    /// </summary>
+    public const string Licenses = "org.opencontainers.image.licenses";
+
+    /// <summary>
+    /// RefName is the annotation key for the name of the reference
+    /// for a target.
+    /// </summary>
+    public const string RefName = "org.opencontainers.image.ref.name";
+
+    /// <summary>
+    /// Title is the annotation key for the human-readable title of
+    /// the image.
+    /// </summary>
+    public const string Title = "org.opencontainers.image.title";
+
+    /// <summary>
+    /// Description is the annotation key for the human-readable
+    /// description of the software packaged in the image.
+    /// </summary>
+    public const string Description = "org.opencontainers.image.description";
+
+    /// <summary>
+    /// BaseImageDigest is the annotation key for the digest of the
+    /// image's base image.
+    /// </summary>
+    public const string BaseImageDigest = "org.opencontainers.image.base.digest";
+
+    /// <summary>
+    /// BaseImageName is the annotation key for the image reference of
+    /// the image's base image.
+    /// </summary>
+    public const string BaseImageName = "org.opencontainers.image.base.name";
+}

--- a/tests/OrasProject.Oras.Tests/Oci/AnnotationsTest.cs
+++ b/tests/OrasProject.Oras.Tests/Oci/AnnotationsTest.cs
@@ -1,0 +1,67 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using OrasProject.Oras.Oci;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Oci;
+
+public class AnnotationsTest
+{
+    [Fact]
+    public void OciAnnotations_HasCorrectValues()
+    {
+        Assert.Equal(
+            "org.opencontainers.image.created",
+            Annotations.Created);
+        Assert.Equal(
+            "org.opencontainers.image.authors",
+            Annotations.Authors);
+        Assert.Equal(
+            "org.opencontainers.image.url",
+            Annotations.Url);
+        Assert.Equal(
+            "org.opencontainers.image.documentation",
+            Annotations.Documentation);
+        Assert.Equal(
+            "org.opencontainers.image.source",
+            Annotations.Source);
+        Assert.Equal(
+            "org.opencontainers.image.version",
+            Annotations.Version);
+        Assert.Equal(
+            "org.opencontainers.image.revision",
+            Annotations.Revision);
+        Assert.Equal(
+            "org.opencontainers.image.vendor",
+            Annotations.Vendor);
+        Assert.Equal(
+            "org.opencontainers.image.licenses",
+            Annotations.Licenses);
+        Assert.Equal(
+            "org.opencontainers.image.ref.name",
+            Annotations.RefName);
+        Assert.Equal(
+            "org.opencontainers.image.title",
+            Annotations.Title);
+        Assert.Equal(
+            "org.opencontainers.image.description",
+            Annotations.Description);
+        Assert.Equal(
+            "org.opencontainers.image.base.digest",
+            Annotations.BaseImageDigest);
+        Assert.Equal(
+            "org.opencontainers.image.base.name",
+            Annotations.BaseImageName);
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it

Adds standard OCI annotation key constants per the [OCI Image Spec v1.1.1 annotations](https://github.com/opencontainers/image-spec/blob/v1.1.1/annotations.md).

Includes a test file that validates all constant values.

### Which issue(s) this PR resolves / fixes

Part of the File Store implementation split (issue 1 of 10).
Related: #328, #37

### Please check the following list
- [x] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [x] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x] Do all new files have an appropriate license header?