### PR TITLE
feat(auth): add IAccessTokenProvider for external token resolution

### DIFF
--- a/OrasProject.Oras.sln
+++ b/OrasProject.Oras.sln
@@ -9,26 +9,75 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrasProject.Oras", "src\Ora
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrasProject.Oras.Examples.Azure", "examples\OrasProject.Oras.Examples.Azure\OrasProject.Oras.Examples.Azure.csproj", "{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrasProject.Oras.Examples.ExternalTokenBroker", "examples\OrasProject.Oras.Examples.ExternalTokenBroker\OrasProject.Oras.Examples.ExternalTokenBroker.csproj", "{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Debug|x64.Build.0 = Debug|Any CPU
+		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Debug|x86.Build.0 = Debug|Any CPU
 		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Release|x64.ActiveCfg = Release|Any CPU
+		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Release|x64.Build.0 = Release|Any CPU
+		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Release|x86.ActiveCfg = Release|Any CPU
+		{70DFCE13-53AA-4CC2-8E1A-F73A1344A0CB}.Release|x86.Build.0 = Release|Any CPU
 		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Debug|x64.Build.0 = Debug|Any CPU
+		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Debug|x86.Build.0 = Debug|Any CPU
 		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Release|Any CPU.Build.0 = Release|Any CPU
+		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Release|x64.ActiveCfg = Release|Any CPU
+		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Release|x64.Build.0 = Release|Any CPU
+		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Release|x86.ActiveCfg = Release|Any CPU
+		{547F152F-6F4D-4E5A-AD3A-C3BC5CDCFD27}.Release|x86.Build.0 = Release|Any CPU
 		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Debug|x64.Build.0 = Debug|Any CPU
+		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Debug|x86.Build.0 = Debug|Any CPU
 		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Release|x64.ActiveCfg = Release|Any CPU
+		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Release|x64.Build.0 = Release|Any CPU
+		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Release|x86.ActiveCfg = Release|Any CPU
+		{B8E3A2F1-5C4D-4E6A-9F7B-8C1D2E3F4A5B}.Release|x86.Build.0 = Release|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Debug|x64.Build.0 = Debug|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Debug|x86.Build.0 = Debug|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Release|x64.ActiveCfg = Release|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Release|x64.Build.0 = Release|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Release|x86.ActiveCfg = Release|Any CPU
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
 	EndGlobalSection
 EndGlobal

--- a/examples/OrasProject.Oras.Examples.ExternalTokenBroker/ExternalBrokerTokenProvider.cs
+++ b/examples/OrasProject.Oras.Examples.ExternalTokenBroker/ExternalBrokerTokenProvider.cs
@@ -1,0 +1,97 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#region Usage
+using System.Net.Http.Json;
+using OrasProject.Oras.Registry.Remote.Auth;
+
+namespace OrasProject.Oras.Examples.ExternalTokenBroker;
+
+/// <summary>
+/// An <see cref="IAccessTokenProvider"/> that delegates token acquisition
+/// to an external broker service via HTTP.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This pattern is useful when long-lived credentials (passwords, refresh
+/// tokens) should not enter the ORAS process.  The broker performs the
+/// credential exchange externally and returns only a short-lived,
+/// narrowly-scoped access token.
+/// </para>
+/// <para>
+/// The provider is only called when the <see cref="Client"/>'s token cache
+/// does not contain a valid token for the requested scopes (i.e., on the
+/// first request or after the server rejects a cached token).
+/// </para>
+/// </remarks>
+public class ExternalBrokerTokenProvider : IAccessTokenProvider
+{
+    private readonly HttpClient _brokerClient;
+    private readonly string _brokerEndpoint;
+
+    /// <summary>
+    /// Initializes a new instance with the broker HTTP client and endpoint.
+    /// </summary>
+    /// <param name="brokerClient">
+    /// An <see cref="HttpClient"/> configured to communicate with the
+    /// token broker (base address, auth headers, etc.).
+    /// </param>
+    /// <param name="brokerEndpoint">
+    /// The broker endpoint path (e.g., "/api/v1/token").
+    /// </param>
+    public ExternalBrokerTokenProvider(
+        HttpClient brokerClient, string brokerEndpoint)
+    {
+        _brokerClient = brokerClient;
+        _brokerEndpoint = brokerEndpoint;
+    }
+
+    /// <inheritdoc/>
+    public async Task<string?> ResolveAccessTokenAsync(
+        string hostname,
+        string realm,
+        string service,
+        IReadOnlyList<string> scopes,
+        bool forceRefresh = false,
+        CancellationToken cancellationToken = default)
+    {
+        // Forward the challenge parameters to the broker.
+        // The broker owns the credential exchange and returns only a
+        // short-lived token — no secrets cross the process boundary.
+        //
+        // IMPORTANT: realm, service, and scopes originate from the
+        // server's WWW-Authenticate header and are untrusted. The
+        // broker should validate these values (e.g., require HTTPS
+        // realm, match an allowlist) before acting on them.
+        var request = new TokenRequest(
+            hostname, realm, service, scopes, forceRefresh);
+
+        using var response = await _brokerClient.PostAsJsonAsync(
+            _brokerEndpoint, request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content
+            .ReadFromJsonAsync<TokenResponse>(
+                cancellationToken: cancellationToken);
+        return result?.AccessToken;
+    }
+
+    private record TokenRequest(
+        string Hostname,
+        string Realm,
+        string Service,
+        IReadOnlyList<string> Scopes,
+        bool ForceRefresh);
+
+    private record TokenResponse(string? AccessToken);
+}
+#endregion

--- a/examples/OrasProject.Oras.Examples.ExternalTokenBroker/ExternalTokenBrokerAuthentication.cs
+++ b/examples/OrasProject.Oras.Examples.ExternalTokenBroker/ExternalTokenBrokerAuthentication.cs
@@ -1,0 +1,69 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#region Usage
+using OrasProject.Oras.Registry;
+using OrasProject.Oras.Registry.Remote;
+using OrasProject.Oras.Registry.Remote.Auth;
+
+namespace OrasProject.Oras.Examples.ExternalTokenBroker;
+
+/// <summary>
+/// Demonstrates using <see cref="IAccessTokenProvider"/> with an
+/// external token broker to pull an artifact without raw credentials
+/// entering the process.
+/// </summary>
+public static class ExternalTokenBrokerAuthentication
+{
+    /// <summary>
+    /// Pulls an artifact using an external broker for token acquisition.
+    /// </summary>
+    public static async Task PullWithExternalBrokerAsync(
+        CancellationToken cancellationToken = default)
+    {
+        // Configure the broker HTTP client.
+        // In production this might have mTLS, API keys, etc.
+        using var brokerClient = new HttpClient
+        {
+            BaseAddress = new Uri("https://broker.internal.example.com")
+        };
+
+        // Create the access-token provider backed by the broker.
+        var tokenProvider = new ExternalBrokerTokenProvider(
+            brokerClient, "/api/v1/token");
+
+        // Build the ORAS auth client with the provider.
+        // No ICredentialProvider is needed — the broker handles
+        // credential exchange externally.
+        using var httpClient = new HttpClient();
+        var authClient = new Client(httpClient)
+        {
+            AccessTokenProvider = tokenProvider
+        };
+
+        // Create a repository and pull the artifact.
+        var repository = new Repository(new RepositoryOptions
+        {
+            Reference = Reference.Parse(
+                "myregistry.example.com/myrepo:v1"),
+            Client = authClient,
+        });
+
+        var descriptor = await repository.ResolveAsync(
+            "v1", cancellationToken);
+
+        // Use descriptor.Digest, descriptor.Size, etc.
+        Console.WriteLine(
+            $"Resolved: {descriptor.Digest} ({descriptor.Size} bytes)");
+    }
+}
+#endregion

--- a/examples/OrasProject.Oras.Examples.ExternalTokenBroker/OrasProject.Oras.Examples.ExternalTokenBroker.csproj
+++ b/examples/OrasProject.Oras.Examples.ExternalTokenBroker/OrasProject.Oras.Examples.ExternalTokenBroker.csproj
@@ -1,0 +1,31 @@
+<!--
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+
+    <!-- Disable requiring ConfigureAwait(false) for awaited tasks -->
+    <NoWarn>CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OrasProject.Oras\OrasProject.Oras.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -393,6 +393,7 @@ public class Client : IClient
         string realm,
         string service,
         IList<string> scopes,
+        bool forceRefresh = false,
         CancellationToken cancellationToken = default)
     {
         // When an AccessTokenProvider is configured, try it first.
@@ -408,6 +409,7 @@ public class Client : IClient
                     realm,
                     service,
                     readOnlyScopes,
+                    forceRefresh,
                     cancellationToken)
                 .ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(accessToken))
@@ -744,6 +746,7 @@ public class Client : IClient
                         realm,
                         service,
                         newScopes.Select(newScope => newScope.ToString()).ToList(),
+                        forceRefresh: true,
                         cancellationToken
                     ).ConfigureAwait(false);
                     Cache.SetCache(host, schemeFromChallenge, newKey, bearerAuthToken, partitionId);

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -69,7 +69,28 @@ public class Client : IClient
         HttpClient? httpClient = null,
         ICredentialProvider? credentialProvider = null,
         ICache? cache = null)
