### PR TITLE
feat: add FileStore annotation constants

### DIFF
--- a/src/OrasProject.Oras/Content/File/Annotations.cs
+++ b/src/OrasProject.Oras/Content/File/Annotations.cs
@@ -1,0 +1,34 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace OrasProject.Oras.Content.File;
+
+/// <summary>
+/// Annotation keys used by the FileStore.
+/// </summary>
+public static class FileStoreAnnotations
+{
+    /// <summary>
+    /// AnnotationDigest is the annotation key for the
+    /// digest of the uncompressed content.
+    /// </summary>
+    public const string AnnotationDigest =
+        "io.deis.oras.content.digest";
+
+    /// <summary>
+    /// AnnotationUnpack is the annotation key for
+    /// indication of unpacking.
+    /// </summary>
+    public const string AnnotationUnpack =
+        "io.deis.oras.content.unpack";
+}

--- a/tests/OrasProject.Oras.Tests/Content/File/AnnotationsTest.cs
+++ b/tests/OrasProject.Oras.Tests/Content/File/AnnotationsTest.cs
@@ -1,0 +1,31 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using OrasProject.Oras.Content.File;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Content.File;
+
+public class AnnotationsTest
+{
+    [Fact]
+    public void FileStoreAnnotations_HasCorrectValues()
+    {
+        Assert.Equal(
+            "io.deis.oras.content.digest",
+            FileStoreAnnotations.AnnotationDigest);
+        Assert.Equal(
+            "io.deis.oras.content.unpack",
+            FileStoreAnnotations.AnnotationUnpack);
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it

Adds FileStore-specific annotation key constants for digest and unpack indicators used by the File Store implementation.

- `FileStoreAnnotations.AnnotationDigest` — key for the digest of uncompressed content
- `FileStoreAnnotations.AnnotationUnpack` — key for indication of unpacking

Includes a test file that validates all constant values.

### Which issue(s) this PR resolves / fixes

Part of the File Store implementation split (issue 2 of 10).
Related: #328, #37

### Please check the following list
- [x] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [x] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x] Do all new files have an appropriate license header?