### PR TITLE
fix: preserve opaque bearer challenge scopes

### DIFF
--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -837,11 +837,13 @@ public class Client : IClient
                 {
                     if (!copiedStructuredScopes)
                     {
-                        structuredScopes = CloneStructuredScopes(existingScopes);
+                        // Copy before merging so an attacker-controllable challenge scope
+                        // cannot mutate the client's persisted scopes for this host.
+                        structuredScopes = new SortedSet<Scope>(existingScopes);
                         copiedStructuredScopes = true;
                     }
 
-                    Scope.AddOrMergeScope(structuredScopes, scope);
+                    Scope.AddOrMergeScopeCopyOnWrite(structuredScopes, scope);
                 }
                 else
                 {
@@ -858,16 +860,6 @@ public class Client : IClient
             tokenRequestScopes,
             cacheKey,
             hasOpaqueScopes: opaqueScopes != null);
-    }
-
-    private static SortedSet<Scope> CloneStructuredScopes(SortedSet<Scope> scopes)
-    {
-        var clonedScopes = new SortedSet<Scope>();
-        foreach (var scope in scopes)
-        {
-            clonedScopes.Add(scope.Clone());
-        }
-        return clonedScopes;
     }
 
     private static List<string> BuildTokenRequestScopes(

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -763,7 +763,8 @@ public class Client : IClient
                     // Validate realm URL before sending credentials.
                     if (!Uri.TryCreate(
                             realm, UriKind.Absolute,
-                            out var realmUri))
+                            out var realmUri)
+                        || string.IsNullOrEmpty(realmUri.Host))
                     {
                         throw new AuthenticationException(
                             $"Invalid realm URL: '{realm}'");

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -730,21 +730,17 @@ public class Client : IClient
                     }
 
                     var existingScopes = ScopeManager.GetScopesForHost(host);
-                    var newScopes = new SortedSet<Scope>(existingScopes);
-                    if (parameters.TryGetValue("scope", out var scopesString))
-                    {
-                        foreach (var scopeStr in scopesString.Split(' ', StringSplitOptions.RemoveEmptyEntries))
-                        {
-                            if (Scope.TryParse(scopeStr, out var scope))
-                            {
-                                Scope.AddOrMergeScope(newScopes, scope);
-                            }
-                        }
-                    }
+                    var (newScopes, opaqueScopes) = MergeChallengeScopes(
+                        existingScopes,
+                        parameters.TryGetValue("scope", out var scopesString)
+                            ? scopesString
+                            : null);
+                    var tokenRequestScopes = GetTokenRequestScopes(newScopes, opaqueScopes);
 
                     // Attempt to send request when the scope changes and a token cache hits
                     var newKey = string.Join(" ", newScopes);
-                    if (newKey != attemptedKey &&
+                    if (opaqueScopes.Count == 0 &&
+                        newKey != attemptedKey &&
                         Cache.TryGetToken(host, schemeFromChallenge, newKey, out var cachedToken, partitionId))
                     {
                         var requestAttempt2 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
@@ -793,11 +789,14 @@ public class Client : IClient
                         host,
                         realm,
                         service,
-                        newScopes.Select(newScope => newScope.ToString()).ToList(),
+                        tokenRequestScopes,
                         forceRefresh: true,
                         cancellationToken
                     ).ConfigureAwait(false);
-                    Cache.SetCache(host, schemeFromChallenge, newKey, bearerAuthToken, partitionId);
+                    if (opaqueScopes.Count == 0)
+                    {
+                        Cache.SetCache(host, schemeFromChallenge, newKey, bearerAuthToken, partitionId);
+                    }
 
                     var requestAttempt3 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
                     requestAttempt3.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerAuthToken);
@@ -806,6 +805,48 @@ public class Client : IClient
             default:
                 return response1;
         }
+    }
+
+    private static (SortedSet<Scope> StructuredScopes, List<string> OpaqueScopes) MergeChallengeScopes(
+        SortedSet<Scope> existingScopes,
+        string? scopesString)
+    {
+        var structuredScopes = new SortedSet<Scope>(existingScopes);
+        var opaqueScopes = new HashSet<string>(StringComparer.Ordinal);
+
+        if (string.IsNullOrWhiteSpace(scopesString))
+        {
+            return (structuredScopes, []);
+        }
+
+        foreach (var scopeStr in scopesString.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (Scope.TryParse(scopeStr, out var scope))
+            {
+                Scope.AddOrMergeScope(structuredScopes, scope);
+            }
+            else
+            {
+                opaqueScopes.Add(scopeStr);
+            }
+        }
+
+        return (structuredScopes, opaqueScopes.OrderBy(scope => scope, StringComparer.Ordinal).ToList());
+    }
+
+    private static List<string> GetTokenRequestScopes(
+        IEnumerable<Scope> structuredScopes,
+        IEnumerable<string> opaqueScopes)
+    {
+        return structuredScopes
+            .Select(scope => scope.ToString())
+            .Where(scope => !string.IsNullOrWhiteSpace(scope))
+            .Distinct(StringComparer.Ordinal)
+            .Concat(opaqueScopes
+                .Where(scope => !string.IsNullOrWhiteSpace(scope))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(scope => scope, StringComparer.Ordinal))
+            .ToList();
     }
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -879,32 +879,25 @@ public class Client : IClient
         var tokenRequestScopes =
             new List<string>(structuredScopes.Count + opaqueScopeCount);
 
-        // The cache key is derived from structured scopes only. When opaque scopes
-        // are present the token is not cached, so the key is left empty.
-        var cacheKeyBuilder = opaqueScopeCount > 0 ? null : new StringBuilder();
         foreach (var scope in structuredScopes)
         {
-            var scopeString = scope.ToString();
-            tokenRequestScopes.Add(scopeString);
-            if (cacheKeyBuilder == null)
-            {
-                continue;
-            }
-
-            if (cacheKeyBuilder.Length > 0)
-            {
-                cacheKeyBuilder.Append(' ');
-            }
-
-            cacheKeyBuilder.Append(scopeString);
+            tokenRequestScopes.Add(scope.ToString());
         }
+
+        // The cache key is derived from structured scopes only and must match the
+        // single-space canonicalization used for the cached-token lookup. When opaque
+        // scopes are present the token is not cached, so the key is left empty. At this
+        // point tokenRequestScopes holds only the structured scopes, so it can be joined
+        // directly before the opaque scopes are appended.
+        cacheKey = opaqueScopeCount > 0
+            ? string.Empty
+            : string.Join(' ', tokenRequestScopes);
 
         if (opaqueScopes != null)
         {
             tokenRequestScopes.AddRange(opaqueScopes);
         }
 
-        cacheKey = cacheKeyBuilder?.ToString() ?? string.Empty;
         return tokenRequestScopes;
     }
 

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -821,8 +821,12 @@ public class Client : IClient
         string? scopesString)
     {
         var structuredScopes = existingScopes;
-        var hasOpaqueScopes = false;
         var copiedStructuredScopes = false;
+
+        // Opaque (unparseable) challenge scopes are preserved verbatim, including
+        // duplicates and original order. The list is allocated lazily so the common
+        // structured-only case stays allocation-free.
+        List<string>? opaqueScopes = null;
 
         if (!string.IsNullOrWhiteSpace(scopesString))
         {
@@ -841,17 +845,19 @@ public class Client : IClient
                 }
                 else
                 {
-                    hasOpaqueScopes = true;
+                    (opaqueScopes ??= new()).Add(scopeSpan.ToString());
                 }
             }
         }
 
         var tokenRequestScopes = BuildTokenRequestScopes(
             structuredScopes,
-            scopesString,
-            hasOpaqueScopes,
+            opaqueScopes,
             out var cacheKey);
