### PR TITLE
feat(auth): add realm URL validation to prevent credential forwarding

### DIFF
--- a/OrasProject.Oras.sln
+++ b/OrasProject.Oras.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59

--- a/OrasProject.Oras.sln
+++ b/OrasProject.Oras.sln
@@ -12,7 +12,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrasProject.Oras.Examples.ExternalTokenBroker", "examples\OrasProject.Oras.Examples.ExternalTokenBroker\OrasProject.Oras.Examples.ExternalTokenBroker.csproj", "{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}"
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrasProject.Oras.Examples.RealmValidation", "examples\OrasProject.Oras.Examples.RealmValidation\OrasProject.Oras.Examples.RealmValidation.csproj", "{667D44C5-0DF2-4FC3-B228-0032CA585002}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrasProject.Oras.Examples.RealmValidation", "examples\OrasProject.Oras.Examples.RealmValidation\OrasProject.Oras.Examples.RealmValidation.csproj", "{667D44C5-0DF2-4FC3-B228-0032CA585002}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
 EndProject

--- a/OrasProject.Oras.sln
+++ b/OrasProject.Oras.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -12,6 +12,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrasProject.Oras.Examples.ExternalTokenBroker", "examples\OrasProject.Oras.Examples.ExternalTokenBroker\OrasProject.Oras.Examples.ExternalTokenBroker.csproj", "{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrasProject.Oras.Examples.RealmValidation", "examples\OrasProject.Oras.Examples.RealmValidation\OrasProject.Oras.Examples.RealmValidation.csproj", "{667D44C5-0DF2-4FC3-B228-0032CA585002}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
 EndProject
@@ -73,11 +74,24 @@ Global
 		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Release|x64.Build.0 = Release|Any CPU
 		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Release|x86.ActiveCfg = Release|Any CPU
 		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}.Release|x86.Build.0 = Release|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Debug|x64.Build.0 = Debug|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Debug|x86.Build.0 = Debug|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Release|Any CPU.Build.0 = Release|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Release|x64.ActiveCfg = Release|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Release|x64.Build.0 = Release|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Release|x86.ActiveCfg = Release|Any CPU
+		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
+		{667D44C5-0DF2-4FC3-B228-0032CA585002} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
 	EndGlobalSection
 EndGlobal

--- a/examples/OrasProject.Oras.Examples.RealmValidation/OrasProject.Oras.Examples.RealmValidation.csproj
+++ b/examples/OrasProject.Oras.Examples.RealmValidation/OrasProject.Oras.Examples.RealmValidation.csproj
@@ -1,0 +1,31 @@
+<!--
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+
+    <!-- Disable requiring ConfigureAwait(false) for awaited tasks -->
+    <NoWarn>CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OrasProject.Oras\OrasProject.Oras.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
+++ b/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
@@ -1,0 +1,128 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#region Usage
+using OrasProject.Oras.Registry.Remote.Auth;
+
+namespace OrasProject.Oras.Examples.RealmValidation;
+
+/// <summary>
+/// Demonstrates configuring <see cref="DefaultRealmValidator"/> and
+/// implementing a custom <see cref="IRealmValidator"/>.
+/// </summary>
+public static class RealmValidationExamples
+{
+    /// <summary>
+    /// Uses the built-in <see cref="DefaultRealmValidator"/> with custom
+    /// trusted hosts added for an enterprise environment.
+    /// </summary>
+    public static Client CreateClientWithCustomTrustedHosts()
+    {
+        // DefaultRealmValidator ships with auth.docker.io and
+        // gitlab.com pre-configured. You can override the trusted
+        // hosts to include your organization's auth endpoints.
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>
+            {
+                "auth.docker.io",
+                "gitlab.com",
+                "login.mycompany.com",
+                "auth.internal.example.com",
+            }
+        };
+
+        return new Client(new HttpClient())
+        {
+            RealmValidator = validator
+        };
+    }
+
+    /// <summary>
+    /// Uses <see cref="DefaultRealmValidator"/> with insecure HTTP
+    /// allowed — useful for local development with registries running
+    /// on localhost without TLS.
+    /// </summary>
+    public static Client CreateClientForLocalDev()
+    {
+        var validator = new DefaultRealmValidator
+        {
+            AllowInsecureHttp = true
+        };
+
+        return new Client(new HttpClient())
+        {
+            RealmValidator = validator
+        };
+    }
+
+    /// <summary>
+    /// Demonstrates a fully custom <see cref="IRealmValidator"/>
+    /// that restricts realm URLs to a specific corporate domain
+    /// suffix.
+    /// </summary>
+    public static Client CreateClientWithCustomValidator()
+    {
+        return new Client(new HttpClient())
+        {
+            RealmValidator = new CorporateDomainRealmValidator(
+                ".mycompany.com")
+        };
+    }
+}
+
+/// <summary>
+/// A custom <see cref="IRealmValidator"/> that allows realm URLs only
+/// when the host ends with a given corporate domain suffix.
+/// </summary>
+/// <remarks>
+/// This is useful in locked-down environments where all auth endpoints
+/// must reside within the corporate network.
+/// </remarks>
+public class CorporateDomainRealmValidator : IRealmValidator
+{
+    private readonly string _allowedSuffix;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    /// <param name="allowedDomainSuffix">
+    /// The required domain suffix (e.g., ".mycompany.com").
+    /// </param>
+    public CorporateDomainRealmValidator(string allowedDomainSuffix)
+    {
+        _allowedSuffix = allowedDomainSuffix.ToLowerInvariant();
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> IsRealmAllowedAsync(
+        Uri registryUri,
+        Uri realmUri,
+        CancellationToken cancellationToken = default)
+    {
+        // Only allow HTTPS.
+        if (!realmUri.Scheme.Equals(
+                Uri.UriSchemeHttps,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult(false);
+        }
+
+        // Allow if the realm host ends with our corporate domain.
+        var host = realmUri.Host.ToLowerInvariant();
+        var allowed = host.EndsWith(_allowedSuffix)
+                      || host == _allowedSuffix.TrimStart('.');
+
+        return Task.FromResult(allowed);
+    }
+}
+#endregion

--- a/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
+++ b/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
@@ -132,8 +132,8 @@ public class CorporateDomainRealmValidator : IRealmValidator
 
         // Allow if the realm host ends with our corporate domain.
         var host = realmUri.Host.ToLowerInvariant();
-        var allowed = host.EndsWith(_allowedSuffix)
-            || host == _allowedSuffix.TrimStart('.');
+        var allowed = host.EndsWith(_allowedSuffix, StringComparison.Ordinal)
+            || string.Equals(host, _allowedSuffix.TrimStart('.'), StringComparison.Ordinal);
 
         return Task.FromResult(allowed);
     }

--- a/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
+++ b/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
@@ -25,8 +25,10 @@ public static class RealmValidationExamples
     /// Uses the built-in <see cref="DefaultRealmValidator"/> with custom
     /// trusted hosts added for an enterprise environment.
     /// </summary>
-    public static Client CreateClientWithCustomTrustedHosts()
+    public static Client CreateClientWithCustomTrustedHosts(HttpClient httpClient)
     {
+        ArgumentNullException.ThrowIfNull(httpClient);
+
         // DefaultRealmValidator ships with auth.docker.io and
         // gitlab.com pre-configured. You can override the trusted
         // hosts to include your organization's auth endpoints.
@@ -41,7 +43,7 @@ public static class RealmValidationExamples
             }
         };
 