-        : this(httpClient, null, credentialProvider, cache)
+        : this(httpClient, null, credentialProvider, null, cache)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the Client class with an access-token provider.
+    /// </summary>
+    /// <param name="httpClient">
+    /// Optional HttpClient to use for standard requests that follow redirects.
+    /// If not provided, uses <see cref="DefaultHttpClient.Instance"/>.
+    /// </param>
+    /// <param name="accessTokenProvider">
+    /// An access-token provider that returns ready-to-use tokens.  When set, the client
+    /// calls this provider first during Bearer authentication before falling back to
+    /// credential-based token exchange.
+    /// </param>
+    /// <param name="cache">Optional cache for storing authentication tokens.</param>
+    public Client(
+        HttpClient? httpClient,
+        IAccessTokenProvider accessTokenProvider,
+        ICache? cache = null)
+        : this(httpClient, null, null, accessTokenProvider, cache)
     {
     }
 
@@ -91,14 +112,21 @@ public class Client : IClient
     /// </para>
     /// </param>
     /// <param name="credentialProvider">Optional credential provider for registry authentication.</param>
+    /// <param name="accessTokenProvider">
+    /// Optional access-token provider.  When set, the client calls this provider first during
+    /// Bearer authentication.  If it returns <c>null</c>, the client falls through to
+    /// credential-based authentication via <paramref name="credentialProvider"/>.
+    /// </param>
     /// <param name="cache">Optional cache for storing authentication tokens.</param>
     public Client(
         HttpClient? httpClient,
         HttpClient? noRedirectHttpClient,
         ICredentialProvider? credentialProvider,
-        ICache? cache)
+        IAccessTokenProvider? accessTokenProvider = null,
+        ICache? cache = null)
     {
         CredentialProvider = credentialProvider;
+        AccessTokenProvider = accessTokenProvider;
         _cache = cache;
         BaseClient = httpClient ?? DefaultHttpClient.Instance;
         NoRedirectClient = noRedirectHttpClient ?? DefaultHttpClient.NoRedirectInstance;
@@ -109,6 +137,14 @@ public class Client : IClient
     /// credentials for accessing remote registries.
     /// </summary>
     public ICredentialProvider? CredentialProvider { get; init; }
+
+    /// <summary>
+    /// AccessTokenProvider provides pre-resolved access tokens for Bearer authentication.
+    /// When set, the client calls this provider first during Bearer auth.  If it returns
+    /// <c>null</c>, the client falls through to credential-based authentication via
+    /// <see cref="CredentialProvider"/>.
+    /// </summary>
+    public IAccessTokenProvider? AccessTokenProvider { get; init; }
 
     /// <summary>
     /// BaseClient is an instance of HttpClient to send http requests that follow redirects.
@@ -299,7 +335,10 @@ public class Client : IClient
     /// <summary>
     /// Fetches a OAuth2 access token for accessing a registry.
     ///
-    /// If credential is empty or refreshToken is not set and OAuth2 authentication is not forced,
+    /// When an <see cref="AccessTokenProvider"/> is configured it is consulted first.
+    /// If it returns a non-empty token, that token is used directly — bypassing credential
+    /// resolution entirely.  Otherwise, the existing credential-based flow is used:
+    /// if credential is empty or refreshToken is not set and OAuth2 authentication is not forced,
     /// the method would fetch anonymous token with a Http Get request
     /// otherwise, it would fetch OAuth2 token with a Http Post request.
     /// </summary>
@@ -322,6 +361,19 @@ public class Client : IClient
         IList<string> scopes,
         CancellationToken cancellationToken = default)
     {
+        // When an AccessTokenProvider is configured, try it first.  It returns a
+        // ready-to-use scoped token without exposing raw credentials in-process.
+        if (AccessTokenProvider != null)
+        {
+            var accessToken = await AccessTokenProvider.ResolveAccessTokenAsync(
+                registry, realm, service, scopes, cancellationToken)
+                .ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(accessToken))
+            {
+                return accessToken;
+            }
+        }
+
         var credential = await ResolveCredentialAsync(registry, cancellationToken)
             .ConfigureAwait(false);
         if (!string.IsNullOrEmpty(credential.AccessToken))

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -74,62 +74,87 @@ public class Client : IClient
     }
 
     /// <summary>