-        return new MergedScopes(tokenRequestScopes, cacheKey, hasOpaqueScopes);
+        return new MergedScopes(
+            tokenRequestScopes,
+            cacheKey,
+            hasOpaqueScopes: opaqueScopes != null);
     }
 
     private static SortedSet<Scope> CloneStructuredScopes(SortedSet<Scope> scopes)
@@ -866,12 +872,16 @@ public class Client : IClient
 
     private static List<string> BuildTokenRequestScopes(
         SortedSet<Scope> structuredScopes,
-        string? scopesString,
-        bool hasOpaqueScopes,
+        List<string>? opaqueScopes,
         out string cacheKey)
     {
-        var tokenRequestScopes = new List<string>(structuredScopes.Count);
-        var cacheKeyBuilder = hasOpaqueScopes ? null : new StringBuilder();
+        var opaqueScopeCount = opaqueScopes?.Count ?? 0;
+        var tokenRequestScopes =
+            new List<string>(structuredScopes.Count + opaqueScopeCount);
+
+        // The cache key is derived from structured scopes only. When opaque scopes
+        // are present the token is not cached, so the key is left empty.
+        var cacheKeyBuilder = opaqueScopeCount > 0 ? null : new StringBuilder();
         foreach (var scope in structuredScopes)
         {
             var scopeString = scope.ToString();
@@ -889,16 +899,9 @@ public class Client : IClient
             cacheKeyBuilder.Append(scopeString);
         }
 
-        if (hasOpaqueScopes && !string.IsNullOrWhiteSpace(scopesString))
+        if (opaqueScopes != null)
         {
-            var remainingScopes = scopesString.AsSpan();
-            while (TryReadNextScope(ref remainingScopes, out var scopeSpan))
-            {
-                if (!Scope.IsParseable(scopeSpan))
-                {
-                    tokenRequestScopes.Add(scopeSpan.ToString());
-                }
-            }
+            tokenRequestScopes.AddRange(opaqueScopes);
         }
 
         cacheKey = cacheKeyBuilder?.ToString() ?? string.Empty;

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -813,7 +813,7 @@ public class Client : IClient
         string? scopesString)
     {
         var structuredScopes = new SortedSet<Scope>(existingScopes);
-        var opaqueScopes = new HashSet<string>(StringComparer.Ordinal);
+        var opaqueScopes = new List<string>();
 
         if (string.IsNullOrWhiteSpace(scopesString))
         {
@@ -832,7 +832,7 @@ public class Client : IClient
             }
         }
 
-        return (structuredScopes, opaqueScopes.OrderBy(scope => scope, StringComparer.Ordinal).ToList());
+        return (structuredScopes, opaqueScopes);
     }
 
     private static List<string> GetTokenRequestScopes(
@@ -841,12 +841,7 @@ public class Client : IClient
     {
         return structuredScopes
             .Select(scope => scope.ToString())
-            .Where(scope => !string.IsNullOrWhiteSpace(scope))
-            .Distinct(StringComparer.Ordinal)
-            .Concat(opaqueScopes
-                .Where(scope => !string.IsNullOrWhiteSpace(scope))
-                .Distinct(StringComparer.Ordinal)
-                .OrderBy(scope => scope, StringComparer.Ordinal))
+            .Concat(opaqueScopes)
             .ToList();
     }
 

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -730,18 +730,21 @@ public class Client : IClient
                     }
 
                     var existingScopes = ScopeManager.GetScopesForHost(host);
-                    var (newScopes, opaqueScopes) = MergeChallengeScopes(
+                    var mergedScopes = MergeChallengeScopes(
                         existingScopes,
                         parameters.TryGetValue("scope", out var scopesString)
                             ? scopesString
                             : null);
-                    var tokenRequestScopes = GetTokenRequestScopes(newScopes, opaqueScopes);
 
                     // Attempt to send request when the scope changes and a token cache hits
-                    var newKey = string.Join(" ", newScopes);
-                    if (opaqueScopes.Count == 0 &&
-                        newKey != attemptedKey &&
-                        Cache.TryGetToken(host, schemeFromChallenge, newKey, out var cachedToken, partitionId))
+                    if (!mergedScopes.HasOpaqueScopes
+                        && mergedScopes.CacheKey != attemptedKey
+                        && Cache.TryGetToken(
+                            host,
+                            schemeFromChallenge,
+                            mergedScopes.CacheKey,
+                            out var cachedToken,
+                            partitionId))
                     {
                         var requestAttempt2 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
                         requestAttempt2.Headers.Authorization = new AuthenticationHeaderValue("Bearer", cachedToken);
@@ -790,13 +793,18 @@ public class Client : IClient
                         host,
                         realm,
                         service,
-                        tokenRequestScopes,
+                        mergedScopes.TokenRequestScopes,
                         forceRefresh: true,
                         cancellationToken
                     ).ConfigureAwait(false);
-                    if (opaqueScopes.Count == 0)
+                    if (!mergedScopes.HasOpaqueScopes)
                     {
-                        Cache.SetCache(host, schemeFromChallenge, newKey, bearerAuthToken, partitionId);
+                        Cache.SetCache(
+                            host,
+                            schemeFromChallenge,
+                            mergedScopes.CacheKey,
+                            bearerAuthToken,
+                            partitionId);
                     }
 
                     var requestAttempt3 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
@@ -808,41 +816,106 @@ public class Client : IClient
         }
     }
 