-        return new Client(new HttpClient())
+        return new Client(httpClient)
         {
             RealmValidator = validator
         };
@@ -52,14 +54,16 @@ public static class RealmValidationExamples
     /// allowed — useful for local development with registries running
     /// on localhost without TLS.
     /// </summary>
-    public static Client CreateClientForLocalDev()
+    public static Client CreateClientForLocalDev(HttpClient httpClient)
     {
+        ArgumentNullException.ThrowIfNull(httpClient);
+
         var validator = new DefaultRealmValidator
         {
             AllowInsecureHttp = true
         };
 
-        return new Client(new HttpClient())
+        return new Client(httpClient)
         {
             RealmValidator = validator
         };
@@ -70,9 +74,11 @@ public static class RealmValidationExamples
     /// that restricts realm URLs to a specific corporate domain
     /// suffix.
     /// </summary>
-    public static Client CreateClientWithCustomValidator()
+    public static Client CreateClientWithCustomValidator(HttpClient httpClient)
     {
-        return new Client(new HttpClient())
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        return new Client(httpClient)
         {
             RealmValidator = new CorporateDomainRealmValidator(
                 ".mycompany.com")
@@ -100,6 +106,13 @@ public class CorporateDomainRealmValidator : IRealmValidator
     /// </param>
     public CorporateDomainRealmValidator(string allowedDomainSuffix)
     {
+        if (string.IsNullOrWhiteSpace(allowedDomainSuffix))
+        {
+            throw new ArgumentException(
+                "Allowed domain suffix cannot be null or whitespace.",
+                nameof(allowedDomainSuffix));
+        }
+
         _allowedSuffix = allowedDomainSuffix.ToLowerInvariant();
     }
 

--- a/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
+++ b/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
@@ -120,7 +120,7 @@ public class CorporateDomainRealmValidator : IRealmValidator
         // Allow if the realm host ends with our corporate domain.
         var host = realmUri.Host.ToLowerInvariant();
         var allowed = host.EndsWith(_allowedSuffix)
-                      || host == _allowedSuffix.TrimStart('.');
+            || host == _allowedSuffix.TrimStart('.');
 
         return Task.FromResult(allowed);
     }

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -779,8 +779,7 @@ public class Client : IClient
                         .ConfigureAwait(false))
                     {
                         throw new AuthenticationException(
-                            $"Authentication realm '{realmUri}' is not allowed for registry '{registryUri.Host}'.");
-                    }
+                            $"Authentication realm '{realmUri}' is not allowed for registry '{registryUri.Authority}'.");
 
                     if (!parameters.TryGetValue("service", out var service))
                     {

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -268,8 +268,7 @@ public class Client : IClient
             ?? throw new ArgumentNullException(nameof(value));
     }
 
-    private readonly IRealmValidator _realmValidator =
-        new DefaultRealmValidator();
+    private IRealmValidator _realmValidator = new DefaultRealmValidator();
 
     /// <summary>
     /// ScopeManager is an instance to manage scopes.
@@ -780,10 +779,7 @@ public class Client : IClient
                         .ConfigureAwait(false))
                     {
                         throw new AuthenticationException(
-                            $"Authentication realm"
-                            + $" '{realmUri.Host}' is not allowed"
-                            + $" for registry"
-                            + $" '{registryUri.Host}'.");
+                            $"Authentication realm '{realmUri}' is not allowed for registry '{registryUri.Host}'.");
                     }
 
                     if (!parameters.TryGetValue("service", out var service))

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -343,6 +343,10 @@ public class Client : IClient
     /// <exception cref="KeyNotFoundException">
     /// Thrown if required parameters (e.g., "realm") are missing in the authentication challenge.
     /// </exception>
+    /// <exception cref="AuthenticationException">
+    /// Thrown when the realm URL is invalid or not allowed by
+    /// <see cref="RealmValidator"/>.
+    /// </exception>
     public Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage originalRequest,
         string? partitionId = null,

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -251,6 +251,19 @@ public class Client : IClient
     internal const long MaxBufferSize = 4 * 1024 * 1024;
 
     /// <summary>
+    /// Validates realm URLs before sending credentials to them.
+    /// Default: a <see cref="DefaultRealmValidator"/> instance with
+    /// secure defaults.
+    /// </summary>
+    /// <remarks>
+    /// This property cannot be null. To disable validation (not
+    /// recommended), provide an implementation that always returns
+    /// <c>true</c>.
+    /// </remarks>
+    public IRealmValidator RealmValidator { get; set; } =
+        new DefaultRealmValidator();
+
+    /// <summary>
     /// ScopeManager is an instance to manage scopes.
     /// </summary>
     public ScopeManager ScopeManager { get; set; } = new();
@@ -739,6 +752,30 @@ public class Client : IClient
                         // 'realm' is required as it specifies the token endpoint URL for Bearer authentication.
                         throw new KeyNotFoundException("Missing 'realm' parameter in WWW-Authenticate Bearer challenge.");
                     }