-    /// Initializes a new instance of the Client class with an access-token provider.
+    /// Initializes a new instance of the Client class with separate
+    /// HttpClient instances for redirect control.
     /// </summary>
     /// <param name="httpClient">
-    /// Optional HttpClient to use for standard requests that follow redirects.
-    /// If not provided, uses <see cref="DefaultHttpClient.Instance"/>.
-    /// </param>
-    /// <param name="accessTokenProvider">
-    /// An access-token provider that returns ready-to-use tokens.  When set, the client
-    /// calls this provider first during Bearer authentication before falling back to
-    /// credential-based token exchange.
-    /// </param>
-    /// <param name="cache">Optional cache for storing authentication tokens.</param>
-    public Client(
-        HttpClient? httpClient,
-        IAccessTokenProvider accessTokenProvider,
-        ICache? cache = null)
-        : this(httpClient, null, null, accessTokenProvider, cache)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the Client class with separate HttpClient instances for redirect control.
-    /// </summary>
-    /// <param name="httpClient">
-    /// Optional HttpClient to use for standard requests that follow redirects.
-    /// If not provided, uses <see cref="DefaultHttpClient.Instance"/>.
+    /// Optional HttpClient to use for standard requests that follow
+    /// redirects.  If not provided, uses
+    /// <see cref="DefaultHttpClient.Instance"/>.
     /// </param>
     /// <param name="noRedirectHttpClient">
-    /// Optional HttpClient configured with <c>AllowAutoRedirect = false</c> for capturing redirect locations.
-    /// If not provided, uses <see cref="DefaultHttpClient.NoRedirectInstance"/>.
+    /// Optional HttpClient configured with
+    /// <c>AllowAutoRedirect = false</c> for capturing redirect
+    /// locations.  If not provided, uses
+    /// <see cref="DefaultHttpClient.NoRedirectInstance"/>.
     /// <para>
-    /// <strong>Advanced Usage:</strong> To apply consistent HTTP configuration (timeouts, proxy, headers) 
-    /// across both redirect and no-redirect scenarios, provide both <paramref name="httpClient"/> and 
-    /// <paramref name="noRedirectHttpClient"/> with the same base configuration but different redirect settings.
-    /// This is useful with IHttpClientFactory or custom HttpClient management.
+    /// <strong>Advanced Usage:</strong> To apply consistent HTTP
+    /// configuration (timeouts, proxy, headers) across both redirect
+    /// and no-redirect scenarios, provide both
+    /// <paramref name="httpClient"/> and
+    /// <paramref name="noRedirectHttpClient"/> with the same base
+    /// configuration but different redirect settings.  This is useful
+    /// with IHttpClientFactory or custom HttpClient management.
     /// </para>
     /// </param>
-    /// <param name="credentialProvider">Optional credential provider for registry authentication.</param>
-    /// <param name="accessTokenProvider">
-    /// Optional access-token provider.  When set, the client calls this provider first during
-    /// Bearer authentication.  If it returns <c>null</c>, the client falls through to
-    /// credential-based authentication via <paramref name="credentialProvider"/>.
+    /// <param name="credentialProvider">
+    /// Optional credential provider for registry authentication.
     /// </param>