-    private static (SortedSet<Scope> StructuredScopes, List<string> OpaqueScopes) MergeChallengeScopes(
+    private static MergedScopes MergeChallengeScopes(
         SortedSet<Scope> existingScopes,
         string? scopesString)
     {
         var structuredScopes = new SortedSet<Scope>(existingScopes);
-        var opaqueScopes = new List<string>();
+        var tokenRequestScopes = new List<string>();
+        var hasOpaqueScopes = false;
 
-        if (string.IsNullOrWhiteSpace(scopesString))
+        if (!string.IsNullOrWhiteSpace(scopesString))
         {
-            return (structuredScopes, []);
+            var remainingScopes = scopesString.AsSpan();
+            while (!remainingScopes.IsEmpty)
+            {
+                var separatorIndex = remainingScopes.IndexOf(' ');
+                var scopeSpan = separatorIndex < 0
+                    ? remainingScopes
+                    : remainingScopes[..separatorIndex];
+                remainingScopes = separatorIndex < 0
+                    ? []
+                    : remainingScopes[(separatorIndex + 1)..];
+
+                if (scopeSpan.IsEmpty)
+                {
+                    continue;
+                }
+
+                if (Scope.TryParse(scopeSpan, out var scope))
+                {
+                    Scope.AddOrMergeScope(structuredScopes, scope);
+                }
+                else
+                {
+                    tokenRequestScopes.Add(scopeSpan.ToString());
+                    hasOpaqueScopes = true;
+                }
+            }
         }
 
-        foreach (var scopeStr in scopesString.Split(' ', StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (Scope.TryParse(scopeStr, out var scope))
-            {
-                Scope.AddOrMergeScope(structuredScopes, scope);
-            }
-            else
-            {
-                opaqueScopes.Add(scopeStr);
-            }
-        }
-
-        return (structuredScopes, opaqueScopes);
+        var cacheKey = PrependStructuredScopes(tokenRequestScopes, structuredScopes);
+        return new MergedScopes(tokenRequestScopes, cacheKey, hasOpaqueScopes);
     }
 
-    private static List<string> GetTokenRequestScopes(
-        IEnumerable<Scope> structuredScopes,
-        IEnumerable<string> opaqueScopes)
+    private static string PrependStructuredScopes(
+        List<string> tokenRequestScopes,
+        SortedSet<Scope> structuredScopes)
     {
-        return structuredScopes
-            .Select(scope => scope.ToString())
-            .Concat(opaqueScopes)
-            .ToList();
+        if (structuredScopes.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var opaqueScopeCount = tokenRequestScopes.Count;
+        var structuredScopeCount = structuredScopes.Count;
+        tokenRequestScopes.Capacity = Math.Max(
+            tokenRequestScopes.Capacity,
+            opaqueScopeCount + structuredScopeCount);
+
+        for (var i = 0; i < structuredScopeCount; i++)
+        {
+            tokenRequestScopes.Add(string.Empty);
+        }
+
+        for (var i = opaqueScopeCount - 1; i >= 0; i--)
+        {
+            tokenRequestScopes[i + structuredScopeCount] = tokenRequestScopes[i];
+        }
+
+        var cacheKeyBuilder = new StringBuilder();
+        var tokenScopeIndex = 0;
+        foreach (var scope in structuredScopes)
+        {
+            var scopeString = scope.ToString();
+            tokenRequestScopes[tokenScopeIndex++] = scopeString;
+            if (cacheKeyBuilder.Length > 0)
+            {
+                cacheKeyBuilder.Append(' ');
+            }
+            cacheKeyBuilder.Append(scopeString);
+        }
+
+        return cacheKeyBuilder.ToString();
+    }
+
+    private readonly struct MergedScopes
+    {
+        public MergedScopes(
+            List<string> tokenRequestScopes,
+            string cacheKey,
+            bool hasOpaqueScopes)
+        {
+            TokenRequestScopes = tokenRequestScopes;
+            CacheKey = cacheKey;
+            HasOpaqueScopes = hasOpaqueScopes;
+        }
+
+        public List<string> TokenRequestScopes { get; }
+
+        public string CacheKey { get; }
+
+        public bool HasOpaqueScopes { get; }
     }
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -821,28 +821,14 @@ public class Client : IClient
         string? scopesString)
     {
         var structuredScopes = existingScopes;
-        var tokenRequestScopes = new List<string>();
         var hasOpaqueScopes = false;
         var copiedStructuredScopes = false;
 
         if (!string.IsNullOrWhiteSpace(scopesString))
         {
             var remainingScopes = scopesString.AsSpan();
-            while (!remainingScopes.IsEmpty)
+            while (TryReadNextScope(ref remainingScopes, out var scopeSpan))
             {
-                var separatorIndex = remainingScopes.IndexOf(' ');
-                var scopeSpan = separatorIndex < 0
-                    ? remainingScopes
-                    : remainingScopes[..separatorIndex];
-                remainingScopes = separatorIndex < 0
-                    ? []
-                    : remainingScopes[(separatorIndex + 1)..];
-
-                if (scopeSpan.IsEmpty)
-                {
-                    continue;
-                }
-
                 if (Scope.TryParse(scopeSpan, out var scope))
                 {
                     if (!copiedStructuredScopes)
@@ -855,13 +841,16 @@ public class Client : IClient
                 }
                 else
                 {
-                    tokenRequestScopes.Add(scopeSpan.ToString());
                     hasOpaqueScopes = true;
                 }
             }
         }
 
-        var cacheKey = PrependStructuredScopes(tokenRequestScopes, structuredScopes);
+        var tokenRequestScopes = BuildTokenRequestScopes(
+            structuredScopes,
+            scopesString,
+            hasOpaqueScopes,
+            out var cacheKey);
         return new MergedScopes(tokenRequestScopes, cacheKey, hasOpaqueScopes);
     }
 
@@ -875,45 +864,69 @@ public class Client : IClient
         return clonedScopes;
     }
 
-    private static string PrependStructuredScopes(
-        List<string> tokenRequestScopes,
-        SortedSet<Scope> structuredScopes)
+    private static List<string> BuildTokenRequestScopes(
+        SortedSet<Scope> structuredScopes,
+        string? scopesString,
+        bool hasOpaqueScopes,
+        out string cacheKey)
     {
-        if (structuredScopes.Count == 0)
-        {
-            return string.Empty;
-        }
-
-        var opaqueScopeCount = tokenRequestScopes.Count;
-        var structuredScopeCount = structuredScopes.Count;
-        tokenRequestScopes.Capacity = Math.Max(
-            tokenRequestScopes.Capacity,
-            opaqueScopeCount + structuredScopeCount);
-
-        for (var i = 0; i < structuredScopeCount; i++)
-        {
-            tokenRequestScopes.Add(string.Empty);
-        }
-
-        for (var i = opaqueScopeCount - 1; i >= 0; i--)
-        {
-            tokenRequestScopes[i + structuredScopeCount] = tokenRequestScopes[i];
-        }
-
-        var cacheKeyBuilder = new StringBuilder();
-        var tokenScopeIndex = 0;
+        var tokenRequestScopes = new List<string>(structuredScopes.Count);
+        var cacheKeyBuilder = hasOpaqueScopes ? null : new StringBuilder();
         foreach (var scope in structuredScopes)
         {
             var scopeString = scope.ToString();
-            tokenRequestScopes[tokenScopeIndex++] = scopeString;
+            tokenRequestScopes.Add(scopeString);
+            if (cacheKeyBuilder == null)
+            {
+                continue;
+            }
+
             if (cacheKeyBuilder.Length > 0)
             {
                 cacheKeyBuilder.Append(' ');
             }
+
             cacheKeyBuilder.Append(scopeString);
         }
 
-        return cacheKeyBuilder.ToString();
+        if (hasOpaqueScopes && !string.IsNullOrWhiteSpace(scopesString))
+        {
+            var remainingScopes = scopesString.AsSpan();
+            while (TryReadNextScope(ref remainingScopes, out var scopeSpan))
+            {
+                if (!Scope.IsParseable(scopeSpan))
+                {
+                    tokenRequestScopes.Add(scopeSpan.ToString());
+                }
+            }
+        }
+
+        cacheKey = cacheKeyBuilder?.ToString() ?? string.Empty;
+        return tokenRequestScopes;
+    }
+
+    private static bool TryReadNextScope(
+        ref ReadOnlySpan<char> remainingScopes,
+        out ReadOnlySpan<char> scope)
+    {
+        while (!remainingScopes.IsEmpty)
+        {
+            var separatorIndex = remainingScopes.IndexOf(' ');
+            scope = separatorIndex < 0
+                ? remainingScopes
+                : remainingScopes[..separatorIndex];
+            remainingScopes = separatorIndex < 0
+                ? []
+                : remainingScopes[(separatorIndex + 1)..];
+
+            if (!scope.IsEmpty)
+            {
+                return true;
+            }
+        }
+
+        scope = [];
+        return false;
     }
 
     private readonly struct MergedScopes

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -847,7 +847,7 @@ public class Client : IClient
                 {
                     if (!copiedStructuredScopes)
                     {
-                        structuredScopes = new SortedSet<Scope>(existingScopes);
+                        structuredScopes = CloneStructuredScopes(existingScopes);
                         copiedStructuredScopes = true;
                     }
 
@@ -863,6 +863,16 @@ public class Client : IClient
 
         var cacheKey = PrependStructuredScopes(tokenRequestScopes, structuredScopes);
         return new MergedScopes(tokenRequestScopes, cacheKey, hasOpaqueScopes);
+    }
+
+    private static SortedSet<Scope> CloneStructuredScopes(SortedSet<Scope> scopes)
+    {
+        var clonedScopes = new SortedSet<Scope>();
+        foreach (var scope in scopes)
+        {
+            clonedScopes.Add(scope.Clone());
+        }
+        return clonedScopes;
     }
 
     private static string PrependStructuredScopes(

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -820,9 +820,10 @@ public class Client : IClient
         SortedSet<Scope> existingScopes,
         string? scopesString)
     {
-        var structuredScopes = new SortedSet<Scope>(existingScopes);
+        var structuredScopes = existingScopes;
         var tokenRequestScopes = new List<string>();
         var hasOpaqueScopes = false;
+        var copiedStructuredScopes = false;
 
         if (!string.IsNullOrWhiteSpace(scopesString))
         {
@@ -844,6 +845,12 @@ public class Client : IClient
 
                 if (Scope.TryParse(scopeSpan, out var scope))
                 {
+                    if (!copiedStructuredScopes)
+                    {
+                        structuredScopes = new SortedSet<Scope>(existingScopes);
+                        copiedStructuredScopes = true;
+                    }
+
                     Scope.AddOrMergeScope(structuredScopes, scope);
                 }
                 else

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -824,8 +824,8 @@ public class Client : IClient
         var copiedStructuredScopes = false;
 
         // Opaque (unparseable) challenge scopes are preserved verbatim, including
-        // duplicates and original order. The list is allocated lazily so the common
-        // structured-only case stays allocation-free.
+        // duplicates and original order. The opaque list is allocated lazily so
+        // the common structured-only case doesn't allocate it.
         List<string>? opaqueScopes = null;
 
         if (!string.IsNullOrWhiteSpace(scopesString))

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
@@ -117,27 +117,11 @@ public class Scope : IComparable<Scope>
     internal static bool TryParse(ReadOnlySpan<char> scopeSpan, [NotNullWhen(true)] out Scope? scope)
     {
         scope = null;
-        scopeSpan = scopeSpan.Trim();
-        if (scopeSpan.IsEmpty)
-        {
-            return false;
-        }
-
-        var firstSeparator = scopeSpan.IndexOf(':');
-        if (firstSeparator < 0 || scopeSpan[..firstSeparator].Trim().IsEmpty)
-        {
-            return false;
-        }
-
-        var remainingScope = scopeSpan[(firstSeparator + 1)..];
-        var secondSeparator = remainingScope.IndexOf(':');
-        if (secondSeparator < 0 || remainingScope[..secondSeparator].Trim().IsEmpty)
-        {
-            return false;
-        }
-
-        var actionSpan = remainingScope[(secondSeparator + 1)..];
-        if (actionSpan.Trim().IsEmpty || actionSpan.Contains(':'))
+        if (!TryGetScopeParts(
+                scopeSpan,
+                out var resourceType,
+                out var resourceName,
+                out var actionSpan))
         {
             return false;
         }
@@ -154,10 +138,58 @@ public class Scope : IComparable<Scope>
         }
 
         scope = new Scope(
-            scopeSpan[..firstSeparator].Trim().ToString(),
-            remainingScope[..secondSeparator].Trim().ToString(),
+            resourceType.ToString(),
+            resourceName.ToString(),
             actions);
         return true;
+    }
+
+    internal static bool IsParseable(ReadOnlySpan<char> scopeSpan)
+    {
+        return TryGetScopeParts(
+                scopeSpan,
+                out _,
+                out _,
+                out var actionSpan)
+            && AreActionsParseable(actionSpan);
+    }
+
+    private static bool TryGetScopeParts(
+        ReadOnlySpan<char> scopeSpan,
+        out ReadOnlySpan<char> resourceType,
+        out ReadOnlySpan<char> resourceName,
+        out ReadOnlySpan<char> actions)
+    {
+        resourceType = [];
+        resourceName = [];
+        actions = [];
+
+        scopeSpan = scopeSpan.Trim();
+        if (scopeSpan.IsEmpty)
+        {
+            return false;
+        }
+
+        var firstSeparator = scopeSpan.IndexOf(':');
+        if (firstSeparator < 0)
+        {
+            return false;
+        }
+
+        var remainingScope = scopeSpan[(firstSeparator + 1)..];
+        var secondSeparator = remainingScope.IndexOf(':');
+        if (secondSeparator < 0)
+        {
+            return false;
+        }
+
+        resourceType = scopeSpan[..firstSeparator].Trim();
+        resourceName = remainingScope[..secondSeparator].Trim();
+        actions = remainingScope[(secondSeparator + 1)..];
+        return !resourceType.IsEmpty
+            && !resourceName.IsEmpty
+            && !actions.Trim().IsEmpty
+            && !actions.Contains(':');
     }
 
     private static bool TryParseActions(
@@ -179,6 +211,28 @@ public class Scope : IComparable<Scope>
             }
 
             actions.Add(action.ToString());
+
+            if (separatorIndex < 0)
+            {
+                return true;
+            }
+
+            actionSpan = actionSpan[(separatorIndex + 1)..];
+        }
+    }
+
+    private static bool AreActionsParseable(ReadOnlySpan<char> actionSpan)
+    {
+        while (true)
+        {
+            var separatorIndex = actionSpan.IndexOf(',');
+            var action = separatorIndex < 0
+                ? actionSpan
+                : actionSpan[..separatorIndex];
+            if (action.Trim().IsEmpty)
+            {
+                return false;
+            }
 
             if (separatorIndex < 0)
             {

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
@@ -116,25 +116,29 @@ public class Scope : IComparable<Scope>
         }
 
         var firstSeparator = scopeSpan.IndexOf(':');
-        if (firstSeparator < 0)
+        if (firstSeparator < 0 || scopeSpan[..firstSeparator].Trim().IsEmpty)
         {
             return false;
         }
 
         var remainingScope = scopeSpan[(firstSeparator + 1)..];
         var secondSeparator = remainingScope.IndexOf(':');
-        if (secondSeparator < 0)
+        if (secondSeparator < 0 || remainingScope[..secondSeparator].Trim().IsEmpty)
         {
             return false;
         }
 
         var actionSpan = remainingScope[(secondSeparator + 1)..];
-        if (actionSpan.Contains(':'))
+        if (actionSpan.Trim().IsEmpty || actionSpan.Contains(':'))
         {
             return false;
         }
 
-        var actions = ParseActions(actionSpan);
+        if (!TryParseActions(actionSpan, out var actions))
+        {
+            return false;
+        }
+
         if (actions.Contains(ActionWildcard))
         {
             actions.Clear();
@@ -148,20 +152,29 @@ public class Scope : IComparable<Scope>
         return true;
     }
 
-    private static HashSet<string> ParseActions(ReadOnlySpan<char> actionSpan)
+    private static bool TryParseActions(
+        ReadOnlySpan<char> actionSpan,
+        [NotNullWhen(true)] out HashSet<string>? actions)
     {
-        var actions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        actions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         while (true)
         {
             var separatorIndex = actionSpan.IndexOf(',');
             var action = separatorIndex < 0
                 ? actionSpan
                 : actionSpan[..separatorIndex];
-            actions.Add(action.Trim().ToString());
+            action = action.Trim();
+            if (action.IsEmpty)
+            {
+                actions = null;
+                return false;
+            }
+
+            actions.Add(action.ToString());
 
             if (separatorIndex < 0)
             {
-                return actions;
+                return true;
             }
 
             actionSpan = actionSpan[(separatorIndex + 1)..];

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
@@ -144,16 +144,6 @@ public class Scope : IComparable<Scope>
         return true;
     }
 
-    internal static bool IsParseable(ReadOnlySpan<char> scopeSpan)
-    {
-        return TryGetScopeParts(
-                scopeSpan,
-                out _,
-                out _,
-                out var actionSpan)
-            && AreActionsParseable(actionSpan);
-    }
-
     private static bool TryGetScopeParts(
         ReadOnlySpan<char> scopeSpan,
         out ReadOnlySpan<char> resourceType,
@@ -211,28 +201,6 @@ public class Scope : IComparable<Scope>
             }
 
             actions.Add(action.ToString());
-
-            if (separatorIndex < 0)
-            {
-                return true;
-            }
-
-            actionSpan = actionSpan[(separatorIndex + 1)..];
-        }
-    }
-
-    private static bool AreActionsParseable(ReadOnlySpan<char> actionSpan)
-    {
-        while (true)
-        {
-            var separatorIndex = actionSpan.IndexOf(',');
-            var action = separatorIndex < 0
-                ? actionSpan
-                : actionSpan[..separatorIndex];
-            if (action.Trim().IsEmpty)
-            {
-                return false;
-            }
 
             if (separatorIndex < 0)
             {

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
@@ -256,17 +256,8 @@ public class Scope : IComparable<Scope>
     {
         if (scopes.TryGetValue(newScope, out var existingScope))
         {
-            if (existingScope.Actions.Contains(ActionWildcard) || newScope.Actions.Contains(ActionWildcard))
-            {
-                // If either scope has the wildcard '*', clear and add '*'
-                existingScope.Actions.Clear();
-                existingScope.Actions.Add(ActionWildcard);
-            }
-            else
-            {
-                // Otherwise, union the actions
-                existingScope.Actions.UnionWith(newScope.Actions);
-            }
+            // Mutates the matched scope in place.
+            MergeActions(existingScope, newScope);
         }
         else
         {
@@ -274,6 +265,45 @@ public class Scope : IComparable<Scope>
             scopes.Add(newScope);
         }
         return scopes;
+    }
+
+    /// <summary>
+    /// AddOrMergeScopeCopyOnWrite merges <paramref name="newScope"/> into <paramref name="scopes"/> without
+    /// mutating any existing <see cref="Scope"/> instance: a matched scope is replaced with a merged clone. This
+    /// lets callers merge into a shallow set copy whose <see cref="Scope"/> instances are shared with another set.
+    /// </summary>
+    /// <param name="scopes">A sorted set of existing scopes.</param>
+    /// <param name="newScope">The new scope to add or merge.</param>
+    internal static void AddOrMergeScopeCopyOnWrite(SortedSet<Scope> scopes, Scope newScope)
+    {
+        if (scopes.TryGetValue(newScope, out var existingScope))
+        {
+            // Copy-on-write: replace the shared existing scope with a merged clone
+            // rather than mutating it in place.
+            scopes.Remove(existingScope);
+            var mergedScope = existingScope.Clone();
+            MergeActions(mergedScope, newScope);
+            scopes.Add(mergedScope);
+        }
+        else
+        {
+            scopes.Add(newScope);
+        }
+    }
+
+    private static void MergeActions(Scope target, Scope source)
+    {
+        if (target.Actions.Contains(ActionWildcard) || source.Actions.Contains(ActionWildcard))
+        {
+            // If either scope has the wildcard '*', clear and add '*'
+            target.Actions.Clear();
+            target.Actions.Add(ActionWildcard);
+        }
+        else
+        {
+            // Otherwise, union the actions
+            target.Actions.UnionWith(source.Actions);
+        }
     }
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
@@ -73,6 +73,14 @@ public class Scope : IComparable<Scope>
         Actions = actions;
     }
 
+    internal Scope Clone()
+    {
+        return new Scope(
+            ResourceType,
+            ResourceName,
+            new HashSet<string>(Actions, Actions.Comparer));
+    }
+
     /// <summary>
     /// ToString converts the scope to its string representation in the format:
     /// "ResourceType:ResourceName:Action1,Action2,...".

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
@@ -97,27 +97,75 @@ public class Scope : IComparable<Scope>
     /// <returns><c>true</c> if the parsing succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryParse(string scopeStr, [NotNullWhen(true)] out Scope? scope)
     {
-        scope = null;
         if (string.IsNullOrWhiteSpace(scopeStr))
         {
+            scope = null;
             return false;
         }
 
-        var parts = scopeStr.Split(':', StringSplitOptions.TrimEntries);
-        if (parts.Length != 3)
+        return TryParse(scopeStr.AsSpan(), out scope);
+    }
+
+    internal static bool TryParse(ReadOnlySpan<char> scopeSpan, [NotNullWhen(true)] out Scope? scope)
+    {
+        scope = null;
+        scopeSpan = scopeSpan.Trim();
+        if (scopeSpan.IsEmpty)
         {
             return false;
         }
 
-        var actions = parts[2].Split(',', StringSplitOptions.TrimEntries).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var firstSeparator = scopeSpan.IndexOf(':');
+        if (firstSeparator < 0)
+        {
+            return false;
+        }
+
+        var remainingScope = scopeSpan[(firstSeparator + 1)..];
+        var secondSeparator = remainingScope.IndexOf(':');
+        if (secondSeparator < 0)
+        {
+            return false;
+        }
+
+        var actionSpan = remainingScope[(secondSeparator + 1)..];
+        if (actionSpan.Contains(':'))
+        {
+            return false;
+        }
+
+        var actions = ParseActions(actionSpan);
         if (actions.Contains(ActionWildcard))
         {
             actions.Clear();
             actions.Add(ActionWildcard);
         }
 
-        scope = new Scope(parts[0], parts[1], actions);
+        scope = new Scope(
+            scopeSpan[..firstSeparator].Trim().ToString(),
+            remainingScope[..secondSeparator].Trim().ToString(),
+            actions);
         return true;
+    }
+
+    private static HashSet<string> ParseActions(ReadOnlySpan<char> actionSpan)
+    {
+        var actions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        while (true)
+        {
+            var separatorIndex = actionSpan.IndexOf(',');
+            var action = separatorIndex < 0
+                ? actionSpan
+                : actionSpan[..separatorIndex];
+            actions.Add(action.Trim().ToString());
+
+            if (separatorIndex < 0)
+            {
+                return actions;
+            }
+
+            actionSpan = actionSpan[(separatorIndex + 1)..];
+        }
     }
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ScopeManager.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ScopeManager.cs
@@ -112,14 +112,34 @@ public class ScopeManager
     /// <param name="scope">The scope to be set for the registry, including its actions.</param>
     public void SetScopeForRegistry(string registry, Scope scope)
     {
-        if (scope.Actions.Contains(Scope.ActionWildcard))
-        {
-            scope.Actions.Clear();
-            scope.Actions.Add(Scope.ActionWildcard);
-        }
-
         Scopes.AddOrUpdate(registry,
-            new SortedSet<Scope> { scope },
-            (_, existingScopes) => Scope.AddOrMergeScope(existingScopes, scope));
+            _ => new SortedSet<Scope> { CloneAndNormalizeScope(scope) },
+            (_, existingScopes) =>
+            {
+                var updatedScopes = CloneScopes(existingScopes);
+                Scope.AddOrMergeScope(updatedScopes, CloneAndNormalizeScope(scope));
+                return updatedScopes;
+            });
+    }
+
+    private static SortedSet<Scope> CloneScopes(SortedSet<Scope> scopes)
+    {
+        var clonedScopes = new SortedSet<Scope>();
+        foreach (var scope in scopes)
+        {
+            clonedScopes.Add(scope.Clone());
+        }
+        return clonedScopes;
+    }
+
+    private static Scope CloneAndNormalizeScope(Scope scope)
+    {
+        var clonedScope = scope.Clone();
+        if (clonedScope.Actions.Contains(Scope.ActionWildcard))
+        {
+            clonedScope.Actions.Clear();
+            clonedScope.Actions.Add(Scope.ActionWildcard);
+        }
+        return clonedScope;
     }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -1183,7 +1183,7 @@ public class ClientTest
         var expectedToken = "opaque_scope_token";
         var tokenRequestCount = 0;
 
-        async Task<HttpResponseMessage> MockHttpRequestHandler(
+        HttpResponseMessage MockHttpRequestHandler(
             HttpRequestMessage req,
             CancellationToken cancellationToken = default)
         {
@@ -1269,7 +1269,7 @@ public class ClientTest
         var tokenRequestCount = 0;
         var currentToken = string.Empty;
 
-        async Task<HttpResponseMessage> MockHttpRequestHandler(
+        HttpResponseMessage MockHttpRequestHandler(
             HttpRequestMessage req,
             CancellationToken cancellationToken = default)
         {
@@ -1439,7 +1439,7 @@ public class ClientTest
             "repository:redis-extra:pull"
         };
 
-        async Task<HttpResponseMessage> MockHttpRequestHandler(
+        HttpResponseMessage MockHttpRequestHandler(
             HttpRequestMessage req,
             CancellationToken cancellationToken = default)
         {
@@ -1532,7 +1532,7 @@ public class ClientTest
         var expectedToken = "mixed_scope_token";
         var tokenRequestCount = 0;
 
-        async Task<HttpResponseMessage> MockHttpRequestHandler(
+        HttpResponseMessage MockHttpRequestHandler(
             HttpRequestMessage req,
             CancellationToken cancellationToken = default)
         {
@@ -3163,11 +3163,10 @@ public class ClientTest
         using var request = new HttpRequestMessage(
             HttpMethod.Get, $"https://{host}/v2/");
 
-        // Act & Assert — /token parses as file:///token on Linux,
-        // which is rejected by the scheme check in the validator.
+        // Act & Assert
         var ex = await Assert.ThrowsAsync<AuthenticationException>(
             () => client.SendAsync(request,
                 cancellationToken: CancellationToken.None));
-        Assert.Contains("not allowed", ex.Message);
+        Assert.Contains("Invalid realm URL", ex.Message);
     }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -1172,6 +1172,441 @@ public class ClientTest
     }
 
     [Fact]
+    public async Task SendAsync_UnauthorizedResponse_PreservesOpaqueChallengeScope()
+    {
+        // Arrange
+        var host = "example.com";
+        var realm = $"https://{host}/token";
+        var service = "test_service";
+        var structuredScope = "repository:docker/library/redis:pull";
+        var opaqueScope = "aws";
+        var expectedToken = "opaque_scope_token";
+        var tokenRequestCount = 0;
+
+        async Task<HttpResponseMessage> MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.AbsoluteUri.StartsWith(realm, StringComparison.Ordinal) == true)
+            {
+                tokenRequestCount++;
+                var query = System.Web.HttpUtility.ParseQueryString(req.RequestUri.Query);
+                var requestedScopes = query.GetValues("scope") ?? [];
+
+                if (query["service"] == service
+                    && requestedScopes.OrderBy(scope => scope, StringComparer.Ordinal)
+                        .SequenceEqual(new[] { opaqueScope, structuredScope }))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent($"{{\"token\": \"{expectedToken}\"}}"),
+                        RequestMessage = req
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    RequestMessage = req
+                };
+            }
+
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Scheme == "Bearer"
+                    && req.Headers.Authorization.Parameter == expectedToken)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Headers =
+                    {
+                        WwwAuthenticate =
+                        {
+                            new AuthenticationHeaderValue(
+                                "Bearer",
+                                $"realm=\"{realm}\",service=\"{service}\",scope=\"{opaqueScope}\"")
+                        }
+                    },
+                    RequestMessage = req
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            };
+        }
+
+        var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object));
+        Assert.True(Scope.TryParse(structuredScope, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, tokenRequestCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_UnauthorizedResponse_DoesNotCacheOpaqueChallengeScopeToken()
+    {
+        // Arrange
+        var host = "example.com";
+        var realm = $"https://{host}/token";
+        var service = "test_service";
+        var structuredScope = "repository:docker/library/redis:pull";
+        var opaqueScope = "aws";
+        var tokenRequestCount = 0;
+        var currentToken = string.Empty;
+
+        async Task<HttpResponseMessage> MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.AbsoluteUri.StartsWith(realm, StringComparison.Ordinal) == true)
+            {
+                var query = System.Web.HttpUtility.ParseQueryString(req.RequestUri.Query);
+                var requestedScopes = query.GetValues("scope") ?? [];
+                if (query["service"] != service
+                    || !requestedScopes.OrderBy(scope => scope, StringComparer.Ordinal)
+                        .SequenceEqual(new[] { opaqueScope, structuredScope }))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                    {
+                        RequestMessage = req
+                    };
+                }
+
+                currentToken = $"opaque_scope_token_{++tokenRequestCount}";
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent($"{{\"token\": \"{currentToken}\"}}"),
+                    RequestMessage = req
+                };
+            }
+
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Scheme == "Bearer"
+                    && req.Headers.Authorization.Parameter == currentToken)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Headers =
+                    {
+                        WwwAuthenticate =
+                        {
+                            new AuthenticationHeaderValue(
+                                "Bearer",
+                                $"realm=\"{realm}\",service=\"{service}\",scope=\"{opaqueScope}\"")
+                        }
+                    },
+                    RequestMessage = req
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            };
+        }
+
+        var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object));
+        Assert.True(Scope.TryParse(structuredScope, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+
+        // Act
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+        var response1 = await client.SendAsync(request1, cancellationToken: CancellationToken.None);
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+        var response2 = await client.SendAsync(request2, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+        Assert.Equal(2, tokenRequestCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_AccessTokenProviderReceivesOpaqueChallengeScope()
+    {
+        // Arrange
+        var host = "example.com";
+        var realm = $"https://{host}/token";
+        var service = "test_service";
+        var structuredScope = "repository:docker/library/redis:pull";
+        var opaqueScope = "aws";
+        var expectedToken = "provider_opaque_scope_token";
+
+        var mockProvider = new Mock<IAccessTokenProvider>();
+        mockProvider
+            .Setup(provider => provider.ResolveAccessTokenAsync(
+                host,
+                realm,
+                service,
+                It.Is<IReadOnlyList<string>>(scopes =>
+                    scopes.OrderBy(scope => scope, StringComparer.Ordinal)
+                        .SequenceEqual(new[] { opaqueScope, structuredScope })),
+                true,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedToken);
+
+        HttpResponseMessage MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Scheme == "Bearer"
+                    && req.Headers.Authorization.Parameter == expectedToken)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Headers =
+                    {
+                        WwwAuthenticate =
+                        {
+                            new AuthenticationHeaderValue(
+                                "Bearer",
+                                $"realm=\"{realm}\",service=\"{service}\",scope=\"{opaqueScope}\"")
+                        }
+                    },
+                    RequestMessage = req
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            };
+        }
+
+        var client = new Client(
+            new HttpClient(CustomHandler(MockHttpRequestHandler).Object),
+            noRedirectHttpClient: null,
+            credentialProvider: null,
+            accessTokenProvider: mockProvider.Object,
+            cache: null);
+        Assert.True(Scope.TryParse(structuredScope, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        mockProvider.VerifyAll();
+    }
+
+    [Fact]
+    public async Task SendAsync_UnauthorizedResponse_PreservesStructuredScopeCacheKeyOrder()
+    {
+        // Arrange
+        var host = "example.com";
+        var realm = $"https://{host}/token";
+        var service = "test_service";
+        var expectedToken = "structured_scope_token";
+        var tokenRequestCount = 0;
+        var expectedScopes = new[]
+        {
+            "repository:redis:pull",
+            "repository:redis-extra:pull"
+        };
+
+        async Task<HttpResponseMessage> MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.AbsoluteUri.StartsWith(realm, StringComparison.Ordinal) == true)
+            {
+                tokenRequestCount++;
+                var query = System.Web.HttpUtility.ParseQueryString(req.RequestUri.Query);
+                var requestedScopes = query.GetValues("scope") ?? [];
+
+                if (query["service"] == service
+                    && requestedScopes.OrderBy(scope => scope, StringComparer.Ordinal)
+                        .SequenceEqual(expectedScopes.OrderBy(scope => scope, StringComparer.Ordinal)))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent($"{{\"token\": \"{expectedToken}\"}}"),
+                        RequestMessage = req
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    RequestMessage = req
+                };
+            }
+
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Scheme == "Bearer"
+                    && req.Headers.Authorization.Parameter == expectedToken)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Headers =
+                    {
+                        WwwAuthenticate =
+                        {
+                            new AuthenticationHeaderValue(
+                                "Bearer",
+                                $"realm=\"{realm}\",service=\"{service}\"")
+                        }
+                    },
+                    RequestMessage = req
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            };
+        }
+
+        var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object));
+        foreach (var scopeString in expectedScopes)
+        {
+            Assert.True(Scope.TryParse(scopeString, out var scope));
+            client.ScopeManager.SetScopeForRegistry(host, scope);
+        }
+
+        // Act
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+        var response1 = await client.SendAsync(request1, cancellationToken: CancellationToken.None);
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+        var response2 = await client.SendAsync(request2, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+        Assert.Equal(1, tokenRequestCount);
+    }
+
+    [Fact]
+    public async Task SendAsync_UnauthorizedResponse_PreservesMixedChallengeScopes()
+    {
+        // Arrange
+        var host = "example.com";
+        var realm = $"https://{host}/token";
+        var service = "test_service";
+        var structuredScope = "repository:docker/library/redis:pull";
+        var challengeStructuredScope = "repository:docker/library/redis:push";
+        var opaqueScope = "aws";
+        var expectedToken = "mixed_scope_token";
+        var tokenRequestCount = 0;
+
+        async Task<HttpResponseMessage> MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.AbsoluteUri.StartsWith(realm, StringComparison.Ordinal) == true)
+            {
+                tokenRequestCount++;
+                var query = System.Web.HttpUtility.ParseQueryString(req.RequestUri.Query);
+                var requestedScopes = query.GetValues("scope") ?? [];
+
+                if (query["service"] == service
+                    && requestedScopes.OrderBy(scope => scope, StringComparer.Ordinal)
+                        .SequenceEqual(new[] { opaqueScope, "repository:docker/library/redis:pull,push" }))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent($"{{\"token\": \"{expectedToken}\"}}"),
+                        RequestMessage = req
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    RequestMessage = req
+                };
+            }
+
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Scheme == "Bearer"
+                    && req.Headers.Authorization.Parameter == expectedToken)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Headers =
+                    {
+                        WwwAuthenticate =
+                        {
+                            new AuthenticationHeaderValue(
+                                "Bearer",
+                                $"realm=\"{realm}\",service=\"{service}\",scope=\"{opaqueScope} {challengeStructuredScope}\"")
+                        }
+                    },
+                    RequestMessage = req
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            };
+        }
+
+        var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object));
+        Assert.True(Scope.TryParse(structuredScope, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, tokenRequestCount);
+    }
+
+    [Fact]
     public async Task SendAsync_BearerChallengeMissingRealm_ThrowsKeyNotFoundException()
     {
         // Arrange

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -1179,7 +1179,7 @@ public class ClientTest
         var realm = $"https://{host}/token";
         var service = "test_service";
         var structuredScope = "repository:docker/library/redis:pull";
-        var opaqueScope = "aws";
+        var opaqueScope = "opaque-scope";
         var expectedToken = "opaque_scope_token";
         var tokenRequestCount = 0;
 
@@ -1265,7 +1265,7 @@ public class ClientTest
         var realm = $"https://{host}/token";
         var service = "test_service";
         var structuredScope = "repository:docker/library/redis:pull";
-        var opaqueScope = "aws";
+        var opaqueScope = "opaque-scope";
         var expectedToken = "duplicate_opaque_scope_token";
         var tokenRequestCount = 0;
 
@@ -1350,7 +1350,7 @@ public class ClientTest
         var realm = $"https://{host}/token";
         var service = "test_service";
         var structuredScope = "repository:docker/library/redis:pull";
-        var opaqueScope = "aws";
+        var opaqueScope = "opaque-scope";
         var tokenRequestCount = 0;
         var currentToken = string.Empty;
 
@@ -1438,7 +1438,7 @@ public class ClientTest
         var realm = $"https://{host}/token";
         var service = "test_service";
         var structuredScope = "repository:docker/library/redis:pull";
-        var opaqueScope = "aws";
+        var opaqueScope = "opaque-scope";
         var expectedToken = "provider_opaque_scope_token";
 
         var mockProvider = new Mock<IAccessTokenProvider>();
@@ -1613,7 +1613,7 @@ public class ClientTest
         var service = "test_service";
         var structuredScope = "repository:docker/library/redis:pull";
         var challengeStructuredScope = "repository:docker/library/redis:push";
-        var opaqueScope = "aws";
+        var opaqueScope = "opaque-scope";
         var expectedToken = "mixed_scope_token";
         var tokenRequestCount = 0;
 

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -1258,6 +1258,91 @@ public class ClientTest
     }
 
     [Fact]
