### PR TITLE
feat: add TarUtilities tar creation methods

### DIFF
--- a/src/OrasProject.Oras/Content/File/TarUtilities.cs
+++ b/src/OrasProject.Oras/Content/File/TarUtilities.cs
@@ -26,31 +26,23 @@ namespace OrasProject.Oras.Content.File;
 internal static class TarUtilities
 {
     /// <summary>
-    /// Creates a tar archive from a directory and writes it
-    /// to a stream.
+    /// Creates a tar archive from a directory and writes it to a stream.
     /// </summary>
-    /// <param name="sourceDirectory">
-    /// The source directory to archive.
-    /// </param>
-    /// <param name="prefix">
-    /// The prefix for entries in the tar archive.
-    /// </param>
+    /// <param name="sourceDirectory">The source directory to archive.</param>
+    /// <param name="prefix">The prefix for entries in the tar archive.</param>
     /// <param name="outputStream">
     /// The output stream to write the tar archive to.
     /// </param>
     /// <param name="reproducible">
     /// Whether to remove timestamps for reproducibility.
     /// </param>
-    /// <param name="cancellationToken">
-    /// Cancellation token.
-    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="prefix"/> is empty,
-    /// absolute, or contains traversal segments.
+    /// Thrown when <paramref name="prefix"/> is empty, absolute, or
+    /// contains traversal segments.
     /// </exception>
     /// <exception cref="DirectoryNotFoundException">
-    /// Thrown when <paramref name="sourceDirectory"/>
-    /// does not exist.
+    /// Thrown when <paramref name="sourceDirectory"/> does not exist.
     /// </exception>
     internal static async Task TarDirectoryAsync(
         string sourceDirectory,
@@ -66,48 +58,35 @@ internal static class TarUtilities
         if (!Directory.Exists(sourceDirectory))
         {
             throw new DirectoryNotFoundException(
-                $"Source directory not found:" +
-                $" '{sourceDirectory}'.");
+                $"Source directory not found: '{sourceDirectory}'.");
         }
 
-        using var tarWriter = new TarWriter(
-            outputStream, leaveOpen: true);
+        using var tarWriter = new TarWriter(outputStream, leaveOpen: true);
 
         // Add root directory entry
-        var rootEntry = CreateDirectoryEntry(
-            prefix, sourceDirectory, reproducible);
-        await tarWriter.WriteEntryAsync(
-            rootEntry, cancellationToken)
+        var rootEntry = CreateDirectoryEntry(prefix, sourceDirectory, reproducible);
+        await tarWriter.WriteEntryAsync(rootEntry, cancellationToken)
             .ConfigureAwait(false);
 
-        // Walk directory tree manually to avoid recursing
-        // into symlinked directories.
+        // Walk directory tree manually to avoid recursing into symlinked directories.
         await WalkDirectoryAsync(
-            tarWriter,
-            sourceDirectory,
-            prefix,
-            sourceDirectory,
-            reproducible,
-            cancellationToken).ConfigureAwait(false);
+            tarWriter, sourceDirectory, prefix, sourceDirectory,
+            reproducible, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Recursively walks a directory, emitting tar entries.
-    /// Symlinked directories are emitted as symlink entries
-    /// without recursion to prevent cycles and unintended
-    /// inclusion of files outside the source tree.
+    /// Recursively walks a directory, emitting tar entries. Symlinked directories
+    /// are emitted as symlink entries without recursion to prevent cycles and
+    /// unintended inclusion of files outside the source tree.
     /// </summary>
     /// <remarks>
-    /// This method uses recursion bounded by actual
-    /// filesystem depth. Symlinked directories are not
-    /// followed, so cycles cannot occur. For typical OCI
-    /// layer content the depth is well within safe stack
-    /// limits.
-    /// Symlink targets (both directory and file) are
-    /// preserved as-is from the filesystem, which may
-    /// include absolute paths. Callers or extractors
-    /// must validate link targets independently to
-    /// guard against symlink-based path traversal.
+    /// This method uses recursion bounded by actual filesystem depth. Symlinked
+    /// directories are not followed, so cycles cannot occur. For typical OCI layer
+    /// content the depth is well within safe stack limits.
+    /// Symlink targets (both directory and file) are preserved as-is from the
+    /// filesystem, which may include absolute paths. Callers or extractors must
+    /// validate link targets independently to guard against symlink-based path
+    /// traversal.
     /// </remarks>
     private static async Task WalkDirectoryAsync(
         TarWriter tarWriter,
@@ -117,31 +96,26 @@ internal static class TarUtilities
         bool reproducible,
         CancellationToken cancellationToken)
     {
-        // Collect subdirectories: materialize and sort
-        // when reproducible; stream lazily otherwise.
+        // Collect subdirectories: materialize and sort when reproducible;
+        // stream lazily otherwise.
         IEnumerable<string> subDirs;
         if (reproducible)
         {
-            var dirs =
-                Directory.GetDirectories(currentDir);
+            var dirs = Directory.GetDirectories(currentDir);
             Array.Sort(dirs, StringComparer.Ordinal);
             subDirs = dirs;
         }
         else
         {
-            subDirs =
-                Directory.EnumerateDirectories(
-                    currentDir);
+            subDirs = Directory.EnumerateDirectories(currentDir);
         }
 
         foreach (var dir in subDirs)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var relativePath = Path.GetRelativePath(
-                sourceDirectory, dir);
-            var entryName = prefix + "/"
-                + NormalizeSeparators(relativePath);
+            var relativePath = Path.GetRelativePath(sourceDirectory, dir);
+            var entryName = prefix + "/" + NormalizeSeparators(relativePath);
             if (!entryName.EndsWith('/'))
             {
                 entryName += '/';
@@ -152,71 +126,56 @@ internal static class TarUtilities
             {
                 // Emit symlink entry without recursing
                 var symEntryName = entryName.EndsWith('/')
-                    ? entryName[..^1]
-                    : entryName;
+                    ? entryName[..^1] : entryName;
 
                 var symEntry = new PaxTarEntry(
-                    TarEntryType.SymbolicLink,
-                    symEntryName)
+                    TarEntryType.SymbolicLink, symEntryName)
                 {
-                    LinkName = NormalizeSeparators(
-                        dirInfo.LinkTarget),
+                    LinkName = NormalizeSeparators(dirInfo.LinkTarget),
                     Uid = 0,
                     Gid = 0
                 };
 
                 if (reproducible)
                 {
-                    symEntry.ModificationTime =
-                        DateTimeOffset.UnixEpoch;
+                    symEntry.ModificationTime = DateTimeOffset.UnixEpoch;
                 }
 
-                await tarWriter.WriteEntryAsync(
-                    symEntry, cancellationToken)
+                await tarWriter.WriteEntryAsync(symEntry, cancellationToken)
                     .ConfigureAwait(false);
                 continue;
             }
 
-            var entry = CreateDirectoryEntry(
-                entryName, dir, reproducible);
-            await tarWriter.WriteEntryAsync(
-                entry, cancellationToken)
+            var entry = CreateDirectoryEntry(entryName, dir, reproducible);
+            await tarWriter.WriteEntryAsync(entry, cancellationToken)
                 .ConfigureAwait(false);
 
             // Recurse into real (non-symlink) directories
             await WalkDirectoryAsync(
-                tarWriter,
-                sourceDirectory,
-                prefix,
-                dir,
-                reproducible,
-                cancellationToken).ConfigureAwait(false);
+                tarWriter, sourceDirectory, prefix, dir,
+                reproducible, cancellationToken).ConfigureAwait(false);
         }
 
-        // Collect files: materialize and sort when
-        // reproducible; stream lazily otherwise.
+        // Collect files: materialize and sort when reproducible;
+        // stream lazily otherwise.
         IEnumerable<string> localFiles;
         if (reproducible)
         {
-            var files =
-                Directory.GetFiles(currentDir);
+            var files = Directory.GetFiles(currentDir);
             Array.Sort(files, StringComparer.Ordinal);
             localFiles = files;
         }
         else
         {
-            localFiles =
-                Directory.EnumerateFiles(currentDir);
+            localFiles = Directory.EnumerateFiles(currentDir);
         }
 
         foreach (var file in localFiles)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var relativePath = Path.GetRelativePath(
-                sourceDirectory, file);
-            var entryName = prefix + "/"
-                + NormalizeSeparators(relativePath);
+            var relativePath = Path.GetRelativePath(sourceDirectory, file);
+            var entryName = prefix + "/" + NormalizeSeparators(relativePath);
 
             var fileInfo = new FileInfo(file);
 
@@ -225,32 +184,26 @@ internal static class TarUtilities
                 var symEntry = new PaxTarEntry(
                     TarEntryType.SymbolicLink, entryName)
                 {
-                    LinkName = NormalizeSeparators(
-                        fileInfo.LinkTarget),
+                    LinkName = NormalizeSeparators(fileInfo.LinkTarget),
                     Uid = 0,
                     Gid = 0
                 };
 
                 if (reproducible)
                 {
-                    symEntry.ModificationTime =
-                        DateTimeOffset.UnixEpoch;
+                    symEntry.ModificationTime = DateTimeOffset.UnixEpoch;
                 }
 