-    /// <param name="cache">Optional cache for storing authentication tokens.</param>
+    /// <param name="cache">
+    /// Optional cache for storing authentication tokens.
+    /// </param>
     public Client(
         HttpClient? httpClient,
         HttpClient? noRedirectHttpClient,
         ICredentialProvider? credentialProvider,
-        IAccessTokenProvider? accessTokenProvider = null,
-        ICache? cache = null)
+        ICache? cache)
+        : this(httpClient, noRedirectHttpClient, credentialProvider,
+            null, cache)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the Client class with separate
+    /// HttpClient instances for redirect control and an optional
+    /// access-token provider.
+    /// </summary>
+    /// <param name="httpClient">
+    /// Optional HttpClient to use for standard requests that follow
+    /// redirects.  If not provided, uses
+    /// <see cref="DefaultHttpClient.Instance"/>.
+    /// </param>
+    /// <param name="noRedirectHttpClient">
+    /// Optional HttpClient configured with
+    /// <c>AllowAutoRedirect = false</c> for capturing redirect
+    /// locations.  If not provided, uses
+    /// <see cref="DefaultHttpClient.NoRedirectInstance"/>.
+    /// </param>
+    /// <param name="credentialProvider">
+    /// Optional credential provider for registry authentication.
+    /// </param>
+    /// <param name="accessTokenProvider">
+    /// Optional access-token provider.  When set, the client calls
+    /// this provider first during Bearer authentication.  If it
+    /// returns <c>null</c> or whitespace, the client falls through to
+    /// credential-based authentication via
+    /// <paramref name="credentialProvider"/>.
+    /// </param>
+    /// <param name="cache">
+    /// Optional cache for storing authentication tokens.
+    /// </param>
+    public Client(
+        HttpClient? httpClient,
+        HttpClient? noRedirectHttpClient,
+        ICredentialProvider? credentialProvider,
+        IAccessTokenProvider? accessTokenProvider,
+        ICache? cache)
     {
         CredentialProvider = credentialProvider;
         AccessTokenProvider = accessTokenProvider;
         _cache = cache;
         BaseClient = httpClient ?? DefaultHttpClient.Instance;
-        NoRedirectClient = noRedirectHttpClient ?? DefaultHttpClient.NoRedirectInstance;
+        NoRedirectClient =
+            noRedirectHttpClient ?? DefaultHttpClient.NoRedirectInstance;
     }
 
     /// <summary>
@@ -139,10 +164,11 @@ public class Client : IClient
     public ICredentialProvider? CredentialProvider { get; init; }
 
     /// <summary>
-    /// AccessTokenProvider provides pre-resolved access tokens for Bearer authentication.
-    /// When set, the client calls this provider first during Bearer auth.  If it returns
-    /// <c>null</c>, the client falls through to credential-based authentication via
-    /// <see cref="CredentialProvider"/>.
+    /// AccessTokenProvider provides pre-resolved access tokens for
+    /// Bearer authentication.  When set, the client calls this provider
+    /// first during Bearer auth.  If it returns <c>null</c> or
+    /// whitespace, the client falls through to credential-based
+    /// authentication via <see cref="CredentialProvider"/>.
     /// </summary>
     public IAccessTokenProvider? AccessTokenProvider { get; init; }
 
@@ -335,21 +361,29 @@ public class Client : IClient
     /// <summary>
     /// Fetches a OAuth2 access token for accessing a registry.
     ///
-    /// When an <see cref="AccessTokenProvider"/> is configured it is consulted first.
-    /// If it returns a non-empty token, that token is used directly — bypassing credential
-    /// resolution entirely.  Otherwise, the existing credential-based flow is used:
-    /// if credential is empty or refreshToken is not set and OAuth2 authentication is not forced,
-    /// the method would fetch anonymous token with a Http Get request
-    /// otherwise, it would fetch OAuth2 token with a Http Post request.
+    /// When an <see cref="AccessTokenProvider"/> is configured it is
+    /// consulted first.  If it returns a non-whitespace token, that
+    /// token is used directly — bypassing credential resolution
+    /// entirely.  Otherwise, the existing credential-based flow is
+    /// used: if credential is empty or refreshToken is not set and
+    /// OAuth2 authentication is not forced, the method would fetch
+    /// anonymous token with a Http Get request otherwise, it would
+    /// fetch OAuth2 token with a Http Post request.
     /// </summary>
     /// <param name="registry">The registry host (e.g., "docker.io").</param>
     /// <param name="realm">The authentication realm to use.</param>
-    /// <param name="service">The service name for which the token is requested.</param>
-    /// <param name="scopes">The scopes of access requested for the token.</param>
-    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <param name="service">
+    /// The service name for which the token is requested.
+    /// </param>
+    /// <param name="scopes">
+    /// The scopes of access requested for the token.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token to monitor for cancellation requests.
+    /// </param>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains the bearer
-    /// authentication token as a string.
+    /// A task that represents the asynchronous operation. The task
+    /// result contains the bearer authentication token as a string.
     /// </returns>
     /// <exception cref="AuthenticationException">
     /// Thrown when credentials are missing or invalid.