+
+                    // Validate realm URL before sending credentials.
+                    if (!Uri.TryCreate(
+                            realm, UriKind.Absolute,
+                            out var realmUri))
+                    {
+                        throw new AuthenticationException(
+                            $"Invalid realm URL: '{realm}'");
+                    }
+
+                    var registryUri = originalRequest.RequestUri!;
+                    if (!await RealmValidator.IsRealmAllowedAsync(
+                            registryUri, realmUri, cancellationToken)
+                        .ConfigureAwait(false))
+                    {
+                        throw new AuthenticationException(
+                            $"Authentication realm"
+                            + $" '{realmUri.Host}' is not allowed"
+                            + $" for registry"
+                            + $" '{registryUri.Host}'. The realm"
+                            + " host must match the registry"
+                            + " host or be explicitly trusted.");
+                    }
+
                     if (!parameters.TryGetValue("service", out var service))
                     {
                         // some registries may omit the `service` parameter; use an empty string when absent.

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -256,11 +256,19 @@ public class Client : IClient
     /// secure defaults.
     /// </summary>
     /// <remarks>
-    /// This property cannot be null. To disable validation (not
-    /// recommended), provide an implementation that always returns
-    /// <c>true</c>.
+    /// This property is init-only and cannot be null. To use a
+    /// different validator, set it during construction. To disable
+    /// validation (not recommended), provide an implementation
+    /// that always returns <c>true</c>.
     /// </remarks>
-    public IRealmValidator RealmValidator { get; set; } =
+    public IRealmValidator RealmValidator
+    {
+        get => _realmValidator;
+        init => _realmValidator = value
+            ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    private readonly IRealmValidator _realmValidator =
         new DefaultRealmValidator();
 
     /// <summary>
@@ -771,9 +779,7 @@ public class Client : IClient
                             $"Authentication realm"
                             + $" '{realmUri.Host}' is not allowed"
                             + $" for registry"
-                            + $" '{registryUri.Host}'. The realm"
-                            + " host must match the registry"
-                            + " host or be explicitly trusted.");
+                            + $" '{registryUri.Host}'.");
                     }
 
                     if (!parameters.TryGetValue("service", out var service))

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -780,6 +780,7 @@ public class Client : IClient
                     {
                         throw new AuthenticationException(
                             $"Authentication realm '{realmUri}' is not allowed for registry '{registryUri.Authority}'.");
+                    }
 
                     if (!parameters.TryGetValue("service", out var service))
                     {

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -1,0 +1,147 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Default implementation of <see cref="IRealmValidator"/> that validates
+/// realm URLs using scheme, host, and trusted-host rules.
+/// </summary>
+/// <remarks>
+/// <para>Validation rules (evaluated in order):</para>
+/// <list type="number">
+/// <item>Reject non-HTTP(S) schemes.</item>
+/// <item>Reject HTTP unless <see cref="AllowInsecureHttp"/> is true.</item>
+/// <item>Reject realm URLs containing userinfo.</item>
+/// <item>Allow if realm host matches the registry host (same host).</item>
+/// <item>Allow if realm host is in <see cref="TrustedRealmHosts"/>.</item>
+/// <item>Default deny.</item>
+/// </list>
+/// </remarks>
+public sealed class DefaultRealmValidator : IRealmValidator
+{
+    /// <summary>
+    /// When <c>true</c>, allows realm URLs with the <c>http</c> scheme
+    /// (for dev/testing only). Default: <c>false</c>.
+    /// </summary>
+    public bool AllowInsecureHttp { get; init; }
+
+    /// <summary>
+    /// Explicit set of trusted realm hostnames (case-insensitive).
+    /// Realms matching these hosts are always allowed regardless of
+    /// other rules.
+    /// </summary>
+    public ISet<string> TrustedRealmHosts { get; init; } =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public Task<bool> IsRealmAllowedAsync(
+        Uri registryUri,
+        Uri realmUri,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. Reject non-HTTP(S) schemes.
+        if (!IsHttpScheme(realmUri))
+        {
+            return Task.FromResult(false);
+        }
+
+        // 2. Reject HTTP unless explicitly allowed.
+        if (!AllowInsecureHttp
+            && string.Equals(
+                realmUri.Scheme, "http",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult(false);
+        }
+
+        // 3. Reject userinfo in realm URL.
+        if (!string.IsNullOrEmpty(realmUri.UserInfo))
+        {
+            return Task.FromResult(false);
+        }
+
+        // 4. Same host check (case-insensitive, port-aware).
+        if (IsSameHost(registryUri, realmUri))
+        {
+            return Task.FromResult(true);
+        }
+
+        // 5. Trusted realm hosts.
+        var realmHost = NormalizeHost(realmUri.Host);
+        if (TrustedRealmHosts.Contains(realmHost))
+        {
+            return Task.FromResult(true);
+        }
+
+        // 6. Default deny.
+        return Task.FromResult(false);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the URI uses http or https.
+    /// </summary>
+    private static bool IsHttpScheme(Uri uri)
+    {
+        return string.Equals(
+                   uri.Scheme, "https",
+                   StringComparison.OrdinalIgnoreCase)
+               || string.Equals(
+                   uri.Scheme, "http",
+                   StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Determines whether two URIs refer to the same host and
+    /// effective port.
+    /// </summary>
+    private static bool IsSameHost(Uri registryUri, Uri realmUri)
+    {
+        var regHost = NormalizeHost(registryUri.Host);
+        var realmHost = NormalizeHost(realmUri.Host);
+
+        if (!string.Equals(
+                regHost, realmHost,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // Compare effective ports. GetEffectivePort returns the
+        // explicit port or the default for the scheme.
+        var regPort = GetEffectivePort(registryUri);
+        var realmPort = GetEffectivePort(realmUri);
+        return regPort == realmPort;
+    }
+
+    /// <summary>
+    /// Normalizes a hostname by lowercasing and stripping trailing
+    /// dots.
+    /// </summary>
+    private static string NormalizeHost(string host)
+    {
+        return host.TrimEnd('.').ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Returns the port for the URI. For http/https URIs,
+    /// <see cref="Uri.Port"/> always returns the effective port
+    /// (explicit or scheme-default).
+    /// </summary>
+    private static int GetEffectivePort(Uri uri) => uri.Port;
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -12,7 +12,9 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -47,21 +49,36 @@ public sealed class DefaultRealmValidator : IRealmValidator
     /// other rules.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Pre-populated with well-known registries whose auth realm
     /// host differs from the registry host:
+    /// </para>
     /// <list type="bullet">
     /// <item><c>auth.docker.io</c> — Docker Hub
     /// (registry: registry-1.docker.io)</item>
     /// <item><c>gitlab.com</c> — GitLab Container Registry
     /// (registry: registry.gitlab.com)</item>
     /// </list>
+    /// <para>
+    /// Values are normalized (lowercased, trailing dots stripped)
+    /// and frozen on assignment. Mutations to the original
+    /// collection have no effect after initialization.
+    /// </para>
     /// </remarks>
-    public ISet<string> TrustedRealmHosts { get; init; } =
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "auth.docker.io",
-            "gitlab.com"
-        };
+    public IReadOnlySet<string> TrustedRealmHosts
+    {
+        get => _trustedRealmHosts;
+        init => _trustedRealmHosts =
+            (value ?? throw new ArgumentNullException(
+                nameof(value)))
+            .Select(NormalizeHost)
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private readonly IReadOnlySet<string> _trustedRealmHosts =
+        FrozenSet.ToFrozenSet(
+            new[] { "auth.docker.io", "gitlab.com" },
+            StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public Task<bool> IsRealmAllowedAsync(

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -46,8 +46,22 @@ public sealed class DefaultRealmValidator : IRealmValidator
     /// Realms matching these hosts are always allowed regardless of
     /// other rules.
     /// </summary>
+    /// <remarks>
+    /// Pre-populated with well-known registries whose auth realm
+    /// host differs from the registry host:
+    /// <list type="bullet">
+    /// <item><c>auth.docker.io</c> — Docker Hub
+    /// (registry: registry-1.docker.io)</item>
+    /// <item><c>gitlab.com</c> — GitLab Container Registry
+    /// (registry: registry.gitlab.com)</item>
+    /// </list>
+    /// </remarks>
     public ISet<string> TrustedRealmHosts { get; init; } =
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "auth.docker.io",
+            "gitlab.com"
+        };
 
     /// <inheritdoc/>
     public Task<bool> IsRealmAllowedAsync(

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -94,8 +94,8 @@ public sealed class DefaultRealmValidator : IRealmValidator
 
         // 2. Reject HTTP unless explicitly allowed.
         if (!AllowInsecureHttp
-            && string.Equals(
-                realmUri.Scheme, "http",
+            && realmUri.Scheme.Equals(
+                Uri.UriSchemeHttp,
                 StringComparison.OrdinalIgnoreCase))
         {
             return Task.FromResult(false);
@@ -129,11 +129,11 @@ public sealed class DefaultRealmValidator : IRealmValidator
     /// </summary>
     private static bool IsHttpScheme(Uri uri)
     {
-        return string.Equals(
-                   uri.Scheme, "https",
+        return uri.Scheme.Equals(
+                   Uri.UriSchemeHttps,
                    StringComparison.OrdinalIgnoreCase)
-               || string.Equals(
-                   uri.Scheme, "http",
+               || uri.Scheme.Equals(
+                   Uri.UriSchemeHttp,
                    StringComparison.OrdinalIgnoreCase);
     }
 

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -130,11 +130,11 @@ public sealed class DefaultRealmValidator : IRealmValidator
     private static bool IsHttpScheme(Uri uri)
     {
         return uri.Scheme.Equals(
-                   Uri.UriSchemeHttps,
-                   StringComparison.OrdinalIgnoreCase)
-               || uri.Scheme.Equals(
-                   Uri.UriSchemeHttp,
-                   StringComparison.OrdinalIgnoreCase);
+                Uri.UriSchemeHttps,
+                StringComparison.OrdinalIgnoreCase)
+            || uri.Scheme.Equals(
+                Uri.UriSchemeHttp,
+                StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -117,7 +117,12 @@ public sealed class DefaultRealmValidator : IRealmValidator
         var realmHost = NormalizeHost(realmUri.Host);
         if (TrustedRealmHosts.Contains(realmHost))
         {
-            return Task.FromResult(true);
+            var defaultPort = realmUri.Scheme.Equals(
+                    Uri.UriSchemeHttps,
+                    StringComparison.OrdinalIgnoreCase)
+                ? 443
+                : 80;
+            return Task.FromResult(realmUri.Port == defaultPort);
         }
 
         // 6. Default deny.

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -45,8 +45,8 @@ public sealed class DefaultRealmValidator : IRealmValidator
 
     /// <summary>
     /// Explicit set of trusted realm hostnames (case-insensitive).
-    /// Realms matching these hosts are always allowed regardless of
-    /// other rules.
+    /// Realms matching these hosts are allowed after basic URI safety
+    /// checks (scheme policy and userinfo rejection).
     /// </summary>
     /// <remarks>
     /// <para>
@@ -75,7 +75,7 @@ public sealed class DefaultRealmValidator : IRealmValidator
             .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
 
-    private readonly IReadOnlySet<string> _trustedRealmHosts =
+    private IReadOnlySet<string> _trustedRealmHosts =
         FrozenSet.ToFrozenSet(
             new[] { "auth.docker.io", "gitlab.com" },
             StringComparer.OrdinalIgnoreCase);

--- a/src/OrasProject.Oras/Registry/Remote/Auth/IRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/IRealmValidator.cs
@@ -1,0 +1,48 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Validates whether a token authentication realm URL is safe to send
+/// credentials to.
+/// </summary>
+/// <seealso href="https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#authorization">
+/// OCI Distribution Spec — Authorization
+/// </seealso>
+public interface IRealmValidator
+{
+    /// <summary>
+    /// Determines whether the specified realm URL is allowed for the
+    /// given registry.
+    /// </summary>
+    /// <param name="registryUri">
+    /// The URI of the registry that issued the challenge.
+    /// </param>
+    /// <param name="realmUri">
+    /// The realm URI from the WWW-Authenticate challenge.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <c>true</c> if credentials may be sent to the realm;
+    /// otherwise <c>false</c>.
+    /// </returns>
+    Task<bool> IsRealmAllowedAsync(
+        Uri registryUri,
+        Uri realmUri,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -731,6 +731,12 @@ public class ClientTest
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
         var client = new Client(new HttpClient(mockHandler.Object));
+        client.RealmValidator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            { "auth.example.com" }
+        };
         using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
         var cancellationToken = new CancellationToken();
 
@@ -1007,6 +1013,12 @@ public class ClientTest
         var mockHandler = CustomHandler(MockHttpRequestHandler);
 
         var client = new Client(new HttpClient(mockHandler.Object), mockCredentialProvider.Object);
+        client.RealmValidator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            { "auth.example.com" }
+        };
         client.CustomHeaders["foo"] = ["bar"];
         client.CustomHeaders["foo"].Add("abc");
         client.CustomHeaders["key1"] = ["value1"];
@@ -1130,6 +1142,12 @@ public class ClientTest
             .ReturnsAsync(new Credential { RefreshToken = refreshToken });
 
         var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object), mockCredentialProvider.Object);
+        client.RealmValidator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            { "auth.noservice.example.com" }
+        };
         // Populate scope manager to ensure scopes passed into token request
         Assert.True(Scope.TryParse(scopes[0], out var scope));
         client.ScopeManager.SetScopeForRegistry(host, scope);
@@ -1443,6 +1461,12 @@ public class ClientTest
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
         var client = new Client(new HttpClient(mockHandler.Object));
+        client.RealmValidator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            { "auth.example.com" }
+        };
 
         // Act: call port 5000
         using var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}:5000");
@@ -1811,6 +1835,12 @@ public class ClientTest
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
         var client = new Client(new HttpClient(mockHandler.Object));
+        client.RealmValidator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            { "auth.example.com" }
+        };
 
         // Use a non-seekable stream as request content
         var nonSeekableStream =
@@ -1914,6 +1944,12 @@ public class ClientTest
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
         var client = new Client(new HttpClient(mockHandler.Object));
+        client.RealmValidator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            { "auth.example.com" }
+        };
 
         // Use a seekable MemoryStream as request content
         var seekableStream = new MemoryStream(bodyContent);
@@ -2011,6 +2047,12 @@ public class ClientTest
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
         var client = new Client(new HttpClient(mockHandler.Object));
+        client.RealmValidator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            { "auth.example.com" }
+        };
 
         var nonSeekableStream =
             new NonSeekableStream(bodyContent);
@@ -2410,6 +2452,12 @@ public class ClientTest
         var client = new Client(
             new HttpClient(mockHandler.Object), null, null,
             mockProvider.Object, null);
+        client.RealmValidator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            { "auth.example.com" }
+        };
         using var request = new HttpRequestMessage(
             HttpMethod.Get, $"https://{host}");
 
@@ -2427,5 +2475,239 @@ public class ClientTest
                 true,
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+
+    [Fact]
+    public async Task SendAsync_RealmValidation_RejectsUntrustedRealm()
+    {
+        // Arrange: registry returns a Bearer challenge with an
+        // untrusted realm host.
+        var host = "victim.io";
+        var evilRealm = "https://evil.com/token";
+
+        async Task<HttpResponseMessage> MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken ct)
+        {
+            return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Headers =
+                {
+                    WwwAuthenticate =
+                    {
+                        new AuthenticationHeaderValue(
+                            "Bearer",
+                            $"realm=\"{evilRealm}\","
+                            + "service=\"test\"")
+                    }
+                },
+                RequestMessage = req
+            };
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(
+            new HttpClient(mockHandler.Object));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get, $"https://{host}/v2/");
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<AuthenticationException>(
+            () => client.SendAsync(request,
+                cancellationToken: CancellationToken.None));
+        Assert.Contains("evil.com", ex.Message);
+        Assert.Contains("not allowed", ex.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_RealmValidation_AllowsSameHost()
+    {
+        // Arrange: registry returns a Bearer challenge pointing to
+        // the same host — should be allowed.
+        var host = "myreg.io";
+        var realm = $"https://{host}/token";
+        var expectedToken = "good_token";
+
+        async Task<HttpResponseMessage> MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken ct)
+        {
+            // Token endpoint
+            if (req.RequestUri?.GetLeftPart(UriPartial.Path)
+                    .Contains("/token") == true)
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        $"{{\"access_token\":\"{expectedToken}\"}}"),
+                    RequestMessage = req
+                };
+            }
+
+            // First call returns 401
+            if (req.Headers.Authorization == null)
+            {
+                return new HttpResponseMessage(
+                    HttpStatusCode.Unauthorized)
+                {
+                    Headers =
+                    {
+                        WwwAuthenticate =
+                        {
+                            new AuthenticationHeaderValue(
+                                "Bearer",
+                                $"realm=\"{realm}\","
+                                + "service=\"test\"")
+                        }
+                    },
+                    RequestMessage = req
+                };
+            }
+
+            // Authenticated call succeeds
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                RequestMessage = req
+            };
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(
+            new HttpClient(mockHandler.Object));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get, $"https://{host}/v2/");
+
+        // Act
+        var response = await client.SendAsync(request,
+            cancellationToken: CancellationToken.None);
+
+        // Assert — no exception, request succeeded
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SendAsync_RealmValidation_InvalidRealmUrl_Throws()
+    {
+        // Arrange: registry returns a Bearer challenge with an
+        // invalid realm URL.
+        var host = "myreg.io";
+
+        async Task<HttpResponseMessage> MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken ct)
+        {
+            return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Headers =
+                {
+                    WwwAuthenticate =
+                    {
+                        new AuthenticationHeaderValue(
+                            "Bearer",
+                            "realm=\"not-a-valid-url\","
+                            + "service=\"test\"")
+                    }
+                },
+                RequestMessage = req
+            };
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(
+            new HttpClient(mockHandler.Object));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get, $"https://{host}/v2/");
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<AuthenticationException>(
+            () => client.SendAsync(request,
+                cancellationToken: CancellationToken.None));
+        Assert.Contains("Invalid realm URL", ex.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_RealmValidation_EmptyRealm_Throws()
+    {
+        // Arrange: registry returns a Bearer challenge with an
+        // empty realm string.
+        var host = "myreg.io";
+
+        async Task<HttpResponseMessage> MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken ct)
+        {
+            return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Headers =
+                {
+                    WwwAuthenticate =
+                    {
+                        new AuthenticationHeaderValue(
+                            "Bearer",
+                            "realm=\"\",service=\"test\"")
+                    }
+                },
+                RequestMessage = req
+            };
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(
+            new HttpClient(mockHandler.Object));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get, $"https://{host}/v2/");
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<AuthenticationException>(
+            () => client.SendAsync(request,
+                cancellationToken: CancellationToken.None));
+        Assert.Contains("Invalid realm URL", ex.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_RealmValidation_RelativeRealm_Throws()
+    {
+        // Arrange: registry returns a Bearer challenge with a
+        // relative realm URL.
+        var host = "myreg.io";
+
+        async Task<HttpResponseMessage> MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken ct)
+        {
+            return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Headers =
+                {
+                    WwwAuthenticate =
+                    {
+                        new AuthenticationHeaderValue(
+                            "Bearer",
+                            "realm=\"/token\","
+                            + "service=\"test\"")
+                    }
+                },
+                RequestMessage = req
+            };
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(
+            new HttpClient(mockHandler.Object));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get, $"https://{host}/v2/");
+
+        // Act & Assert — /token parses as file:///token on Linux,
+        // which is rejected by the scheme check in the validator.
+        var ex = await Assert.ThrowsAsync<AuthenticationException>(
+            () => client.SendAsync(request,
+                cancellationToken: CancellationToken.None));
+        Assert.Contains("not allowed", ex.Message);
     }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -2474,12 +2474,14 @@ public class ClientTest
         var mockHandler = CustomHandler(MockHttpRequestHandler);
         var client = new Client(
             new HttpClient(mockHandler.Object), null, null,
-            mockProvider.Object, null);
-        client.RealmValidator = new DefaultRealmValidator
+            mockProvider.Object, null)
         {
-            TrustedRealmHosts = new HashSet<string>(
-                StringComparer.OrdinalIgnoreCase)
-            { "auth.example.com" }
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                { "auth.example.com" }
+            }
         };
         using var request = new HttpRequestMessage(
             HttpMethod.Get, $"https://{host}");

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -2535,7 +2535,7 @@ public class ClientTest
         var client = new Client(
             new HttpClient(mockHandler.Object));
 