-                await tarWriter.WriteEntryAsync(
-                    symEntry, cancellationToken)
+                await tarWriter.WriteEntryAsync(symEntry, cancellationToken)
                     .ConfigureAwait(false);
             }
             else
             {
-                var dataStream =
-                    System.IO.File.OpenRead(file);
-                await using (
-                    dataStream.ConfigureAwait(false))
+                var dataStream = System.IO.File.OpenRead(file);
+                await using (dataStream.ConfigureAwait(false))
                 {
                     var fileEntry = new PaxTarEntry(
-                        TarEntryType.RegularFile,
-                        entryName)
+                        TarEntryType.RegularFile, entryName)
                     {
                         DataStream = dataStream,
                         Uid = 0,
@@ -260,12 +213,10 @@ internal static class TarUtilities
 
                     if (reproducible)
                     {
-                        fileEntry.ModificationTime =
-                            DateTimeOffset.UnixEpoch;
+                        fileEntry.ModificationTime = DateTimeOffset.UnixEpoch;
                     }
 
-                    await tarWriter.WriteEntryAsync(
-                        fileEntry, cancellationToken)
+                    await tarWriter.WriteEntryAsync(fileEntry, cancellationToken)
                         .ConfigureAwait(false);
                 }
             }
@@ -273,31 +224,26 @@ internal static class TarUtilities
     }
 
     /// <summary>
-    /// Normalizes OS-specific directory separators to
-    /// forward slashes for tar entry paths. On Unix this
-    /// is a no-op, preserving literal backslashes in
+    /// Normalizes OS-specific directory separators to forward slashes for tar
+    /// entry paths. On Unix this is a no-op, preserving literal backslashes in
     /// filenames.
     /// </summary>
-    private static string NormalizeSeparators(
-        string path)
+    private static string NormalizeSeparators(string path)
     {
         return Path.DirectorySeparatorChar != '/'
-            ? path.Replace(
-                Path.DirectorySeparatorChar, '/')
+            ? path.Replace(Path.DirectorySeparatorChar, '/')
             : path;
     }
 
     /// <summary>
-    /// Validates that a prefix contains no traversal, empty,
-    /// or dot-only segments.
+    /// Validates that a prefix contains no traversal, empty, or dot-only segments.
     /// </summary>
     private static void ValidatePrefix(string prefix)
     {
         if (string.IsNullOrEmpty(prefix))
         {
             throw new ArgumentException(
-                "Prefix must not be empty.",
-                nameof(prefix));
+                "Prefix must not be empty.", nameof(prefix));
         }
 
         var segments = prefix.Split('/');
@@ -306,8 +252,7 @@ internal static class TarUtilities
             if (segment is "" or "." or "..")
             {
                 throw new ArgumentException(
-                    "Prefix must be a relative path" +
-                    " without traversal segments.",
+                    "Prefix must be a relative path without traversal segments.",
                     nameof(prefix));
             }
         }
@@ -316,12 +261,8 @@ internal static class TarUtilities
     /// <summary>
     /// Creates a <see cref="PaxTarEntry"/> for a directory.
     /// </summary>
-    /// <param name="entryName">
-    /// The name of the tar entry.
-    /// </param>
-    /// <param name="directoryPath">
-    /// The path of the directory on disk.
-    /// </param>
+    /// <param name="entryName">The name of the tar entry.</param>
+    /// <param name="directoryPath">The path of the directory on disk.</param>
     /// <param name="reproducible">
     /// Whether to use epoch timestamp for reproducibility.
     /// </param>
@@ -329,9 +270,7 @@ internal static class TarUtilities
     /// A <see cref="PaxTarEntry"/> representing the directory.
     /// </returns>
     internal static PaxTarEntry CreateDirectoryEntry(
-        string entryName,
-        string directoryPath,
-        bool reproducible)
+        string entryName, string directoryPath, bool reproducible)
     {
         if (!entryName.EndsWith('/'))
         {
@@ -339,8 +278,7 @@ internal static class TarUtilities
         }
 
         var dirInfo = new DirectoryInfo(directoryPath);
-        var entry = new PaxTarEntry(
-            TarEntryType.Directory, entryName)
+        var entry = new PaxTarEntry(TarEntryType.Directory, entryName)
         {
             Uid = 0,
             Gid = 0,
@@ -356,39 +294,28 @@ internal static class TarUtilities
     }
 
     /// <summary>
-    /// Returns a hardcoded portable Unix file mode for a
-    /// file system entry: rwxr-xr-x (755) for directories,
-    /// rw-r--r-- (644) for files.
+    /// Returns a hardcoded portable Unix file mode for a file system entry:
+    /// rwxr-xr-x (755) for directories, rw-r--r-- (644) for files.
     /// </summary>
     /// <remarks>
-    /// This method does not read actual filesystem
-    /// permissions. It returns fixed modes suitable for
-    /// cross-platform tar archives. The
-    /// <paramref name="info"/> parameter is used only to
-    /// distinguish directories from files via type check.
+    /// This method does not read actual filesystem permissions. It returns fixed
+    /// modes suitable for cross-platform tar archives. The
+    /// <paramref name="info"/> parameter is used only to distinguish directories
+    /// from files via type check.
     /// </remarks>
-    /// <param name="info">
-    /// The file system info to determine the mode for.
-    /// </param>
-    /// <returns>The appropriate <see cref="UnixFileMode"/>.
-    /// </returns>
-    internal static UnixFileMode GetUnixFileMode(
-        FileSystemInfo info)
+    /// <param name="info">The file system info to determine the mode for.</param>
+    /// <returns>The appropriate <see cref="UnixFileMode"/>.</returns>
+    internal static UnixFileMode GetUnixFileMode(FileSystemInfo info)
     {
         if (info is DirectoryInfo)
         {
-            return UnixFileMode.UserRead
-                | UnixFileMode.UserWrite
-                | UnixFileMode.UserExecute
-                | UnixFileMode.GroupRead
-                | UnixFileMode.GroupExecute
-                | UnixFileMode.OtherRead
+            return UnixFileMode.UserRead | UnixFileMode.UserWrite
+                | UnixFileMode.UserExecute | UnixFileMode.GroupRead
+                | UnixFileMode.GroupExecute | UnixFileMode.OtherRead
                 | UnixFileMode.OtherExecute;
         }
 
-        return UnixFileMode.UserRead
-            | UnixFileMode.UserWrite
-            | UnixFileMode.GroupRead
-            | UnixFileMode.OtherRead;
+        return UnixFileMode.UserRead | UnixFileMode.UserWrite
+            | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
     }
 }