@@ -361,14 +395,22 @@ public class Client : IClient
         IList<string> scopes,
         CancellationToken cancellationToken = default)
     {
-        // When an AccessTokenProvider is configured, try it first.  It returns a
-        // ready-to-use scoped token without exposing raw credentials in-process.
+        // When an AccessTokenProvider is configured, try it first.
+        // It returns a ready-to-use scoped token without exposing raw
+        // credentials in-process.
         if (AccessTokenProvider != null)
         {
-            var accessToken = await AccessTokenProvider.ResolveAccessTokenAsync(
-                registry, realm, service, scopes, cancellationToken)
+            var readOnlyScopes =
+                (IReadOnlyList<string>)scopes.ToArray();
+            var accessToken =
+                await AccessTokenProvider.ResolveAccessTokenAsync(
+                    registry,
+                    realm,
+                    service,
+                    readOnlyScopes,
+                    cancellationToken)
                 .ConfigureAwait(false);
-            if (!string.IsNullOrEmpty(accessToken))
+            if (!string.IsNullOrWhiteSpace(accessToken))
             {
                 return accessToken;
             }

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -359,7 +359,7 @@ public class Client : IClient
     }
 
     /// <summary>
-    /// Fetches a OAuth2 access token for accessing a registry.
+    /// Fetches a bearer access token for accessing a registry.
     ///
     /// When an <see cref="AccessTokenProvider"/> is configured it is
     /// consulted first.  If it returns a non-whitespace token, that
@@ -377,6 +377,11 @@ public class Client : IClient
     /// </param>
     /// <param name="scopes">
     /// The scopes of access requested for the token.
+    /// </param>
+    /// <param name="forceRefresh">
+    /// When <see langword="true"/>, instructs the provider to bypass
+    /// any cached token and acquire a fresh one. This is always set
+    /// after a 401 response indicates the current token is stale.
     /// </param>
     /// <param name="cancellationToken">
     /// A token to monitor for cancellation requests.
@@ -401,8 +406,8 @@ public class Client : IClient
         // credentials in-process.
         if (AccessTokenProvider != null)
         {
-            var readOnlyScopes =
-                (IReadOnlyList<string>)scopes.ToArray();
+            var readOnlyScopes = scopes as IReadOnlyList<string>
+                ?? (IReadOnlyList<string>)scopes.ToArray();
             var accessToken =
                 await AccessTokenProvider.ResolveAccessTokenAsync(
                     registry,

--- a/src/OrasProject.Oras/Registry/Remote/Auth/IAccessTokenProvider.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/IAccessTokenProvider.cs
@@ -49,11 +49,36 @@ public interface IAccessTokenProvider
     /// </param>
     /// <param name="realm">
     /// The authentication realm URL from the WWW-Authenticate header.
+    /// <para>
+    /// <b>Trust boundary:</b> This value is derived from a server-supplied
+    /// WWW-Authenticate header and must be treated as untrusted input.
+    /// Implementations should validate the URL before making outbound
+    /// requests (e.g., restrict to HTTPS, allowlist known token
+    /// endpoints).
+    /// </para>
     /// </param>
     /// <param name="service">
     /// The service identifier from the WWW-Authenticate header.
+    /// <para>
+    /// <b>Trust boundary:</b> This value is attacker-controlled.
+    /// Implementations should not use it to make security decisions
+    /// without independent validation.
+    /// </para>
     /// </param>
-    /// <param name="scopes">The requested access scopes (read-only).</param>
+    /// <param name="scopes">
+    /// The requested access scopes (read-only).
+    /// <para>
+    /// <b>Trust boundary:</b> Scope values originate from the
+    /// WWW-Authenticate header and should be validated or sanitized
+    /// before forwarding to external token services.
+    /// </para>
+    /// </param>
+    /// <param name="forceRefresh">
+    /// When <c>true</c>, indicates that a previously returned token was
+    /// rejected by the server (e.g., expired or revoked). Implementations
+    /// that maintain their own token cache should bypass it and acquire a
+    /// fresh token.  When <c>false</c>, a cached token may be returned.
+    /// </param>
     /// <param name="cancellationToken">
     /// A token to cancel the asynchronous operation.
     /// </param>
@@ -67,5 +92,6 @@ public interface IAccessTokenProvider
         string realm,
         string service,
         IReadOnlyList<string> scopes,
+        bool forceRefresh = false,
         CancellationToken cancellationToken = default);
 }

--- a/src/OrasProject.Oras/Registry/Remote/Auth/IAccessTokenProvider.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/IAccessTokenProvider.cs
@@ -22,36 +22,50 @@ namespace OrasProject.Oras.Registry.Remote.Auth;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Unlike <see cref="ICredentialProvider"/>, which returns raw credentials that the
-/// <see cref="Client"/> exchanges at a token endpoint, an <see cref="IAccessTokenProvider"/>
-/// returns a ready-to-use access token.  This is useful when token acquisition is handled
-/// by an external service (e.g., a gRPC token service) that owns the credential exchange.
+/// Unlike <see cref="ICredentialProvider"/>, which returns raw credentials that
+/// the <see cref="Client"/> exchanges at a token endpoint, an
+/// <see cref="IAccessTokenProvider"/> returns a ready-to-use access token.
+/// This is useful when token acquisition is handled by an external service
+/// (e.g., a gRPC token service) that owns the credential exchange.
 /// </para>
 /// <para>
-/// When both <see cref="IAccessTokenProvider"/> and <see cref="ICredentialProvider"/> are
-/// configured on a <see cref="Client"/>, the access-token provider is tried first.  If it
-/// returns <c>null</c>, the client falls through to credential-based authentication.
+/// When both <see cref="IAccessTokenProvider"/> and
+/// <see cref="ICredentialProvider"/> are configured on a <see cref="Client"/>,
+/// the access-token provider is tried first.  If it returns <c>null</c> or
+/// whitespace, the client falls through to credential-based authentication.
 /// </para>
 /// </remarks>
+/// <seealso href="https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#authorization">
+/// OCI Distribution Spec — Authorization
+/// </seealso>
 public interface IAccessTokenProvider
 {
     /// <summary>
-    /// Resolves an access token for the given registry authentication challenge.
+    /// Resolves an access token for the given registry authentication
+    /// challenge.
     /// </summary>
-    /// <param name="hostname">The registry hostname (authority) that issued the challenge.</param>
-    /// <param name="realm">The authentication realm URL from the WWW-Authenticate header.</param>
-    /// <param name="service">The service identifier from the WWW-Authenticate header.</param>
-    /// <param name="scopes">The requested access scopes.</param>
-    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <param name="hostname">
+    /// The registry hostname (authority) that issued the challenge.
+    /// </param>
+    /// <param name="realm">
+    /// The authentication realm URL from the WWW-Authenticate header.
+    /// </param>
+    /// <param name="service">
+    /// The service identifier from the WWW-Authenticate header.
+    /// </param>
+    /// <param name="scopes">The requested access scopes (read-only).</param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the asynchronous operation.
+    /// </param>
     /// <returns>
-    /// The access token string, or <c>null</c> if this provider cannot resolve a token
-    /// for the given parameters (in which case the client falls through to credential-based
-    /// authentication).
+    /// The access token string, or <c>null</c> / whitespace if this provider
+    /// cannot resolve a token for the given parameters (in which case the
+    /// client falls through to credential-based authentication).
     /// </returns>
     Task<string?> ResolveAccessTokenAsync(
         string hostname,
         string realm,
         string service,
-        IList<string> scopes,
+        IReadOnlyList<string> scopes,
         CancellationToken cancellationToken = default);
 }

--- a/src/OrasProject.Oras/Registry/Remote/Auth/IAccessTokenProvider.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/IAccessTokenProvider.cs
@@ -1,0 +1,57 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Provides pre-resolved access tokens for registry authentication challenges.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="ICredentialProvider"/>, which returns raw credentials that the
+/// <see cref="Client"/> exchanges at a token endpoint, an <see cref="IAccessTokenProvider"/>
+/// returns a ready-to-use access token.  This is useful when token acquisition is handled
+/// by an external service (e.g., a gRPC token service) that owns the credential exchange.
+/// </para>
+/// <para>
+/// When both <see cref="IAccessTokenProvider"/> and <see cref="ICredentialProvider"/> are
+/// configured on a <see cref="Client"/>, the access-token provider is tried first.  If it
+/// returns <c>null</c>, the client falls through to credential-based authentication.
+/// </para>
+/// </remarks>
+public interface IAccessTokenProvider
+{
+    /// <summary>
+    /// Resolves an access token for the given registry authentication challenge.
+    /// </summary>
+    /// <param name="hostname">The registry hostname (authority) that issued the challenge.</param>
+    /// <param name="realm">The authentication realm URL from the WWW-Authenticate header.</param>
+    /// <param name="service">The service identifier from the WWW-Authenticate header.</param>
+    /// <param name="scopes">The requested access scopes.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// The access token string, or <c>null</c> if this provider cannot resolve a token
+    /// for the given parameters (in which case the client falls through to credential-based
+    /// authentication).
+    /// </returns>
+    Task<string?> ResolveAccessTokenAsync(
+        string hostname,
+        string realm,
+        string service,
+        IList<string> scopes,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -2171,18 +2171,27 @@ public class ClientTest
 
         var mockProvider = new Mock<IAccessTokenProvider>();
         mockProvider
-            .Setup(p => p.ResolveAccessTokenAsync(registry, realm, service, scopes, It.IsAny<CancellationToken>()))
+            .Setup(p => p.ResolveAccessTokenAsync(
+                registry, realm, service,
+                It.Is<IReadOnlyList<string>>(
+                    s => s.SequenceEqual(scopes)),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedToken);
 
-        var client = new Client(new HttpClient(), mockProvider.Object);
+        var client = new Client(new HttpClient(), null, null,
+            mockProvider.Object, null);
 
         // Act
-        var result = await client.FetchBearerAuthAsync(registry, realm, service, scopes, CancellationToken.None);
+        var result = await client.FetchBearerAuthAsync(
+            registry, realm, service, scopes, CancellationToken.None);
 
         // Assert
         Assert.Equal(expectedToken, result);
         mockProvider.Verify(
-            p => p.ResolveAccessTokenAsync(registry, realm, service, scopes, It.IsAny<CancellationToken>()),
+            p => p.ResolveAccessTokenAsync(
+                registry, realm, service,
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -2198,34 +2207,141 @@ public class ClientTest
 
         var mockProvider = new Mock<IAccessTokenProvider>();
         mockProvider
-            .Setup(p => p.ResolveAccessTokenAsync(registry, realm, service, scopes, It.IsAny<CancellationToken>()))
+            .Setup(p => p.ResolveAccessTokenAsync(
+                registry, realm, service,
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
 
         var mockCredentialProvider = new Mock<ICredentialProvider>();
         mockCredentialProvider
-            .Setup(p => p.ResolveCredentialAsync(registry, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Credential { AccessToken = expectedToken });
+            .Setup(p => p.ResolveCredentialAsync(
+                registry, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new Credential { AccessToken = expectedToken });
 
-        var client = new Client(null, null, mockCredentialProvider.Object, mockProvider.Object);
+        var client = new Client(
+            null, null, mockCredentialProvider.Object,
+            mockProvider.Object, null);
 
         // Act
-        var result = await client.FetchBearerAuthAsync(registry, realm, service, scopes, CancellationToken.None);
+        var result = await client.FetchBearerAuthAsync(
+            registry, realm, service, scopes, CancellationToken.None);
 
         // Assert — fell through to credential-based auth
         Assert.Equal(expectedToken, result);
         mockProvider.Verify(
-            p => p.ResolveAccessTokenAsync(registry, realm, service, scopes, It.IsAny<CancellationToken>()),
+            p => p.ResolveAccessTokenAsync(
+                registry, realm, service,
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<CancellationToken>()),
             Times.Once);
         mockCredentialProvider.Verify(
-            p => p.ResolveCredentialAsync(registry, It.IsAny<CancellationToken>()),
+            p => p.ResolveCredentialAsync(
+                registry, It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public async Task FetchBearerAuth_AccessTokenProviderReturnsEmptyOrWhitespace_FallsThrough(
+        string emptyToken)
+    {
+        // Arrange
+        var registry = "example.com";
+        var realm = "https://auth.example.com/token";
+        var service = "test_service";
+        var scopes = new List<string> { "repository:repo:pull" };
+        var expectedToken = "credential-access-token";
+
+        var mockProvider = new Mock<IAccessTokenProvider>();
+        mockProvider
+            .Setup(p => p.ResolveAccessTokenAsync(
+                registry, realm, service,
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(emptyToken);
+
+        var mockCredentialProvider = new Mock<ICredentialProvider>();
+        mockCredentialProvider
+            .Setup(p => p.ResolveCredentialAsync(
+                registry, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new Credential { AccessToken = expectedToken });
+
+        var client = new Client(
+            null, null, mockCredentialProvider.Object,
+            mockProvider.Object, null);
+
+        // Act
+        var result = await client.FetchBearerAuthAsync(
+            registry, realm, service, scopes, CancellationToken.None);
+
+        // Assert — whitespace/empty triggers fallthrough
+        Assert.Equal(expectedToken, result);
+        mockCredentialProvider.Verify(
+            p => p.ResolveCredentialAsync(
+                registry, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void Client_AccessTokenProviderProperty_CanBeSetViaInitializer()
+    {
+        // The init property allows setting via object initializer.
+        var mockProvider = new Mock<IAccessTokenProvider>();
+        var client = new Client(new HttpClient())
+        {
+            AccessTokenProvider = mockProvider.Object
+        };
+
+        Assert.Same(mockProvider.Object, client.AccessTokenProvider);
+    }
+
+    [Fact]
+    public async Task FetchBearerAuth_WithBothProviders_SkipsCredentialWhenTokenResolved()
+    {
+        // Arrange — both providers configured, token provider succeeds
+        var registry = "example.com";
+        var realm = "https://auth.example.com/token";
+        var service = "test_service";
+        var scopes = new List<string> { "repository:repo:pull" };
+        var expectedToken = "provider-token";
+
+        var mockProvider = new Mock<IAccessTokenProvider>();
+        mockProvider
+            .Setup(p => p.ResolveAccessTokenAsync(
+                registry, realm, service,
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedToken);
+
+        var mockCredentialProvider = new Mock<ICredentialProvider>();
+
+        var client = new Client(
+            null, null, mockCredentialProvider.Object,
+            mockProvider.Object, null);
+
+        // Act
+        var result = await client.FetchBearerAuthAsync(
+            registry, realm, service, scopes, CancellationToken.None);
+
+        // Assert — credential provider was never consulted
+        Assert.Equal(expectedToken, result);
+        mockCredentialProvider.Verify(
+            p => p.ResolveCredentialAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
     public async Task SendAsync_WithAccessTokenProvider_BypassesCredentialResolution()
     {
-        // Arrange — a mock registry that returns 401 with a Bearer challenge,
-        // then succeeds when the expected token is presented.
+        // Arrange — a mock registry that returns 401 with a Bearer
+        // challenge, then succeeds when the expected token is
+        // presented.
         var host = "example.com";
         var expectedToken = "provider-scoped-token";
         var realm = "https://auth.example.com/token";
@@ -2236,22 +2352,30 @@ public class ClientTest
         mockProvider
             .Setup(p => p.ResolveAccessTokenAsync(
                 host, realm, service,
-                It.Is<IList<string>>(s => s.SequenceEqual(expectedScopes)),
+                It.Is<IReadOnlyList<string>>(
+                    s => s.SequenceEqual(expectedScopes)),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedToken);
 
         // No credential provider — proves we never fall through
-        HttpResponseMessage MockHttpRequestHandler(HttpRequestMessage req, CancellationToken ct)
+        HttpResponseMessage MockHttpRequestHandler(
+            HttpRequestMessage req, CancellationToken ct)
         {
-            if (req.Method == HttpMethod.Get && req.RequestUri?.Host == host)
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.Host == host)
             {
                 if (req.Headers.Authorization?.Scheme == "Bearer"
-                    && req.Headers.Authorization.Parameter == expectedToken)
+                    && req.Headers.Authorization.Parameter
+                        == expectedToken)
                 {
-                    return new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = req };
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    };
                 }
 
-                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                return new HttpResponseMessage(
+                    HttpStatusCode.Unauthorized)
                 {
                     Headers =
                     {
@@ -2259,28 +2383,40 @@ public class ClientTest
                         {
                             new AuthenticationHeaderValue(
                                 "Bearer",
-                                $"realm=\"{realm}\",service=\"{service}\",scope=\"{string.Join(" ", expectedScopes)}\"")
+                                $"realm=\"{realm}\","
+                                + $"service=\"{service}\","
+                                + $"scope=\"{string.Join(
+                                    " ", expectedScopes)}\"")
                         }
                     },
                     RequestMessage = req
                 };
             }
 
-            return new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = req };
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            };
         }
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
-        var client = new Client(new HttpClient(mockHandler.Object), mockProvider.Object);
-        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+        var client = new Client(
+            new HttpClient(mockHandler.Object), null, null,
+            mockProvider.Object, null);
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get, $"https://{host}");
 
         // Act
-        var result = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+        var result = await client.SendAsync(
+            request, cancellationToken: CancellationToken.None);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         mockProvider.Verify(
-            p => p.ResolveAccessTokenAsync(host, realm, service,
-                It.Is<IList<string>>(s => s.SequenceEqual(expectedScopes)),
+            p => p.ResolveAccessTokenAsync(
+                host, realm, service,
+                It.Is<IReadOnlyList<string>>(
+                    s => s.SequenceEqual(expectedScopes)),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -2175,6 +2175,7 @@ public class ClientTest
                 registry, realm, service,
                 It.Is<IReadOnlyList<string>>(
                     s => s.SequenceEqual(scopes)),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedToken);
 
@@ -2183,7 +2184,7 @@ public class ClientTest
 
         // Act
         var result = await client.FetchBearerAuthAsync(
-            registry, realm, service, scopes, CancellationToken.None);
+            registry, realm, service, scopes, false, CancellationToken.None);
 
         // Assert
         Assert.Equal(expectedToken, result);
@@ -2191,6 +2192,7 @@ public class ClientTest
             p => p.ResolveAccessTokenAsync(
                 registry, realm, service,
                 It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -2210,6 +2212,7 @@ public class ClientTest
             .Setup(p => p.ResolveAccessTokenAsync(
                 registry, realm, service,
                 It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
 
@@ -2226,7 +2229,7 @@ public class ClientTest
 
         // Act
         var result = await client.FetchBearerAuthAsync(
-            registry, realm, service, scopes, CancellationToken.None);
+            registry, realm, service, scopes, false, CancellationToken.None);
 
         // Assert — fell through to credential-based auth
         Assert.Equal(expectedToken, result);
@@ -2234,6 +2237,7 @@ public class ClientTest
             p => p.ResolveAccessTokenAsync(
                 registry, realm, service,
                 It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
         mockCredentialProvider.Verify(
@@ -2261,6 +2265,7 @@ public class ClientTest
             .Setup(p => p.ResolveAccessTokenAsync(
                 registry, realm, service,
                 It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(emptyToken);
 
@@ -2277,7 +2282,7 @@ public class ClientTest
 
         // Act
         var result = await client.FetchBearerAuthAsync(
-            registry, realm, service, scopes, CancellationToken.None);
+            registry, realm, service, scopes, false, CancellationToken.None);
 
         // Assert — whitespace/empty triggers fallthrough
         Assert.Equal(expectedToken, result);
@@ -2315,6 +2320,7 @@ public class ClientTest
             .Setup(p => p.ResolveAccessTokenAsync(
                 registry, realm, service,
                 It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedToken);
 
@@ -2326,7 +2332,7 @@ public class ClientTest
 
         // Act
         var result = await client.FetchBearerAuthAsync(
-            registry, realm, service, scopes, CancellationToken.None);
+            registry, realm, service, scopes, false, CancellationToken.None);
 
         // Assert — credential provider was never consulted
         Assert.Equal(expectedToken, result);
@@ -2354,6 +2360,7 @@ public class ClientTest
                 host, realm, service,
                 It.Is<IReadOnlyList<string>>(
                     s => s.SequenceEqual(expectedScopes)),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedToken);
 
@@ -2417,6 +2424,7 @@ public class ClientTest
                 host, realm, service,
                 It.Is<IReadOnlyList<string>>(
                     s => s.SequenceEqual(expectedScopes)),
+                true,
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -2158,4 +2158,130 @@ public class ClientTest
                 request,
                 cancellationToken: CancellationToken.None));
     }
+
+    [Fact]
+    public async Task FetchBearerAuth_WithAccessTokenProvider_ReturnsToken()
+    {
+        // Arrange
+        var registry = "example.com";
+        var realm = "https://auth.example.com/token";
+        var service = "test_service";
+        var scopes = new List<string> { "repository:repo:pull" };
+        var expectedToken = "access-token-from-provider";
+
+        var mockProvider = new Mock<IAccessTokenProvider>();
+        mockProvider
+            .Setup(p => p.ResolveAccessTokenAsync(registry, realm, service, scopes, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedToken);
+
+        var client = new Client(new HttpClient(), mockProvider.Object);
+
+        // Act
+        var result = await client.FetchBearerAuthAsync(registry, realm, service, scopes, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(expectedToken, result);
+        mockProvider.Verify(
+            p => p.ResolveAccessTokenAsync(registry, realm, service, scopes, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FetchBearerAuth_AccessTokenProviderReturnsNull_FallsThroughToCredential()
+    {
+        // Arrange
+        var registry = "example.com";
+        var realm = "https://auth.example.com/token";
+        var service = "test_service";
+        var scopes = new List<string> { "repository:repo:pull" };
+        var expectedToken = "credential-access-token";
+
+        var mockProvider = new Mock<IAccessTokenProvider>();
+        mockProvider
+            .Setup(p => p.ResolveAccessTokenAsync(registry, realm, service, scopes, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var mockCredentialProvider = new Mock<ICredentialProvider>();
+        mockCredentialProvider
+            .Setup(p => p.ResolveCredentialAsync(registry, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Credential { AccessToken = expectedToken });
+
+        var client = new Client(null, null, mockCredentialProvider.Object, mockProvider.Object);
+
+        // Act
+        var result = await client.FetchBearerAuthAsync(registry, realm, service, scopes, CancellationToken.None);
+
+        // Assert — fell through to credential-based auth
+        Assert.Equal(expectedToken, result);
+        mockProvider.Verify(
+            p => p.ResolveAccessTokenAsync(registry, realm, service, scopes, It.IsAny<CancellationToken>()),
+            Times.Once);
+        mockCredentialProvider.Verify(
+            p => p.ResolveCredentialAsync(registry, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithAccessTokenProvider_BypassesCredentialResolution()
+    {
+        // Arrange — a mock registry that returns 401 with a Bearer challenge,
+        // then succeeds when the expected token is presented.
+        var host = "example.com";
+        var expectedToken = "provider-scoped-token";
+        var realm = "https://auth.example.com/token";
+        var service = "test_service";
+        string[] expectedScopes = ["repository:repo1:pull"];
+
+        var mockProvider = new Mock<IAccessTokenProvider>();
+        mockProvider
+            .Setup(p => p.ResolveAccessTokenAsync(
+                host, realm, service,
+                It.Is<IList<string>>(s => s.SequenceEqual(expectedScopes)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedToken);
+
+        // No credential provider — proves we never fall through
+        HttpResponseMessage MockHttpRequestHandler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Scheme == "Bearer"
+                    && req.Headers.Authorization.Parameter == expectedToken)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = req };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Headers =
+                    {
+                        WwwAuthenticate =
+                        {
+                            new AuthenticationHeaderValue(
+                                "Bearer",
+                                $"realm=\"{realm}\",service=\"{service}\",scope=\"{string.Join(" ", expectedScopes)}\"")
+                        }
+                    },
+                    RequestMessage = req
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = req };
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(new HttpClient(mockHandler.Object), mockProvider.Object);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+
+        // Act
+        var result = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        mockProvider.Verify(
+            p => p.ResolveAccessTokenAsync(host, realm, service,
+                It.Is<IList<string>>(s => s.SequenceEqual(expectedScopes)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }


### PR DESCRIPTION
### What this PR does / why we need it

Adds an `IAccessTokenProvider` interface that allows callers to supply an external token resolution strategy (e.g., workload identity, managed identity, or custom token acquisition) without replacing the entire auth client.

When configured, the provider is consulted during bearer token fetch. If it returns a token, that token is used directly; otherwise the client falls back to the existing credential-based OAuth flow.

**Key changes:**
- New `IAccessTokenProvider` interface in `Registry.Remote.Auth`
- `Client` gains an `AccessTokenProvider` property (settable via constructor or init)
- Existing 4-parameter constructor preserved (non-breaking)
- `FetchBearerAuthAsync` integrates the provider before credential-based flow
- Scopes passed as `IReadOnlyList<string>` (immutable snapshot)

**Design decisions:**
- Provider returns `null`/empty to signal fallthrough (no exception needed)
- Scopes are snapshotted with `.ToArray()` to prevent mutation
- Provider is nullable — passing `null` is valid (no provider configured)
- Whitespace-only tokens treated as fallthrough (not cached)

### Which issue(s) this PR resolves / fixes

Fixes #371

### Please check the following list
- [x] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ] Does this change require a documentation update?
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [x] Do all new files have an appropriate license header?