-        var request = new HttpRequestMessage(
+        using var request = new HttpRequestMessage(
             HttpMethod.Get, $"https://{host}/v2/");
 
         // Act & Assert
@@ -2602,7 +2602,7 @@ public class ClientTest
         var client = new Client(
             new HttpClient(mockHandler.Object));
 
-        var request = new HttpRequestMessage(
+        using var request = new HttpRequestMessage(
             HttpMethod.Get, $"https://{host}/v2/");
 
         // Act
@@ -2644,7 +2644,7 @@ public class ClientTest
         var client = new Client(
             new HttpClient(mockHandler.Object));
 
-        var request = new HttpRequestMessage(
+        using var request = new HttpRequestMessage(
             HttpMethod.Get, $"https://{host}/v2/");
 
         // Act & Assert
@@ -2684,7 +2684,7 @@ public class ClientTest
         var client = new Client(
             new HttpClient(mockHandler.Object));
 
-        var request = new HttpRequestMessage(
+        using var request = new HttpRequestMessage(
             HttpMethod.Get, $"https://{host}/v2/");
 
         // Act & Assert
@@ -2725,7 +2725,7 @@ public class ClientTest
         var client = new Client(
             new HttpClient(mockHandler.Object));
 
-        var request = new HttpRequestMessage(
+        using var request = new HttpRequestMessage(
             HttpMethod.Get, $"https://{host}/v2/");
 
         // Act & Assert — /token parses as file:///token on Linux,

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -730,12 +730,14 @@ public class ClientTest
         }
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
-        var client = new Client(new HttpClient(mockHandler.Object));
-        client.RealmValidator = new DefaultRealmValidator
+        var client = new Client(new HttpClient(mockHandler.Object))
         {
-            TrustedRealmHosts = new HashSet<string>(
-                StringComparer.OrdinalIgnoreCase)
-            { "auth.example.com" }
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                { "auth.example.com" }
+            }
         };
         using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
         var cancellationToken = new CancellationToken();
@@ -1012,12 +1014,14 @@ public class ClientTest
             });
         var mockHandler = CustomHandler(MockHttpRequestHandler);
 
-        var client = new Client(new HttpClient(mockHandler.Object), mockCredentialProvider.Object);
-        client.RealmValidator = new DefaultRealmValidator
+        var client = new Client(new HttpClient(mockHandler.Object), mockCredentialProvider.Object)
         {
-            TrustedRealmHosts = new HashSet<string>(
-                StringComparer.OrdinalIgnoreCase)
-            { "auth.example.com" }
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                { "auth.example.com" }
+            }
         };
         client.CustomHeaders["foo"] = ["bar"];
         client.CustomHeaders["foo"].Add("abc");