--- a/src/OrasProject.Oras/Content/File/TarUtilities.cs
+++ b/src/OrasProject.Oras/Content/File/TarUtilities.cs
@@ -1,0 +1,367 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Formats.Tar;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Content.File;
+
+/// <summary>
+/// Utilities for creating tar archives from directories.
+/// </summary>
+internal static class TarUtilities
+{
+    /// <summary>
+    /// Creates a tar archive from a directory and writes it
+    /// to a stream.
+    /// </summary>
+    /// <param name="sourceDirectory">
+    /// The source directory to archive.
+    /// </param>
+    /// <param name="prefix">
+    /// The prefix for entries in the tar archive.
+    /// </param>
+    /// <param name="outputStream">
+    /// The output stream to write the tar archive to.
+    /// </param>
+    /// <param name="reproducible">
+    /// Whether to remove timestamps for reproducibility.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancellation token.
+    /// </param>
+    internal static async Task TarDirectoryAsync(
+        string sourceDirectory,
+        string prefix,
+        Stream outputStream,
+        bool reproducible,
+        CancellationToken cancellationToken = default)
+    {
+        // Normalize and validate prefix
+        prefix = prefix.Replace('\\', '/').TrimEnd('/');
+        ValidatePrefix(prefix);
+
+        if (!Directory.Exists(sourceDirectory))
+        {
+            throw new DirectoryNotFoundException(
+                $"Source directory not found:" +
+                $" '{sourceDirectory}'.");
+        }
+
+        using var tarWriter = new TarWriter(
+            outputStream, leaveOpen: true);
+
+        // Add root directory entry
+        var rootEntry = CreateDirectoryEntry(
+            prefix, sourceDirectory, reproducible);
+        await tarWriter.WriteEntryAsync(
+            rootEntry, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Walk directory tree manually to avoid recursing
+        // into symlinked directories.
+        await WalkDirectoryAsync(
+            tarWriter,
+            sourceDirectory,
+            prefix,
+            sourceDirectory,
+            reproducible,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Recursively walks a directory, emitting tar entries.
+    /// Symlinked directories are emitted as symlink entries
+    /// without recursion to prevent cycles and unintended
+    /// inclusion of files outside the source tree.
+    /// </summary>
+    private static async Task WalkDirectoryAsync(
+        TarWriter tarWriter,
+        string sourceDirectory,
+        string prefix,
+        string currentDir,
+        bool reproducible,
+        CancellationToken cancellationToken)
+    {
+        // Collect subdirectories: materialize and sort
+        // when reproducible; stream lazily otherwise.
+        IEnumerable<string> subDirs;
+        if (reproducible)
+        {
+            var dirs =
+                Directory.GetDirectories(currentDir);
+            Array.Sort(dirs, StringComparer.Ordinal);
+            subDirs = dirs;
+        }
+        else
+        {
+            subDirs =
+                Directory.EnumerateDirectories(
+                    currentDir);
+        }
+
+        foreach (var dir in subDirs)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var relativePath = Path.GetRelativePath(
+                sourceDirectory, dir);
+            var entryName = prefix + "/"
+                + NormalizeSeparators(relativePath);
+            if (!entryName.EndsWith('/'))
+            {
+                entryName += '/';
+            }
+
+            var dirInfo = new DirectoryInfo(dir);
+            if (dirInfo.LinkTarget != null)
+            {
+                // Emit symlink entry without recursing
+                var symEntryName = entryName.EndsWith('/')
+                    ? entryName[..^1]
+                    : entryName;
+
+                var symEntry = new PaxTarEntry(
+                    TarEntryType.SymbolicLink,
+                    symEntryName)
+                {
+                    LinkName = NormalizeSeparators(
+                        dirInfo.LinkTarget),
+                    Uid = 0,
+                    Gid = 0
+                };
+
+                if (reproducible)
+                {
+                    symEntry.ModificationTime =
+                        DateTimeOffset.UnixEpoch;
+                }
+
+                await tarWriter.WriteEntryAsync(
+                    symEntry, cancellationToken)
+                    .ConfigureAwait(false);
+                continue;
+            }
+
+            var entry = CreateDirectoryEntry(
+                entryName, dir, reproducible);
+            await tarWriter.WriteEntryAsync(
+                entry, cancellationToken)
+                .ConfigureAwait(false);
+
+            // Recurse into real (non-symlink) directories
+            await WalkDirectoryAsync(
+                tarWriter,
+                sourceDirectory,
+                prefix,
+                dir,
+                reproducible,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        // Collect files: materialize and sort when
+        // reproducible; stream lazily otherwise.
+        IEnumerable<string> localFiles;
+        if (reproducible)
+        {
+            var files =
+                Directory.GetFiles(currentDir);
+            Array.Sort(files, StringComparer.Ordinal);
+            localFiles = files;
+        }
+        else
+        {
+            localFiles =
+                Directory.EnumerateFiles(currentDir);
+        }
+
+        foreach (var file in localFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var relativePath = Path.GetRelativePath(
+                sourceDirectory, file);
+            var entryName = prefix + "/"
+                + NormalizeSeparators(relativePath);
+
+            var fileInfo = new FileInfo(file);
+
+            if (fileInfo.LinkTarget != null)
+            {
+                var symEntry = new PaxTarEntry(
+                    TarEntryType.SymbolicLink, entryName)
+                {
+                    LinkName = NormalizeSeparators(
+                        fileInfo.LinkTarget),
+                    Uid = 0,
+                    Gid = 0
+                };
+
+                if (reproducible)
+                {
+                    symEntry.ModificationTime =
+                        DateTimeOffset.UnixEpoch;
+                }
+
+                await tarWriter.WriteEntryAsync(
+                    symEntry, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                var dataStream =
+                    System.IO.File.OpenRead(file);
+                await using (
+                    dataStream.ConfigureAwait(false))
+                {
+                    var fileEntry = new PaxTarEntry(
+                        TarEntryType.RegularFile,
+                        entryName)
+                    {
+                        DataStream = dataStream,
+                        Uid = 0,
+                        Gid = 0,
+                        Mode = GetUnixFileMode(fileInfo)
+                    };
+
+                    if (reproducible)
+                    {
+                        fileEntry.ModificationTime =
+                            DateTimeOffset.UnixEpoch;
+                    }
+
+                    await tarWriter.WriteEntryAsync(
+                        fileEntry, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Normalizes OS-specific directory separators to
+    /// forward slashes for tar entry paths. On Unix this
+    /// is a no-op, preserving literal backslashes in
+    /// filenames.
+    /// </summary>
+    private static string NormalizeSeparators(
+        string path)
+    {
+        return Path.DirectorySeparatorChar != '/'
+            ? path.Replace(
+                Path.DirectorySeparatorChar, '/')
+            : path;
+    }
+
+    /// <summary>
+    /// Validates that a prefix contains no traversal, empty,
+    /// or dot-only segments.
+    /// </summary>
+    private static void ValidatePrefix(string prefix)
+    {
+        if (string.IsNullOrEmpty(prefix))
+        {
+            throw new ArgumentException(
+                "Prefix must not be empty.",
+                nameof(prefix));
+        }
+
+        var segments = prefix.Split('/');
+        foreach (var segment in segments)
+        {
+            if (segment is "" or "." or "..")
+            {
+                throw new ArgumentException(
+                    "Prefix must be a relative path" +
+                    " without traversal segments.",
+                    nameof(prefix));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a <see cref="PaxTarEntry"/> for a directory.
+    /// </summary>
+    /// <param name="entryName">
+    /// The name of the tar entry.
+    /// </param>
+    /// <param name="directoryPath">
+    /// The path of the directory on disk.
+    /// </param>
+    /// <param name="reproducible">
+    /// Whether to use epoch timestamp for reproducibility.
+    /// </param>
+    /// <returns>
+    /// A <see cref="PaxTarEntry"/> representing the directory.
+    /// </returns>
+    internal static PaxTarEntry CreateDirectoryEntry(
+        string entryName,
+        string directoryPath,
+        bool reproducible)
+    {
+        if (!entryName.EndsWith('/'))
+        {
+            entryName += '/';
+        }
+
+        var dirInfo = new DirectoryInfo(directoryPath);
+        var entry = new PaxTarEntry(
+            TarEntryType.Directory, entryName)
+        {
+            Uid = 0,
+            Gid = 0,
+            Mode = GetUnixFileMode(dirInfo)
+        };
+
+        if (reproducible)
+        {
+            entry.ModificationTime = DateTimeOffset.UnixEpoch;
+        }
+
+        return entry;
+    }
+
+    /// <summary>
+    /// Returns the default Unix file mode for a file system
+    /// entry: rwxr-xr-x (755) for directories, rw-r--r--
+    /// (644) for files.
+    /// </summary>
+    /// <param name="info">
+    /// The file system info to determine the mode for.
+    /// </param>
+    /// <returns>The appropriate <see cref="UnixFileMode"/>.
+    /// </returns>
+    internal static UnixFileMode GetUnixFileMode(
+        FileSystemInfo info)
+    {
+        if (info is DirectoryInfo)
+        {
+            return UnixFileMode.UserRead
+                | UnixFileMode.UserWrite
+                | UnixFileMode.UserExecute
+                | UnixFileMode.GroupRead
+                | UnixFileMode.GroupExecute
+                | UnixFileMode.OtherRead
+                | UnixFileMode.OtherExecute;
+        }
+
+        return UnixFileMode.UserRead
+            | UnixFileMode.UserWrite
+            | UnixFileMode.GroupRead
+            | UnixFileMode.OtherRead;
+    }
+}

--- a/src/OrasProject.Oras/Content/File/TarUtilities.cs
+++ b/src/OrasProject.Oras/Content/File/TarUtilities.cs
@@ -236,7 +236,21 @@ internal static class TarUtilities
     }
 
     /// <summary>
-    /// Validates that a prefix contains no traversal, empty, or dot-only segments.
+    /// Returns true if the path starts with a Windows-style drive prefix
+    /// (e.g. "C:" or "C:/"). This check is needed because
+    /// <see cref="Path.IsPathRooted"/> does not recognise drive letters on
+    /// non-Windows platforms.
+    /// </summary>
+    private static bool HasDrivePrefix(string path)
+    {
+        return path.Length >= 2
+            && char.IsAsciiLetter(path[0])
+            && path[1] == ':';
+    }
+
+    /// <summary>
+    /// Validates that a prefix is a relative, non-rooted path with no traversal,
+    /// empty, or dot-only segments.
     /// </summary>
     private static void ValidatePrefix(string prefix)
     {
@@ -244,6 +258,12 @@ internal static class TarUtilities
         {
             throw new ArgumentException(
                 "Prefix must not be empty.", nameof(prefix));
+        }
+
+        if (Path.IsPathRooted(prefix) || HasDrivePrefix(prefix))
+        {
+            throw new ArgumentException(
+                "Prefix must be a relative path.", nameof(prefix));
         }
 
         var segments = prefix.Split('/');

--- a/src/OrasProject.Oras/Content/File/TarUtilities.cs
+++ b/src/OrasProject.Oras/Content/File/TarUtilities.cs
@@ -44,6 +44,14 @@ internal static class TarUtilities
     /// <param name="cancellationToken">
     /// Cancellation token.
     /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="prefix"/> is empty,
+    /// absolute, or contains traversal segments.
+    /// </exception>
+    /// <exception cref="DirectoryNotFoundException">
+    /// Thrown when <paramref name="sourceDirectory"/>
+    /// does not exist.
+    /// </exception>
     internal static async Task TarDirectoryAsync(
         string sourceDirectory,
         string prefix,
@@ -89,6 +97,18 @@ internal static class TarUtilities
     /// without recursion to prevent cycles and unintended
     /// inclusion of files outside the source tree.
     /// </summary>
+    /// <remarks>
+    /// This method uses recursion bounded by actual
+    /// filesystem depth. Symlinked directories are not
+    /// followed, so cycles cannot occur. For typical OCI
+    /// layer content the depth is well within safe stack
+    /// limits.
+    /// Symlink targets (both directory and file) are
+    /// preserved as-is from the filesystem, which may
+    /// include absolute paths. Callers or extractors
+    /// must validate link targets independently to
+    /// guard against symlink-based path traversal.
+    /// </remarks>
     private static async Task WalkDirectoryAsync(
         TarWriter tarWriter,
         string sourceDirectory,
@@ -336,10 +356,17 @@ internal static class TarUtilities
     }
 
     /// <summary>
-    /// Returns the default Unix file mode for a file system
-    /// entry: rwxr-xr-x (755) for directories, rw-r--r--
-    /// (644) for files.
+    /// Returns a hardcoded portable Unix file mode for a
+    /// file system entry: rwxr-xr-x (755) for directories,
+    /// rw-r--r-- (644) for files.
     /// </summary>
+    /// <remarks>
+    /// This method does not read actual filesystem
+    /// permissions. It returns fixed modes suitable for
+    /// cross-platform tar archives. The
+    /// <paramref name="info"/> parameter is used only to
+    /// distinguish directories from files via type check.
+    /// </remarks>
     /// <param name="info">
     /// The file system info to determine the mode for.
     /// </param>

--- a/tests/OrasProject.Oras.Tests/Content/File/TarUtilitiesTest.cs
+++ b/tests/OrasProject.Oras.Tests/Content/File/TarUtilitiesTest.cs
@@ -209,6 +209,8 @@ public class TarUtilitiesTest : IDisposable
     [Theory]
     [InlineData("")]
     [InlineData("/absolute")]
+    [InlineData("C:/abs")]
+    [InlineData("C:\\abs")]
     [InlineData("../escape")]
     [InlineData("a/..")]
     [InlineData("a/../b")]

--- a/tests/OrasProject.Oras.Tests/Content/File/TarUtilitiesTest.cs
+++ b/tests/OrasProject.Oras.Tests/Content/File/TarUtilitiesTest.cs
@@ -1,0 +1,571 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Formats.Tar;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using OrasProject.Oras.Content.File;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Content.File;
+
+public class TarUtilitiesTest : IDisposable
+{
+    private readonly string _tempDir;
+
+    public TarUtilitiesTest()
+    {
+        _tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"oras-tar-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_BasicFiles()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(srcDir, "file1.txt"), "hello");
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(srcDir, "file2.txt"), "world");
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "myprefix", output,
+            reproducible: false);
+        output.Position = 0;
+
+        // Assert
+        var entries = await ReadAllTarEntriesAsync(output);
+        Assert.Contains(entries,
+            e => e.Name == "myprefix/"
+                && e.EntryType == TarEntryType.Directory);
+        Assert.Contains(entries,
+            e => e.Name == "myprefix/file1.txt"
+                && e.EntryType == TarEntryType.RegularFile);
+        Assert.Contains(entries,
+            e => e.Name == "myprefix/file2.txt"
+                && e.EntryType == TarEntryType.RegularFile);
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_WithSubdirectories()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "src");
+        var subDir = Path.Combine(srcDir, "sub");
+        Directory.CreateDirectory(subDir);
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(srcDir, "root.txt"), "root");
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(subDir, "nested.txt"), "nested");
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "pkg", output, reproducible: false);
+        output.Position = 0;
+
+        // Assert
+        var entries = await ReadAllTarEntriesAsync(output);
+        Assert.Contains(entries,
+            e => e.Name == "pkg/"
+                && e.EntryType == TarEntryType.Directory);
+        Assert.Contains(entries,
+            e => e.Name == "pkg/sub/"
+                && e.EntryType == TarEntryType.Directory);
+        Assert.Contains(entries,
+            e => e.Name == "pkg/root.txt"
+                && e.EntryType == TarEntryType.RegularFile);
+        Assert.Contains(entries,
+            e => e.Name == "pkg/sub/nested.txt"
+                && e.EntryType == TarEntryType.RegularFile);
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_Reproducible_SetsEpoch()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(srcDir, "data.txt"), "content");
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "prefix", output,
+            reproducible: true);
+        output.Position = 0;
+
+        // Assert — all entries should have Unix epoch
+        var entries = await ReadAllTarEntriesAsync(output);
+        Assert.All(entries, e =>
+            Assert.Equal(
+                DateTimeOffset.UnixEpoch,
+                e.ModificationTime));
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_NonReproducible_HasRecentTime()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(srcDir, "data.txt"), "content");
+
+        // Act
+        var beforeTar = DateTimeOffset.UtcNow;
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "prefix", output,
+            reproducible: false);
+        var afterTar = DateTimeOffset.UtcNow;
+        output.Position = 0;
+
+        // Assert — entries should have a recent time
+        var entries = await ReadAllTarEntriesAsync(output);
+        var earliest = beforeTar.AddMinutes(-5);
+        var latest = afterTar.AddMinutes(5);
+        Assert.All(entries, e =>
+            Assert.InRange(
+                e.ModificationTime,
+                earliest,
+                latest));
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_EmptyDirectory()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "empty");
+        Directory.CreateDirectory(srcDir);
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "root", output,
+            reproducible: true);
+        output.Position = 0;
+
+        // Assert — only root directory entry
+        var entries = await ReadAllTarEntriesAsync(output);
+        Assert.Single(entries);
+        Assert.Equal("root/", entries[0].Name);
+        Assert.Equal(
+            TarEntryType.Directory, entries[0].EntryType);
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_FileContent_IsPreserved()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        var expected = "hello, tar!";
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(srcDir, "test.txt"), expected);
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "p", output, reproducible: false);
+        output.Position = 0;
+
+        // Assert
+        using var reader = new TarReader(output);
+        TarEntry? entry;
+        while ((entry = await reader.GetNextEntryAsync()) !=
+            null)
+        {
+            if (entry.Name == "p/test.txt"
+                && entry.DataStream != null)
+            {
+                using var sr = new StreamReader(
+                    entry.DataStream);
+                var actual = await sr.ReadToEndAsync();
+                Assert.Equal(expected, actual);
+                return;
+            }
+        }
+        Assert.Fail("Expected entry p/test.txt not found");
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_SetsUidGidToZero()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(srcDir, "f.txt"), "x");
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "test", output,
+            reproducible: false);
+        output.Position = 0;
+
+        // Assert — all entries should have uid=0, gid=0
+        var entries = await ReadAllTarEntriesAsync(output);
+        Assert.All(entries, e =>
+        {
+            var pax = Assert.IsType<PaxTarEntry>(e);
+            Assert.Equal(0, pax.Uid);
+            Assert.Equal(0, pax.Gid);
+        });
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_Reproducible_DeterministicOrder()
+    {
+        // Arrange — create files in non-alphabetical order
+        var srcDir = Path.Combine(_tempDir, "src");
+        var subB = Path.Combine(srcDir, "beta");
+        var subA = Path.Combine(srcDir, "alpha");
+        Directory.CreateDirectory(subB);
+        Directory.CreateDirectory(subA);
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(srcDir, "z.txt"), "z");
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(srcDir, "a.txt"), "a");
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(subA, "inner.txt"), "i");
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "pkg", output,
+            reproducible: true);
+        output.Position = 0;
+
+        // Assert — entries are in deterministic order
+        var entries = await ReadAllTarEntriesAsync(output);
+        var names = entries.Select(e => e.Name).ToList();
+
+        // Depth-first walk: root → sorted subdirs
+        // (recursing into each) → sorted files.
+        Assert.Equal(
+            new List<string>
+            {
+                "pkg/",
+                "pkg/alpha/",
+                "pkg/alpha/inner.txt",
+                "pkg/beta/",
+                "pkg/a.txt",
+                "pkg/z.txt"
+            },
+            names);
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_PrefixWithoutSlash()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        // Act — prefix without trailing slash
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "notrail", output,
+            reproducible: true);
+        output.Position = 0;
+
+        // Assert — root entry should still end with /
+        var entries = await ReadAllTarEntriesAsync(output);
+        Assert.Contains(entries,
+            e => e.Name == "notrail/"
+                && e.EntryType == TarEntryType.Directory);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("/absolute")]
+    [InlineData("../escape")]
+    [InlineData("a/..")]
+    [InlineData("a/../b")]
+    [InlineData("a/./b")]
+    [InlineData("a//b")]
+    public async Task TarDirectoryAsync_InvalidPrefix_Throws(
+        string prefix)
+    {
+        var srcDir = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        using var output = new MemoryStream();
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => TarUtilities.TarDirectoryAsync(
+                srcDir, prefix, output,
+                reproducible: false));
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_MissingSource_Throws()
+    {
+        var missing = Path.Combine(
+            _tempDir, "does-not-exist");
+
+        using var output = new MemoryStream();
+        await Assert.ThrowsAsync<
+            DirectoryNotFoundException>(
+            () => TarUtilities.TarDirectoryAsync(
+                missing, "pkg", output,
+                reproducible: false));
+
+        // Stream should be empty — no partial archive
+        Assert.Equal(0, output.Length);
+    }
+
+    [Fact]
+    public void CreateDirectoryEntry_AppendsSlash()
+    {
+        // Arrange
+        var dir = Path.Combine(_tempDir, "testdir");
+        Directory.CreateDirectory(dir);
+
+        // Act
+        var entry = TarUtilities.CreateDirectoryEntry(
+            "mydir", dir, reproducible: false);
+
+        // Assert
+        Assert.Equal("mydir/", entry.Name);
+        Assert.Equal(TarEntryType.Directory, entry.EntryType);
+    }
+
+    [Fact]
+    public void CreateDirectoryEntry_PreservesTrailingSlash()
+    {
+        // Arrange
+        var dir = Path.Combine(_tempDir, "testdir");
+        Directory.CreateDirectory(dir);
+
+        // Act
+        var entry = TarUtilities.CreateDirectoryEntry(
+            "mydir/", dir, reproducible: false);
+
+        // Assert
+        Assert.Equal("mydir/", entry.Name);
+    }
+
+    [Fact]
+    public void CreateDirectoryEntry_Reproducible_SetsEpoch()
+    {
+        // Arrange
+        var dir = Path.Combine(_tempDir, "testdir");
+        Directory.CreateDirectory(dir);
+
+        // Act
+        var entry = TarUtilities.CreateDirectoryEntry(
+            "mydir", dir, reproducible: true);
+
+        // Assert
+        Assert.Equal(
+            DateTimeOffset.UnixEpoch,
+            entry.ModificationTime);
+        Assert.Equal(0, entry.Uid);
+        Assert.Equal(0, entry.Gid);
+    }
+
+    [Fact]
+    public void GetUnixFileMode_Directory_Returns755()
+    {
+        // Arrange
+        var dir = Path.Combine(_tempDir, "testdir");
+        Directory.CreateDirectory(dir);
+        var dirInfo = new DirectoryInfo(dir);
+
+        // Act
+        var mode = TarUtilities.GetUnixFileMode(dirInfo);
+
+        // Assert — rwxr-xr-x = 755
+        var expected = UnixFileMode.UserRead
+            | UnixFileMode.UserWrite
+            | UnixFileMode.UserExecute
+            | UnixFileMode.GroupRead
+            | UnixFileMode.GroupExecute
+            | UnixFileMode.OtherRead
+            | UnixFileMode.OtherExecute;
+        Assert.Equal(expected, mode);
+    }
+
+    [Fact]
+    public void GetUnixFileMode_File_Returns644()
+    {
+        // Arrange
+        var filePath = Path.Combine(_tempDir, "test.txt");
+        System.IO.File.WriteAllText(filePath, "data");
+        var fileInfo = new FileInfo(filePath);
+
+        // Act
+        var mode = TarUtilities.GetUnixFileMode(fileInfo);
+
+        // Assert — rw-r--r-- = 644
+        var expected = UnixFileMode.UserRead
+            | UnixFileMode.UserWrite
+            | UnixFileMode.GroupRead
+            | UnixFileMode.OtherRead;
+        Assert.Equal(expected, mode);
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_Symlink_EmitsEntry()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        var targetFile = Path.Combine(srcDir, "real.txt");
+        await System.IO.File.WriteAllTextAsync(
+            targetFile, "data");
+        var linkPath = Path.Combine(srcDir, "link.txt");
+        try
+        {
+            System.IO.File.CreateSymbolicLink(
+                linkPath, "real.txt");
+        }
+        catch (Exception ex)
+            when (ex is UnauthorizedAccessException
+                or PlatformNotSupportedException
+                or IOException)
+        {
+            throw Xunit.Sdk.SkipException.ForSkip(
+                "Symlinks not supported on this" +
+                $" platform: {ex.Message}");
+        }
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "sym", output,
+            reproducible: true);
+        output.Position = 0;
+
+        // Assert
+        var entries = await ReadAllTarEntriesAsync(output);
+        var symEntry = Assert.Single(entries,
+            e => e.EntryType == TarEntryType.SymbolicLink);
+        Assert.Equal("sym/link.txt", symEntry.Name);
+        Assert.Equal("real.txt", symEntry.LinkName);
+        var pax = Assert.IsType<PaxTarEntry>(symEntry);
+        Assert.Equal(0, pax.Uid);
+        Assert.Equal(0, pax.Gid);
+        Assert.Equal(
+            DateTimeOffset.UnixEpoch,
+            pax.ModificationTime);
+    }
+
+    [Fact]
+    public async Task
+        TarDirectoryAsync_DirSymlink_EmitsEntryNoRecurse()
+    {
+        // Arrange — create a real subdirectory with a file,
+        // then create a directory symlink pointing to it.
+        var srcDir = Path.Combine(_tempDir, "src");
+        var realDir = Path.Combine(srcDir, "real");
+        Directory.CreateDirectory(realDir);
+        await System.IO.File.WriteAllTextAsync(
+            Path.Combine(realDir, "inner.txt"), "data");
+        var linkDir = Path.Combine(srcDir, "linked");
+        try
+        {
+            Directory.CreateSymbolicLink(
+                linkDir, realDir);
+        }
+        catch (Exception ex)
+            when (ex is UnauthorizedAccessException
+                or PlatformNotSupportedException
+                or IOException)
+        {
+            throw Xunit.Sdk.SkipException.ForSkip(
+                "Symlinks not supported on this" +
+                $" platform: {ex.Message}");
+        }
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(
+            srcDir, "ds", output,
+            reproducible: true);
+        output.Position = 0;
+
+        // Assert
+        var entries = await ReadAllTarEntriesAsync(output);
+        var names = entries
+            .Select(e => e.Name).ToList();
+
+        // The directory symlink should be emitted as a
+        // SymbolicLink entry (not a Directory entry), and
+        // no files from inside the target should appear.
+        var symEntry = Assert.Single(entries,
+            e => e.EntryType
+                == TarEntryType.SymbolicLink);
+        Assert.Equal("ds/linked", symEntry.Name);
+        Assert.Equal(
+            NormalizeSeparators(realDir),
+            symEntry.LinkName);
+
+        // inner.txt should appear only under ds/real/,
+        // not under ds/linked/.
+        Assert.Single(names,
+            n => n == "ds/real/inner.txt");
+        Assert.DoesNotContain(
+            "ds/linked/inner.txt", names);
+    }
+
+    /// <summary>
+    /// Normalizes path separators for test assertions,
+    /// mirroring the production NormalizeSeparators logic.
+    /// </summary>
+    private static string NormalizeSeparators(string path)
+    {
+        return Path.DirectorySeparatorChar != '/'
+            ? path.Replace(
+                Path.DirectorySeparatorChar, '/')
+            : path;
+    }
+
+    /// <summary>
+    /// Reads all tar entries from a stream into a list.
+    /// </summary>
+    private static async Task<List<TarEntry>>
+        ReadAllTarEntriesAsync(Stream stream)
+    {
+        var entries = new List<TarEntry>();
+        using var reader = new TarReader(
+            stream, leaveOpen: true);
+        TarEntry? entry;
+        while ((entry = await reader.GetNextEntryAsync()) !=
+            null)
+        {
+            entries.Add(entry);
+        }
+        return entries;
+    }
+}