+    public async Task SendAsync_UnauthorizedResponse_PreservesDuplicateOpaqueChallengeScopes()
+    {
+        // Arrange
+        var host = "example.com";
+        var realm = $"https://{host}/token";
+        var service = "test_service";
+        var structuredScope = "repository:docker/library/redis:pull";
+        var opaqueScope = "aws";
+        var expectedToken = "duplicate_opaque_scope_token";
+        var tokenRequestCount = 0;
+
+        HttpResponseMessage MockHttpRequestHandler(
+            HttpRequestMessage req,
+            CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.AbsoluteUri.StartsWith(realm, StringComparison.Ordinal) == true)
+            {
+                tokenRequestCount++;
+                var query = System.Web.HttpUtility.ParseQueryString(req.RequestUri.Query);
+                var requestedScopes = query.GetValues("scope") ?? [];
+
+                if (query["service"] == service
+                    && requestedScopes.SequenceEqual(new[] { structuredScope, opaqueScope, opaqueScope }))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent($"{{\"token\": \"{expectedToken}\"}}"),
+                        RequestMessage = req
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    RequestMessage = req
+                };
+            }
+
+            if (req.Method == HttpMethod.Get
+                && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Scheme == "Bearer"
+                    && req.Headers.Authorization.Parameter == expectedToken)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Headers =
+                    {
+                        WwwAuthenticate =
+                        {
+                            new AuthenticationHeaderValue(
+                                "Bearer",
+                                $"realm=\"{realm}\",service=\"{service}\",scope=\"{opaqueScope} {opaqueScope}\"")
+                        }
+                    },
+                    RequestMessage = req
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            };
+        }
+
+        var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object));
+        Assert.True(Scope.TryParse(structuredScope, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, tokenRequestCount);
+    }
+
+    [Fact]
     public async Task SendAsync_UnauthorizedResponse_DoesNotCacheOpaqueChallengeScopeToken()
     {
         // Arrange

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -3034,7 +3034,7 @@ public class ClientTest
         var host = "victim.io";
         var evilRealm = "https://evil.com/token";
 
-        async Task<HttpResponseMessage> MockHttpRequestHandler(
+        HttpResponseMessage MockHttpRequestHandler(
             HttpRequestMessage req,
             CancellationToken ct)
         {
@@ -3078,7 +3078,7 @@ public class ClientTest
         var realm = $"https://{host}/token";
         var expectedToken = "good_token";
 
-        async Task<HttpResponseMessage> MockHttpRequestHandler(
+        HttpResponseMessage MockHttpRequestHandler(
             HttpRequestMessage req,
             CancellationToken ct)
         {
@@ -3143,7 +3143,7 @@ public class ClientTest
         // invalid realm URL.
         var host = "myreg.io";
 
-        async Task<HttpResponseMessage> MockHttpRequestHandler(
+        HttpResponseMessage MockHttpRequestHandler(
             HttpRequestMessage req,
             CancellationToken ct)
         {
@@ -3184,7 +3184,7 @@ public class ClientTest
         // empty realm string.
         var host = "myreg.io";
 
-        async Task<HttpResponseMessage> MockHttpRequestHandler(
+        HttpResponseMessage MockHttpRequestHandler(
             HttpRequestMessage req,
             CancellationToken ct)
         {
@@ -3224,7 +3224,7 @@ public class ClientTest
         // relative realm URL.
         var host = "myreg.io";
 
-        async Task<HttpResponseMessage> MockHttpRequestHandler(
+        HttpResponseMessage MockHttpRequestHandler(
             HttpRequestMessage req,
             CancellationToken ct)
         {

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -1689,6 +1689,9 @@ public class ClientTest
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(1, tokenRequestCount);
+        Assert.Equal(
+            new[] { structuredScope },
+            client.ScopeManager.GetScopesStringForHost(host));
     }
 
     [Fact]

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ScopeManagerTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ScopeManagerTest.cs
@@ -146,19 +146,6 @@ public class ScopeManagerTest
         var mergedScope = result.First();
         Assert.Contains(Scope.ActionPull, mergedScope.Actions);
         Assert.Contains(Scope.ActionPush, mergedScope.Actions);
-
-        var newScopes = new SortedSet<Scope>
-        {
-            scope1,
-            scope2
-        };
-
-        result.UnionWith(newScopes);
-        Assert.Single(result);
-        mergedScope = result.First();
-        Assert.Contains(Scope.ActionPull, mergedScope.Actions);
-        Assert.Contains(Scope.ActionPush, mergedScope.Actions);
-
     }
 
     [Fact]
@@ -198,6 +185,25 @@ public class ScopeManagerTest
         Assert.Single(result);
         Assert.Contains(scope, result);
 
+    }
+
+    [Fact]
+    public void SetScopeForRegistry_DoesNotMutatePreviouslyReturnedScopeSet()
+    {
+        // Arrange
+        var scopeManager = new ScopeManager();
+        var pullScope = new Scope("repository", "repo1", new() { Scope.ActionPull });
+        var pushScope = new Scope("repository", "repo1", new() { Scope.ActionPush });
+
+        // Act
+        scopeManager.SetScopeForRegistry("registry1", pullScope);
+        var previousScopes = scopeManager.GetScopesForHost("registry1");
+        scopeManager.SetScopeForRegistry("registry1", pushScope);
+        var currentScopes = scopeManager.GetScopesForHost("registry1");
+
+        // Assert
+        Assert.Equal("repository:repo1:pull", previousScopes.First().ToString());
+        Assert.Equal("repository:repo1:pull,push", currentScopes.First().ToString());
     }
 
     [Fact]

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ScopeTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ScopeTest.cs
@@ -112,6 +112,26 @@ public class ScopeTest
         Assert.Null(scope);
     }
 
+    [Theory]
+    [InlineData(":my-repo:pull")]
+    [InlineData("   :my-repo:pull")]
+    [InlineData("repository::pull")]
+    [InlineData("repository:   :pull")]
+    [InlineData("repository:my-repo:")]
+    [InlineData("repository:my-repo:   ")]
+    [InlineData("repository:my-repo:pull,")]
+    [InlineData("repository:my-repo:,pull")]
+    [InlineData("repository:my-repo:pull,,push")]
+    public void TryParse_ScopeStringWithEmptyComponents_ReturnsFalse(string scopeStr)
+    {
+        // Act
+        bool result = Scope.TryParse(scopeStr, out var scope);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(scope);
+    }
+
     [Fact]
     public void EqualsInSortedSet_DifferentScopeInstancesWithSameValues_ReturnsTrue()
     {

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ScopeTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ScopeTest.cs
@@ -248,6 +248,45 @@ public class ScopeTest
         Assert.Contains(scopes, s => s.ToString() == "registry:catalog:*");
     }
 
+    [Fact]
+    public void AddOrMergeScopeCopyOnWrite_MergeMatchingScope_DoesNotMutateSharedScope()
+    {
+        // Arrange: a "stored" set and a shallow copy that shares the same Scope instance.
+        var storedScope = new Scope("repository", "my-repo", new HashSet<string> { Scope.ActionPull });
+        var storedScopes = new SortedSet<Scope> { storedScope };
+        var workingScopes = new SortedSet<Scope>(storedScopes);
+        var challengeScope = new Scope("repository", "my-repo", new HashSet<string> { Scope.ActionPush });
+
+        // Act
+        Scope.AddOrMergeScopeCopyOnWrite(workingScopes, challengeScope);
+
+        // Assert: the working copy is merged...
+        Assert.Single(workingScopes);
+        Assert.Equal("repository:my-repo:pull,push", workingScopes.First().ToString());
+        // ...but the shared/stored scope instance is untouched.
+        Assert.Equal("repository:my-repo:pull", storedScope.ToString());
+        Assert.Equal("repository:my-repo:pull", storedScopes.First().ToString());
+    }
+
+    [Fact]
+    public void AddOrMergeScopeCopyOnWrite_AddNonMatchingScope_AddsToSet()
+    {
+        // Arrange
+        var scopes = new SortedSet<Scope>
+        {
+            new Scope("repository", "repo-a", new HashSet<string> { Scope.ActionPull })
+        };
+        var newScope = new Scope("repository", "repo-b", new HashSet<string> { Scope.ActionPull });
+
+        // Act
+        Scope.AddOrMergeScopeCopyOnWrite(scopes, newScope);
+
+        // Assert
+        Assert.Equal(2, scopes.Count);
+        Assert.Contains(scopes, s => s.ToString() == "repository:repo-a:pull");
+        Assert.Contains(scopes, s => s.ToString() == "repository:repo-b:pull");
+    }
+
     [Theory]
     [InlineData(Scope.Action.Pull, Scope.ActionPull)]
     [InlineData(Scope.Action.Push, Scope.ActionPush)]


### PR DESCRIPTION
## Summary

Fixes #395.

This PR preserves opaque/unparseable Bearer challenge scopes when requesting registry tokens. Some registries return implementation-specific scope values in `WWW-Authenticate` challenges (for example, Public ECR may return `scope="aws"`). ORAS-dotnet previously dropped those values because they do not parse as structured Distribution scopes.

The change keeps the existing structured scope model, appends opaque challenge scopes to the token request, and deliberately avoids caching tokens acquired when opaque scopes are present.

## Details

- Preserve unparseable challenge scope strings for the challenged token request.
- Continue merging structured scopes through `Scope` / `ScopeManager`.
- Bypass auth cache lookup/write when any opaque scopes are present.
- Preserve existing structured-only cache key behavior.
- Add tests for:
  - opaque scope preservation,
  - no caching for opaque-scope tokens,
  - access-token provider receiving opaque scopes,
  - structured-only cache reuse,
  - mixed structured and opaque challenge scopes.

## Validation

- `dotnet build OrasProject.Oras.sln --no-restore`
- `dotnet test tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj --filter "FullyQualifiedName~OpaqueChallengeScope|FullyQualifiedName~PreservesMixedChallengeScopes|FullyQualifiedName~PreservesStructuredScopeCacheKeyOrder|FullyQualifiedName~SendAsync_UnauthorizedResponse_FetchesNewBearerTokenAndRetries" --no-restore`
- `dotnet test tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj --filter "FullyQualifiedName~OrasProject.Oras.Tests.Registry.Remote.Auth.ClientTest&FullyQualifiedName!~SendAsync_RealmValidation_RelativeRealm_Throws" --no-restore`