@@ -1141,12 +1145,14 @@ public class ClientTest
             .Setup(p => p.ResolveCredentialAsync(host, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Credential { RefreshToken = refreshToken });
 
-        var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object), mockCredentialProvider.Object);
-        client.RealmValidator = new DefaultRealmValidator
+        var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object), mockCredentialProvider.Object)
         {
-            TrustedRealmHosts = new HashSet<string>(
-                StringComparer.OrdinalIgnoreCase)
-            { "auth.noservice.example.com" }
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                { "auth.noservice.example.com" }
+            }
         };
         // Populate scope manager to ensure scopes passed into token request
         Assert.True(Scope.TryParse(scopes[0], out var scope));
@@ -1268,7 +1274,16 @@ public class ClientTest
                 Password = password
             });
         var mockHandler = CustomHandler(MockHttpRequestHandler);
-        var client = new Client(new HttpClient(mockHandler.Object), mockCredentialProvider.Object);
+
+        var client = new Client(new HttpClient(mockHandler.Object), mockCredentialProvider.Object)
+        {
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                { "auth.example.com" }
+            }
+        };
         client.CustomHeaders["foo"] = ["bar"];
         client.CustomHeaders["foo"].Add("abc");
         client.CustomHeaders["key1"] = ["value1"];
@@ -1460,12 +1475,14 @@ public class ClientTest
         }
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
-        var client = new Client(new HttpClient(mockHandler.Object));
-        client.RealmValidator = new DefaultRealmValidator
+        var client = new Client(new HttpClient(mockHandler.Object))
         {
-            TrustedRealmHosts = new HashSet<string>(
-                StringComparer.OrdinalIgnoreCase)
-            { "auth.example.com" }
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                { "auth.example.com" }
+            }
         };
 
         // Act: call port 5000