--- a/tests/OrasProject.Oras.Tests/Content/File/TarUtilitiesTest.cs
+++ b/tests/OrasProject.Oras.Tests/Content/File/TarUtilitiesTest.cs
@@ -28,9 +28,7 @@ public class TarUtilitiesTest : IDisposable
 
     public TarUtilitiesTest()
     {
-        _tempDir = Path.Combine(
-            Path.GetTempPath(),
-            $"oras-tar-test-{Guid.NewGuid():N}");
+        _tempDir = Path.Combine(Path.GetTempPath(), $"oras-tar-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }
 
@@ -42,199 +40,36 @@ public class TarUtilitiesTest : IDisposable
         }
     }
 
+    /// <summary>
+    /// Verifies basic tar creation with files: entry names, types, uid/gid=0,
+    /// and trailing-slash normalization for the root entry.
+    /// Consolidates BasicFiles, SetsUidGidToZero, and PrefixWithoutSlash tests.
+    /// </summary>
     [Fact]
-    public async Task TarDirectoryAsync_BasicFiles()
+    public async Task TarDirectoryAsync_BasicFilesAndPortability()
     {
         // Arrange
         var srcDir = Path.Combine(_tempDir, "src");
         Directory.CreateDirectory(srcDir);
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(srcDir, "file1.txt"), "hello");
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(srcDir, "file2.txt"), "world");
+        await System.IO.File.WriteAllTextAsync(Path.Combine(srcDir, "file1.txt"), "hello");
+        await System.IO.File.WriteAllTextAsync(Path.Combine(srcDir, "file2.txt"), "world");
 
-        // Act
+        // Act — prefix without trailing slash
         using var output = new MemoryStream();
         await TarUtilities.TarDirectoryAsync(
-            srcDir, "myprefix", output,
-            reproducible: false);
+            srcDir, "myprefix", output, reproducible: false);
         output.Position = 0;
 
-        // Assert
+        // Assert — entry names and types
         var entries = await ReadAllTarEntriesAsync(output);
         Assert.Contains(entries,
-            e => e.Name == "myprefix/"
-                && e.EntryType == TarEntryType.Directory);
+            e => e.Name == "myprefix/" && e.EntryType == TarEntryType.Directory);
         Assert.Contains(entries,
-            e => e.Name == "myprefix/file1.txt"
-                && e.EntryType == TarEntryType.RegularFile);
+            e => e.Name == "myprefix/file1.txt" && e.EntryType == TarEntryType.RegularFile);
         Assert.Contains(entries,
-            e => e.Name == "myprefix/file2.txt"
-                && e.EntryType == TarEntryType.RegularFile);
-    }
+            e => e.Name == "myprefix/file2.txt" && e.EntryType == TarEntryType.RegularFile);
 
-    [Fact]
-    public async Task TarDirectoryAsync_WithSubdirectories()
-    {
-        // Arrange
-        var srcDir = Path.Combine(_tempDir, "src");
-        var subDir = Path.Combine(srcDir, "sub");
-        Directory.CreateDirectory(subDir);
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(srcDir, "root.txt"), "root");
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(subDir, "nested.txt"), "nested");
-
-        // Act
-        using var output = new MemoryStream();
-        await TarUtilities.TarDirectoryAsync(
-            srcDir, "pkg", output, reproducible: false);
-        output.Position = 0;
-
-        // Assert
-        var entries = await ReadAllTarEntriesAsync(output);
-        Assert.Contains(entries,
-            e => e.Name == "pkg/"
-                && e.EntryType == TarEntryType.Directory);
-        Assert.Contains(entries,
-            e => e.Name == "pkg/sub/"
-                && e.EntryType == TarEntryType.Directory);
-        Assert.Contains(entries,
-            e => e.Name == "pkg/root.txt"
-                && e.EntryType == TarEntryType.RegularFile);
-        Assert.Contains(entries,
-            e => e.Name == "pkg/sub/nested.txt"
-                && e.EntryType == TarEntryType.RegularFile);
-    }
-
-    [Fact]
-    public async Task TarDirectoryAsync_Reproducible_SetsEpoch()
-    {
-        // Arrange
-        var srcDir = Path.Combine(_tempDir, "src");
-        Directory.CreateDirectory(srcDir);
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(srcDir, "data.txt"), "content");
-
-        // Act
-        using var output = new MemoryStream();
-        await TarUtilities.TarDirectoryAsync(
-            srcDir, "prefix", output,
-            reproducible: true);
-        output.Position = 0;
-
-        // Assert — all entries should have Unix epoch
-        var entries = await ReadAllTarEntriesAsync(output);
-        Assert.All(entries, e =>
-            Assert.Equal(
-                DateTimeOffset.UnixEpoch,
-                e.ModificationTime));
-    }
-
-    [Fact]
-    public async Task TarDirectoryAsync_NonReproducible_HasRecentTime()
-    {
-        // Arrange
-        var srcDir = Path.Combine(_tempDir, "src");
-        Directory.CreateDirectory(srcDir);
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(srcDir, "data.txt"), "content");
-
-        // Act
-        var beforeTar = DateTimeOffset.UtcNow;
-        using var output = new MemoryStream();
-        await TarUtilities.TarDirectoryAsync(
-            srcDir, "prefix", output,
-            reproducible: false);
-        var afterTar = DateTimeOffset.UtcNow;
-        output.Position = 0;
-
-        // Assert — entries should have a recent time
-        var entries = await ReadAllTarEntriesAsync(output);
-        var earliest = beforeTar.AddMinutes(-5);
-        var latest = afterTar.AddMinutes(5);
-        Assert.All(entries, e =>
-            Assert.InRange(
-                e.ModificationTime,
-                earliest,
-                latest));
-    }
-
-    [Fact]
-    public async Task TarDirectoryAsync_EmptyDirectory()
-    {
-        // Arrange
-        var srcDir = Path.Combine(_tempDir, "empty");
-        Directory.CreateDirectory(srcDir);
-
-        // Act
-        using var output = new MemoryStream();
-        await TarUtilities.TarDirectoryAsync(
-            srcDir, "root", output,
-            reproducible: true);
-        output.Position = 0;
-
-        // Assert — only root directory entry
-        var entries = await ReadAllTarEntriesAsync(output);
-        Assert.Single(entries);
-        Assert.Equal("root/", entries[0].Name);
-        Assert.Equal(
-            TarEntryType.Directory, entries[0].EntryType);
-    }
-
-    [Fact]
-    public async Task TarDirectoryAsync_FileContent_IsPreserved()
-    {
-        // Arrange
-        var srcDir = Path.Combine(_tempDir, "src");
-        Directory.CreateDirectory(srcDir);
-        var expected = "hello, tar!";
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(srcDir, "test.txt"), expected);
-
-        // Act
-        using var output = new MemoryStream();
-        await TarUtilities.TarDirectoryAsync(
-            srcDir, "p", output, reproducible: false);
-        output.Position = 0;
-
-        // Assert
-        using var reader = new TarReader(output);
-        TarEntry? entry;
-        while ((entry = await reader.GetNextEntryAsync()) !=
-            null)
-        {
-            if (entry.Name == "p/test.txt"
-                && entry.DataStream != null)
-            {
-                using var sr = new StreamReader(
-                    entry.DataStream);
-                var actual = await sr.ReadToEndAsync();
-                Assert.Equal(expected, actual);
-                return;
-            }
-        }
-        Assert.Fail("Expected entry p/test.txt not found");
-    }
-
-    [Fact]
-    public async Task TarDirectoryAsync_SetsUidGidToZero()
-    {
-        // Arrange
-        var srcDir = Path.Combine(_tempDir, "src");
-        Directory.CreateDirectory(srcDir);
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(srcDir, "f.txt"), "x");
-
-        // Act
-        using var output = new MemoryStream();
-        await TarUtilities.TarDirectoryAsync(
-            srcDir, "test", output,
-            reproducible: false);
-        output.Position = 0;
-
-        // Assert — all entries should have uid=0, gid=0
-        var entries = await ReadAllTarEntriesAsync(output);
+        // Assert — all entries have uid=0, gid=0 (portable)
         Assert.All(entries, e =>
         {
             var pax = Assert.IsType<PaxTarEntry>(e);
@@ -243,35 +78,33 @@ public class TarUtilitiesTest : IDisposable
         });
     }
 