@@ -1834,12 +1851,14 @@ public class ClientTest
         }
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
-        var client = new Client(new HttpClient(mockHandler.Object));
-        client.RealmValidator = new DefaultRealmValidator
+        var client = new Client(new HttpClient(mockHandler.Object))
         {
-            TrustedRealmHosts = new HashSet<string>(
-                StringComparer.OrdinalIgnoreCase)
-            { "auth.example.com" }
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                { "auth.example.com" }
+            }
         };
 
         // Use a non-seekable stream as request content
@@ -1943,12 +1962,14 @@ public class ClientTest
         }
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
-        var client = new Client(new HttpClient(mockHandler.Object));
-        client.RealmValidator = new DefaultRealmValidator
+        var client = new Client(new HttpClient(mockHandler.Object))
         {
-            TrustedRealmHosts = new HashSet<string>(
-                StringComparer.OrdinalIgnoreCase)
-            { "auth.example.com" }
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                { "auth.example.com" }
+            }
         };
 
         // Use a seekable MemoryStream as request content
@@ -2046,12 +2067,14 @@ public class ClientTest
         }
 
         var mockHandler = CustomHandler(MockHttpRequestHandler);
-        var client = new Client(new HttpClient(mockHandler.Object));
-        client.RealmValidator = new DefaultRealmValidator
+        var client = new Client(new HttpClient(mockHandler.Object))
         {
-            TrustedRealmHosts = new HashSet<string>(
-                StringComparer.OrdinalIgnoreCase)
-            { "auth.example.com" }
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                { "auth.example.com" }
+            }
         };
 
         var nonSeekableStream =

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
@@ -302,16 +302,22 @@ public class DefaultRealmValidatorTest
     [Fact]
     public async Task TrustedHostNotAffectedBySchemeBlock()
     {
-        // Trusted host with HTTPS is allowed.
-        var validator = new DefaultRealmValidator
-        {
-            TrustedRealmHosts = new HashSet<string>(
-                StringComparer.OrdinalIgnoreCase)
-            { "auth.docker.io" }
-        };
+        // Docker Hub: auth.docker.io is in the default trusted
+        // list — works without explicit TrustedRealmHosts.
+        var validator = new DefaultRealmValidator();
         Assert.True(await validator.IsRealmAllowedAsync(
             Reg("https://registry-1.docker.io/v2/"),
             Realm("https://auth.docker.io/token")));
+    }
+
+    [Fact]
+    public async Task GitLabRegistry_DefaultTrusted_Allowed()
+    {
+        // GitLab: gitlab.com is in the default trusted list.
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://registry.gitlab.com/v2/"),
+            Realm("https://gitlab.com/jwt/auth")));
     }
 
     [Fact]

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
@@ -330,4 +330,205 @@ public class DefaultRealmValidatorTest
     }
 
     #endregion