+    /// <summary>
+    /// Verifies reproducible tar: deterministic entry order, epoch timestamps,
+    /// and correct entry types for subdirectories and files.
+    /// Consolidates WithSubdirectories, DeterministicOrder, and
+    /// Reproducible_SetsEpoch tests.
+    /// </summary>
     [Fact]
-    public async Task TarDirectoryAsync_Reproducible_DeterministicOrder()
+    public async Task TarDirectoryAsync_Reproducible_OrderAndTimestamps()
     {
-        // Arrange — create files in non-alphabetical order
+        // Arrange — create files and dirs in non-alphabetical order
         var srcDir = Path.Combine(_tempDir, "src");
         var subB = Path.Combine(srcDir, "beta");
         var subA = Path.Combine(srcDir, "alpha");
         Directory.CreateDirectory(subB);
         Directory.CreateDirectory(subA);
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(srcDir, "z.txt"), "z");
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(srcDir, "a.txt"), "a");
-        await System.IO.File.WriteAllTextAsync(
-            Path.Combine(subA, "inner.txt"), "i");
+        await System.IO.File.WriteAllTextAsync(Path.Combine(srcDir, "z.txt"), "z");
+        await System.IO.File.WriteAllTextAsync(Path.Combine(srcDir, "a.txt"), "a");
+        await System.IO.File.WriteAllTextAsync(Path.Combine(subA, "inner.txt"), "i");
 
         // Act
         using var output = new MemoryStream();
-        await TarUtilities.TarDirectoryAsync(
-            srcDir, "pkg", output,
-            reproducible: true);
+        await TarUtilities.TarDirectoryAsync(srcDir, "pkg", output, reproducible: true);
         output.Position = 0;
 
-        // Assert — entries are in deterministic order
+        // Assert — entries are in deterministic depth-first order
         var entries = await ReadAllTarEntriesAsync(output);
         var names = entries.Select(e => e.Name).ToList();
-
-        // Depth-first walk: root → sorted subdirs
-        // (recursing into each) → sorted files.
         Assert.Equal(
             new List<string>
             {
@@ -283,27 +116,94 @@ public class TarUtilitiesTest : IDisposable
                 "pkg/z.txt"
             },
             names);
+
+        // Assert — correct entry types
+        Assert.Contains(entries,
+            e => e.Name == "pkg/" && e.EntryType == TarEntryType.Directory);
+        Assert.Contains(entries,
+            e => e.Name == "pkg/alpha/" && e.EntryType == TarEntryType.Directory);
+        Assert.Contains(entries,
+            e => e.Name == "pkg/beta/" && e.EntryType == TarEntryType.Directory);
+        Assert.Contains(entries,
+            e => e.Name == "pkg/alpha/inner.txt"
+                && e.EntryType == TarEntryType.RegularFile);
+
+        // Assert — all entries should have Unix epoch timestamp
+        Assert.All(entries,
+            e => Assert.Equal(DateTimeOffset.UnixEpoch, e.ModificationTime));
     }
 
     [Fact]
-    public async Task TarDirectoryAsync_PrefixWithoutSlash()
+    public async Task TarDirectoryAsync_NonReproducible_HasRecentTime()
     {
         // Arrange
         var srcDir = Path.Combine(_tempDir, "src");
         Directory.CreateDirectory(srcDir);
+        await System.IO.File.WriteAllTextAsync(Path.Combine(srcDir, "data.txt"), "content");
 
-        // Act — prefix without trailing slash
+        // Act
+        var beforeTar = DateTimeOffset.UtcNow;
         using var output = new MemoryStream();
         await TarUtilities.TarDirectoryAsync(
-            srcDir, "notrail", output,
-            reproducible: true);
+            srcDir, "prefix", output, reproducible: false);
+        var afterTar = DateTimeOffset.UtcNow;
         output.Position = 0;
 
-        // Assert — root entry should still end with /
+        // Assert — entries should have a recent time
         var entries = await ReadAllTarEntriesAsync(output);
-        Assert.Contains(entries,
-            e => e.Name == "notrail/"
-                && e.EntryType == TarEntryType.Directory);
+        var earliest = beforeTar.AddMinutes(-5);
+        var latest = afterTar.AddMinutes(5);
+        Assert.All(entries,
+            e => Assert.InRange(e.ModificationTime, earliest, latest));
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_EmptyDirectory()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "empty");
+        Directory.CreateDirectory(srcDir);
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(srcDir, "root", output, reproducible: true);
+        output.Position = 0;
+
+        // Assert — only root directory entry
+        var entries = await ReadAllTarEntriesAsync(output);
+        Assert.Single(entries);
+        Assert.Equal("root/", entries[0].Name);
+        Assert.Equal(TarEntryType.Directory, entries[0].EntryType);
+    }
+
+    [Fact]
+    public async Task TarDirectoryAsync_FileContent_IsPreserved()
+    {
+        // Arrange
+        var srcDir = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        var expected = "hello, tar!";
+        await System.IO.File.WriteAllTextAsync(Path.Combine(srcDir, "test.txt"), expected);
+
+        // Act
+        using var output = new MemoryStream();
+        await TarUtilities.TarDirectoryAsync(srcDir, "p", output, reproducible: false);
+        output.Position = 0;
+
+        // Assert
+        using var reader = new TarReader(output);
+        TarEntry? entry;
+        while ((entry = await reader.GetNextEntryAsync()) != null)
+        {
+            if (entry.Name == "p/test.txt" && entry.DataStream != null)
+            {
+                using var sr = new StreamReader(entry.DataStream);
+                var actual = await sr.ReadToEndAsync();
+                Assert.Equal(expected, actual);
+                return;
+            }
+        }
+        Assert.Fail("Expected entry p/test.txt not found");
     }
 
     [Theory]
@@ -314,8 +214,7 @@ public class TarUtilitiesTest : IDisposable
     [InlineData("a/../b")]
     [InlineData("a/./b")]
     [InlineData("a//b")]
-    public async Task TarDirectoryAsync_InvalidPrefix_Throws(
-        string prefix)
+    public async Task TarDirectoryAsync_InvalidPrefix_Throws(string prefix)
     {
         var srcDir = Path.Combine(_tempDir, "src");
         Directory.CreateDirectory(srcDir);
@@ -323,115 +222,82 @@ public class TarUtilitiesTest : IDisposable
         using var output = new MemoryStream();
         await Assert.ThrowsAsync<ArgumentException>(
             () => TarUtilities.TarDirectoryAsync(
-                srcDir, prefix, output,
-                reproducible: false));
+                srcDir, prefix, output, reproducible: false));
     }
 
     [Fact]
     public async Task TarDirectoryAsync_MissingSource_Throws()
     {
-        var missing = Path.Combine(
-            _tempDir, "does-not-exist");
+        var missing = Path.Combine(_tempDir, "does-not-exist");
 
         using var output = new MemoryStream();
-        await Assert.ThrowsAsync<
-            DirectoryNotFoundException>(
+        await Assert.ThrowsAsync<DirectoryNotFoundException>(
             () => TarUtilities.TarDirectoryAsync(
-                missing, "pkg", output,
-                reproducible: false));
+                missing, "pkg", output, reproducible: false));
 
         // Stream should be empty — no partial archive
         Assert.Equal(0, output.Length);
     }
 
-    [Fact]
-    public void CreateDirectoryEntry_AppendsSlash()
+    /// <summary>
+    /// Consolidates CreateDirectoryEntry tests: slash appending, preserving
+    /// trailing slash, and reproducible timestamp behavior.
+    /// </summary>
+    [Theory]
+    [InlineData("mydir", false, "mydir/")]
+    [InlineData("mydir/", false, "mydir/")]
+    [InlineData("mydir", true, "mydir/")]
+    public void CreateDirectoryEntry_SlashAndTimestamp(
+        string input, bool reproducible, string expectedName)
     {
-        // Arrange
         var dir = Path.Combine(_tempDir, "testdir");
         Directory.CreateDirectory(dir);
 
-        // Act
-        var entry = TarUtilities.CreateDirectoryEntry(
-            "mydir", dir, reproducible: false);
+        var entry = TarUtilities.CreateDirectoryEntry(input, dir, reproducible);
 
-        // Assert
-        Assert.Equal("mydir/", entry.Name);
+        Assert.Equal(expectedName, entry.Name);
         Assert.Equal(TarEntryType.Directory, entry.EntryType);
-    }
-
-    [Fact]
-    public void CreateDirectoryEntry_PreservesTrailingSlash()
-    {
-        // Arrange
-        var dir = Path.Combine(_tempDir, "testdir");
-        Directory.CreateDirectory(dir);
-
-        // Act
-        var entry = TarUtilities.CreateDirectoryEntry(
-            "mydir/", dir, reproducible: false);
-
-        // Assert
-        Assert.Equal("mydir/", entry.Name);
-    }
-
-    [Fact]
-    public void CreateDirectoryEntry_Reproducible_SetsEpoch()
-    {
-        // Arrange
-        var dir = Path.Combine(_tempDir, "testdir");
-        Directory.CreateDirectory(dir);
-
-        // Act
-        var entry = TarUtilities.CreateDirectoryEntry(
-            "mydir", dir, reproducible: true);
-
-        // Assert
-        Assert.Equal(
-            DateTimeOffset.UnixEpoch,
-            entry.ModificationTime);
         Assert.Equal(0, entry.Uid);
         Assert.Equal(0, entry.Gid);
+
+        if (reproducible)
+        {
+            Assert.Equal(DateTimeOffset.UnixEpoch, entry.ModificationTime);
+        }
     }
 