+
+    #region Adversarial — immutability & mutation resistance
+
+    [Fact]
+    public async Task TrustedHosts_FrozenAfterInit_MutationHasNoEffect()
+    {
+        // Arrange: pass a mutable HashSet, then mutate it after
+        // construction.
+        var mutable = new HashSet<string>(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            "auth.example.com"
+        };
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = mutable
+        };
+
+        // Act: mutate the original collection.
+        mutable.Add("evil.com");
+
+        // Assert: the validator is unaffected.
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm("https://evil.com/token")));
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://registry.example.com/v2/"),
+            Realm("https://auth.example.com/token")));
+    }
+
+    [Fact]
+    public void TrustedHosts_NullAssignment_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new DefaultRealmValidator
+            {
+                TrustedRealmHosts = null!
+            });
+    }
+
+    [Fact]
+    public async Task TrustedHosts_TrailingDotNormalized()
+    {
+        // Trailing dot in the configured set should still match.
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>
+            {
+                "auth.example.com."
+            }
+        };
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://registry.example.com/v2/"),
+            Realm("https://auth.example.com/token")));
+    }
+
+    [Fact]
+    public async Task TrustedHosts_IsReadOnly()
+    {
+        var validator = new DefaultRealmValidator();
+        // IReadOnlySet does not expose Add/Remove — compile-time
+        // safety. At runtime, FrozenSet throws on mutation
+        // attempts via ICollection<T>.
+        Assert.IsAssignableFrom<IReadOnlySet<string>>(
+            validator.TrustedRealmHosts);
+    }
+
+    #endregion
+
+    #region Adversarial — attack patterns
+
+    [Fact]
+    public async Task FragmentInjection_HostStillEvil_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        // Fragment doesn't change the host.
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm("https://evil.com/token#victim.io")));
+    }
+
+    [Fact]
+    public async Task QueryInjection_HostStillEvil_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm(
+                "https://evil.com/token?host=victim.io")));
+    }
+
+    [Fact]
+    public async Task IPv6SameHost_Allowed()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://[::1]/v2/"),
+            Realm("https://[::1]/token")));
+    }
+
+    [Fact]
+    public async Task IPv6DifferentHost_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://[::1]/v2/"),
+            Realm("https://[::2]/token")));
+    }
+
+    [Fact]
+    public async Task PortSmuggling_SamePortDifferentHost_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io:8443/v2/"),
+            Realm("https://evil.com:8443/token")));
+    }
+
+    [Fact]
+    public async Task UserinfoOnTrustedHost_Rejected()
+    {
+        // Userinfo check fires before trusted host check.
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://registry-1.docker.io/v2/"),
+            Realm(
+                "https://user@auth.docker.io/token")));
+    }
+
+    [Fact]
+    public async Task HttpOnTrustedHost_RejectedByDefault()
+    {
+        // HTTP scheme block applies even to trusted hosts.
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://registry-1.docker.io/v2/"),
+            Realm("http://auth.docker.io/token")));
+    }
+
+    [Fact]
+    public async Task AtSignInPath_NotConfusedAsUserinfo()
+    {
+        // '@' in path segment is valid and should not be
+        // confused with userinfo.
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io/v2/"),
+            Realm("https://myreg.io/auth@v2/token")));
+    }
+
+    [Fact]
+    public async Task SuperstringHostname_Rejected()
+    {
+        // "auth.docker.io.evil.com" is NOT "auth.docker.io"
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://registry-1.docker.io/v2/"),
+            Realm(
+                "https://auth.docker.io.evil.com/tok"
+                )));
+    }
+
+    [Fact]
+    public async Task EmptyTrustedHosts_OnlySameHostAllowed()
+    {
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts =
+                new HashSet<string>()
+        };
+        // Same host still allowed.
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io/v2/"),
+            Realm("https://myreg.io/token")));
+        // Docker Hub realm rejected without trusted list.
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://registry-1.docker.io/v2/"),
+            Realm("https://auth.docker.io/token")));
+    }
+
+    #endregion
+
+    #region Adversarial — Client null guard
+
+    [Fact]
+    public void Client_RealmValidator_NullAssignment_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new Client { RealmValidator = null! });
+    }
+
+    [Fact]
+    public void Client_RealmValidator_HasDefault()
+    {
+        var client = new Client();
+        Assert.NotNull(client.RealmValidator);
+        Assert.IsType<DefaultRealmValidator>(
+            client.RealmValidator);
+    }
+
+    #endregion
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
@@ -1,0 +1,327 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OrasProject.Oras.Registry.Remote.Auth;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Registry.Remote.Auth;
+
+public class DefaultRealmValidatorTest
+{
+    private static Uri Reg(string url) => new(url);
+    private static Uri Realm(string url) => new(url);
+
+    #region Must ALLOW
+
+    [Fact]
+    public async Task SameHostExactly_Allowed()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io/v2/"),
+            Realm("https://myreg.io/token")));
+    }
+
+    [Fact]
+    public async Task SameHostDifferentPath_Allowed()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io/v2/"),
+            Realm("https://myreg.io/v2/auth")));
+    }
+
+    [Fact]
+    public async Task SameHostDefaultPort_Allowed()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io:443/v2/"),
+            Realm("https://myreg.io/token")));
+    }
+
+    [Fact]
+    public async Task TrustedHost_Allowed()
+    {
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://registry.example.com/v2/"),
+            Realm("https://auth.example.com/token")));
+    }
+
+    [Fact]
+    public async Task CaseInsensitiveHost_Allowed()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://MyReg.IO/v2/"),
+            Realm("https://myreg.io/token")));
+    }
+
+    [Fact]
+    public async Task HttpRealm_AllowedWhenInsecureEnabled()
+    {
+        var validator = new DefaultRealmValidator
+        {
+            AllowInsecureHttp = true
+        };
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("http://localhost/v2/"),
+            Realm("http://localhost/token")));
+    }
+
+    [Fact]
+    public async Task IpLiteralSameHost_Allowed()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://192.168.1.5/v2/"),
+            Realm("https://192.168.1.5/token")));
+    }
+
+    [Fact]
+    public async Task SameHostExplicitSamePort_Allowed()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io:8443/v2/"),
+            Realm("https://myreg.io:8443/token")));
+    }
+
+    [Fact]
+    public async Task TrailingDotNormalized_Allowed()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io./v2/"),
+            Realm("https://myreg.io/token")));
+    }
+
+    #endregion
+
+    #region Must REJECT
+
+    [Fact]
+    public async Task DifferentDomain_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm("https://evil.com/token")));
+    }
+
+    [Fact]
+    public async Task HttpScheme_RejectedByDefault()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm("http://victim.io/token")));
+    }
+
+    [Fact]
+    public async Task NonHttpScheme_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm("file:///etc/passwd")));
+    }
+
+    [Fact]
+    public async Task UserinfoInRealm_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm("https://user:pass@victim.io/token")));
+    }
+
+    [Fact]
+    public async Task SubdomainTrick_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm("https://victim.io.evil.com/token")));
+    }
+
+    [Fact]
+    public async Task RegistryHostAsPathSegment_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm("https://evil.com/victim.io/token")));
+    }
+
+    [Fact]
+    public async Task DifferentIpLiteral_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://192.168.1.5/v2/"),
+            Realm("https://192.168.1.6/token")));
+    }
+
+    [Fact]
+    public async Task DifferentPort_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io:8443/v2/"),
+            Realm("https://myreg.io:9443/token")));
+    }
+
+    [Fact]
+    public async Task FtpScheme_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm("ftp://victim.io/token")));
+    }
+
+    #endregion
+
+    #region Edge cases
+
+    [Fact]
+    public async Task TrustedHostCaseInsensitive_Allowed()
+    {
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "AUTH.EXAMPLE.COM"
+            }
+        };
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://registry.example.com/v2/"),
+            Realm("https://auth.example.com/token")));
+    }
+
+    [Fact]
+    public async Task DefaultPortExplicit443VsImplicit_Allowed()
+    {
+        var validator = new DefaultRealmValidator();
+        // Explicit 443 on realm, implicit on registry
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io/v2/"),
+            Realm("https://myreg.io:443/token")));
+    }
+
+    [Fact]
+    public async Task NonDefaultPort_MatchRequired()
+    {
+        var validator = new DefaultRealmValidator();
+        // Registry on :5000, realm on default → reject
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io:5000/v2/"),
+            Realm("https://myreg.io/token")));
+    }
+
+    [Fact]
+    public async Task HttpInsecure_SameHost_Allowed()
+    {
+        var validator = new DefaultRealmValidator
+        {
+            AllowInsecureHttp = true
+        };
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("http://localhost:5000/v2/"),
+            Realm("http://localhost:5000/token")));
+    }
+
+    [Fact]
+    public async Task HttpInsecure_DifferentHost_Rejected()
+    {
+        var validator = new DefaultRealmValidator
+        {
+            AllowInsecureHttp = true
+        };
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("http://localhost:5000/v2/"),
+            Realm("http://evil.com/token")));
+    }
+
+    [Fact]
+    public async Task HttpInsecure_SameHost_DifferentPort_Rejected()
+    {
+        var validator = new DefaultRealmValidator
+        {
+            AllowInsecureHttp = true
+        };
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("http://localhost:5000/v2/"),
+            Realm("http://localhost:6000/token")));
+    }
+
+    [Fact]
+    public async Task UserinfoOnSameHost_Rejected()
+    {
+        // Userinfo must be rejected even if the host matches.
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io/v2/"),
+            Realm("https://user:pass@myreg.io/token")));
+    }
+
+    [Fact]
+    public async Task HttpScheme_SameHost_RejectedByDefault()
+    {
+        // HTTP realm on same host is still rejected unless
+        // AllowInsecureHttp is true.
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://myreg.io/v2/"),
+            Realm("http://myreg.io/token")));
+    }
+
+    [Fact]
+    public async Task TrustedHostNotAffectedBySchemeBlock()
+    {
+        // Trusted host with HTTPS is allowed.
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            { "auth.docker.io" }
+        };
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://registry-1.docker.io/v2/"),
+            Realm("https://auth.docker.io/token")));
+    }
+
+    [Fact]
+    public async Task DataScheme_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://victim.io/v2/"),
+            Realm("data:text/plain;base64,abc")));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
This PR adds realm URL validation to the authentication flow to prevent credential forwarding attacks.

## Changes

1. **feat(auth): add realm URL validation to prevent credential forwarding** — Core validation logic that checks the realm URL before sending credentials.
2. **feat(auth): add curated TrustedRealmHosts defaults** — Provides a default set of trusted realm hosts for common registries.
3. **fix(auth): harden realm validator — FrozenSet, init-only, adversarial tests** — Hardening with immutable collections, init-only properties, and adversarial test cases.
4. **docs: add realm validation example, exception docs, and use Uri scheme constants** — Documentation and examples for the new feature.

## Security

This addresses a credential forwarding vulnerability where a malicious registry could redirect authentication to an attacker-controlled realm URL, causing the client to send credentials to an unintended endpoint.