-    [Fact]
-    public void GetUnixFileMode_Directory_Returns755()
+    /// <summary>
+    /// Consolidates GetUnixFileMode tests: directory returns 755, file returns 644.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GetUnixFileMode_ReturnsCorrectMode(bool isDirectory)
     {
-        // Arrange
-        var dir = Path.Combine(_tempDir, "testdir");
-        Directory.CreateDirectory(dir);
-        var dirInfo = new DirectoryInfo(dir);
+        FileSystemInfo info;
+        UnixFileMode expected;
 
-        // Act
-        var mode = TarUtilities.GetUnixFileMode(dirInfo);
+        if (isDirectory)
+        {
+            var dir = Path.Combine(_tempDir, "testdir");
+            Directory.CreateDirectory(dir);
+            info = new DirectoryInfo(dir);
+            expected = UnixFileMode.UserRead | UnixFileMode.UserWrite
+                | UnixFileMode.UserExecute | UnixFileMode.GroupRead
+                | UnixFileMode.GroupExecute | UnixFileMode.OtherRead
+                | UnixFileMode.OtherExecute;
+        }
+        else
+        {
+            var filePath = Path.Combine(_tempDir, "test.txt");
+            System.IO.File.WriteAllText(filePath, "data");
+            info = new FileInfo(filePath);
+            expected = UnixFileMode.UserRead | UnixFileMode.UserWrite
+                | UnixFileMode.GroupRead | UnixFileMode.OtherRead;
+        }
 
-        // Assert — rwxr-xr-x = 755
-        var expected = UnixFileMode.UserRead
-            | UnixFileMode.UserWrite
-            | UnixFileMode.UserExecute
-            | UnixFileMode.GroupRead
-            | UnixFileMode.GroupExecute
-            | UnixFileMode.OtherRead
-            | UnixFileMode.OtherExecute;
-        Assert.Equal(expected, mode);
-    }
+        var mode = TarUtilities.GetUnixFileMode(info);
 
-    [Fact]
-    public void GetUnixFileMode_File_Returns644()
-    {
-        // Arrange
-        var filePath = Path.Combine(_tempDir, "test.txt");
-        System.IO.File.WriteAllText(filePath, "data");
-        var fileInfo = new FileInfo(filePath);
-
-        // Act
-        var mode = TarUtilities.GetUnixFileMode(fileInfo);
-
-        // Assert — rw-r--r-- = 644
-        var expected = UnixFileMode.UserRead
-            | UnixFileMode.UserWrite
-            | UnixFileMode.GroupRead
-            | UnixFileMode.OtherRead;
         Assert.Equal(expected, mode);
     }
 
@@ -442,29 +308,23 @@ public class TarUtilitiesTest : IDisposable
         var srcDir = Path.Combine(_tempDir, "src");
         Directory.CreateDirectory(srcDir);
         var targetFile = Path.Combine(srcDir, "real.txt");
-        await System.IO.File.WriteAllTextAsync(
-            targetFile, "data");
+        await System.IO.File.WriteAllTextAsync(targetFile, "data");
         var linkPath = Path.Combine(srcDir, "link.txt");
         try
         {
-            System.IO.File.CreateSymbolicLink(
-                linkPath, "real.txt");
+            System.IO.File.CreateSymbolicLink(linkPath, "real.txt");
         }
         catch (Exception ex)
             when (ex is UnauthorizedAccessException
-                or PlatformNotSupportedException
-                or IOException)
+                or PlatformNotSupportedException or IOException)
         {
             throw Xunit.Sdk.SkipException.ForSkip(
-                "Symlinks not supported on this" +
-                $" platform: {ex.Message}");
+                $"Symlinks not supported on this platform: {ex.Message}");
         }
 
         // Act
         using var output = new MemoryStream();
-        await TarUtilities.TarDirectoryAsync(
-            srcDir, "sym", output,
-            reproducible: true);
+        await TarUtilities.TarDirectoryAsync(srcDir, "sym", output, reproducible: true);
         output.Position = 0;
 
         // Assert
@@ -476,14 +336,11 @@ public class TarUtilitiesTest : IDisposable
         var pax = Assert.IsType<PaxTarEntry>(symEntry);
         Assert.Equal(0, pax.Uid);
         Assert.Equal(0, pax.Gid);
-        Assert.Equal(
-            DateTimeOffset.UnixEpoch,
-            pax.ModificationTime);
+        Assert.Equal(DateTimeOffset.UnixEpoch, pax.ModificationTime);
     }
 
     [Fact]
-    public async Task
-        TarDirectoryAsync_DirSymlink_EmitsEntryNoRecurse()
+    public async Task TarDirectoryAsync_DirSymlink_EmitsEntryNoRecurse()
     {
         // Arrange — create a real subdirectory with a file,
         // then create a directory symlink pointing to it.
@@ -495,74 +352,58 @@ public class TarUtilitiesTest : IDisposable
         var linkDir = Path.Combine(srcDir, "linked");
         try
         {
-            Directory.CreateSymbolicLink(
-                linkDir, realDir);
+            Directory.CreateSymbolicLink(linkDir, realDir);
         }
         catch (Exception ex)
             when (ex is UnauthorizedAccessException
-                or PlatformNotSupportedException
-                or IOException)
+                or PlatformNotSupportedException or IOException)
         {
             throw Xunit.Sdk.SkipException.ForSkip(
-                "Symlinks not supported on this" +
-                $" platform: {ex.Message}");
+                $"Symlinks not supported on this platform: {ex.Message}");
         }
 
         // Act
         using var output = new MemoryStream();
-        await TarUtilities.TarDirectoryAsync(
-            srcDir, "ds", output,
-            reproducible: true);
+        await TarUtilities.TarDirectoryAsync(srcDir, "ds", output, reproducible: true);
         output.Position = 0;
 
         // Assert
         var entries = await ReadAllTarEntriesAsync(output);
-        var names = entries
-            .Select(e => e.Name).ToList();
+        var names = entries.Select(e => e.Name).ToList();
 
-        // The directory symlink should be emitted as a
-        // SymbolicLink entry (not a Directory entry), and
-        // no files from inside the target should appear.
+        // The directory symlink should be emitted as a SymbolicLink entry
+        // (not a Directory entry), and no files from inside the target
+        // should appear.
         var symEntry = Assert.Single(entries,
-            e => e.EntryType
-                == TarEntryType.SymbolicLink);
+            e => e.EntryType == TarEntryType.SymbolicLink);
         Assert.Equal("ds/linked", symEntry.Name);
-        Assert.Equal(
-            NormalizeSeparators(realDir),
-            symEntry.LinkName);
+        Assert.Equal(NormalizeSeparators(realDir), symEntry.LinkName);
 
-        // inner.txt should appear only under ds/real/,
-        // not under ds/linked/.
-        Assert.Single(names,
-            n => n == "ds/real/inner.txt");
-        Assert.DoesNotContain(
-            "ds/linked/inner.txt", names);
+        // inner.txt should appear only under ds/real/, not under ds/linked/.
+        Assert.Single(names, n => n == "ds/real/inner.txt");
+        Assert.DoesNotContain("ds/linked/inner.txt", names);
     }
 
     /// <summary>
-    /// Normalizes path separators for test assertions,
-    /// mirroring the production NormalizeSeparators logic.
+    /// Normalizes path separators for test assertions, mirroring the production
+    /// NormalizeSeparators logic.
     /// </summary>
     private static string NormalizeSeparators(string path)
     {
         return Path.DirectorySeparatorChar != '/'
-            ? path.Replace(
-                Path.DirectorySeparatorChar, '/')
+            ? path.Replace(Path.DirectorySeparatorChar, '/')
             : path;
     }
 
     /// <summary>
     /// Reads all tar entries from a stream into a list.
     /// </summary>
-    private static async Task<List<TarEntry>>
-        ReadAllTarEntriesAsync(Stream stream)
+    private static async Task<List<TarEntry>> ReadAllTarEntriesAsync(Stream stream)
     {
         var entries = new List<TarEntry>();
-        using var reader = new TarReader(
-            stream, leaveOpen: true);
+        using var reader = new TarReader(stream, leaveOpen: true);
         TarEntry? entry;
-        while ((entry = await reader.GetNextEntryAsync()) !=
-            null)
+        while ((entry = await reader.GetNextEntryAsync()) != null)
         {
             entries.Add(entry);
         }


### PR DESCRIPTION
## Description
Part of #37 
Add tar archive creation utilities as part of the FileStore implementation breakdown.

### Changes

- **`TarUtilities.TarDirectoryAsync`** — creates a tar archive from a directory, writing entries to an output stream. Supports:
  - Recursive directory traversal (subdirectories and files)
  - Reproducible tarballs (Unix epoch timestamps when `reproducible: true`)
  - Symbolic link entries
  - Portable entries (uid/gid set to zero)
- **`TarUtilities.CreateDirectoryEntry`** — creates a `PaxTarEntry` for a directory with correct mode and optional epoch timestamp
- **`TarUtilities.GetUnixFileMode`** — returns standard Unix file modes: 755 for directories, 644 for files

### Tests (13 test methods)

- `TarDirectoryAsync`: basic files, subdirectories, reproducible timestamps, non-reproducible timestamps, empty directory, file content preservation, uid/gid zero, prefix normalization
- `CreateDirectoryEntry`: slash appending, preserving trailing slash, reproducible timestamp
- `GetUnixFileMode`: directory returns 755, file returns 644

### Context

Part 4 of the FileStore PR breakdown ([#328](https://github.com/oras-project/oras-dotnet/pull/328)), per [sajayantony's suggested split](https://github.com/oras-project/oras-dotnet/pull/328#issuecomment-2844569498). This PR has no dependencies and can be reviewed independently.