### PR TITLE
fix: NullReferenceException when referrers index has null manifests

### DIFF
--- a/src/OrasProject.Oras/Oci/Index.cs
+++ b/src/OrasProject.Oras/Oci/Index.cs
@@ -34,8 +34,17 @@ public class Index : Versioned
     public string? ArtifactType { get; set; }
 
     // Manifests references platform specific manifests.
+    // A null JSON value (e.g. `"manifests": null`) is coalesced to an empty
+    // list to mirror Go's nil-slice semantics and tolerate non-conformant
+    // registries that return null instead of an empty array.
     [JsonPropertyName("manifests")]
-    public required IList<Descriptor> Manifests { get; set; }
+    public required IList<Descriptor> Manifests
+    {
+        get => _manifests;
+        set => _manifests = value ?? [];
+    }
+
+    private IList<Descriptor> _manifests = [];
 
     [JsonPropertyName("subject")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs
@@ -3649,6 +3649,52 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
     }
 
     [Fact]
+    public async Task Repository_ReferrersByApi_NullManifests_ReturnsEmpty()
+    {
+        // Some non-conformant registries return `"manifests": null` instead of
+        // an empty array when a subject has no referrers. This must not throw
+        // and should yield no referrers.
+        var indexBytes = """
+            {"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":null}
+            """u8.ToArray();
+
+        var desc = RandomDescriptor();
+        HttpResponseMessage MockedHttpHandler(HttpRequestMessage req, CancellationToken cancellationToken = default)
+        {
+            var res = new HttpResponseMessage
+            {
+                RequestMessage = req
+            };
+            if (req.Method != HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.MethodNotAllowed);
+            }
+            if (req.RequestUri?.AbsolutePath == $"/v2/test/referrers/{desc.Digest}")
+            {
+                res.Content = new ByteArrayContent(indexBytes);
+                res.Content.Headers.Add("Content-Type", [MediaType.ImageIndex]);
+                res.Headers.Add(_dockerContentDigestHeader, [desc.Digest]);
+                return res;
+            }
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+        var repo = new Repository(new RepositoryOptions()
+        {
+            Reference = Reference.Parse("localhost:5000/test"),
+            Client = CustomClient(MockedHttpHandler),
+            PlainHttp = true,
+        });
+
+        var cancellationToken = new CancellationToken();
+        var returnedReferrers = new List<Descriptor>();
+        await foreach (var referrer in repo.FetchReferrersByApi(desc, cancellationToken))
+        {
+            returnedReferrers.Add(referrer);
+        }
+        Assert.Empty(returnedReferrers);
+    }
+
+    [Fact]
     public async Task Repository_ReferrersByApi_SinglePageWithServerSideFilter_Successfully()
     {
         var expectedReferrersList = new List<Descriptor>

--- a/tests/OrasProject.Oras.Tests/Serialization/ManifestSerializationTest.Index.cs
+++ b/tests/OrasProject.Oras.Tests/Serialization/ManifestSerializationTest.Index.cs
@@ -132,6 +132,17 @@ public partial class ManifestSerializationTest
         }
         """;
 
+    // Some non-conformant registries return `"manifests": null` instead of an
+    // empty array when a subject has no referrers. This must be tolerated and
+    // coalesced to an empty list (mirrors Go's nil-slice semantics).
+    private const string NullManifestsIndexJson = """
+        {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": null
+        }
+        """;
+
     [Theory]
     [MemberData(nameof(IndexFieldFixtures))]
     public void Deserialize_Index_PreservesAllFields(
@@ -259,6 +270,21 @@ public partial class ManifestSerializationTest
         Assert.Contains("\"manifests\":[]", json);
     }
 
+    [Fact]
+    public void Deserialize_NullManifests_CoalescesToEmptyList()
+    {
+        var bytes = Encoding.UTF8.GetBytes(NullManifestsIndexJson);
+        var idx = OciJsonSerializer.Deserialize<OciIndex>(bytes)!;
+
+        Assert.NotNull(idx.Manifests);
+        Assert.Empty(idx.Manifests);
+
+        // Enumeration must not throw (mirrors Go's nil-slice semantics).
+        foreach (var _ in idx.Manifests)
+        {
+        }
+    }
+
     public static IEnumerable<object[]> IndexFieldFixtures()
     {
         yield return new object[]
@@ -267,5 +293,7 @@ public partial class ManifestSerializationTest
             { FullIndexJson, 2, true };
         yield return new object[]
             { EmptyManifestsIndexJson, 0, false };
+        yield return new object[]
+            { NullManifestsIndexJson, 0, false };
     }
 }


### PR DESCRIPTION
## What this PR does

Fixes a `NullReferenceException` that occurs when a registry returns `"manifests": null` (instead of an empty array `"manifests": []`) for a subject with no referrers.

Per the [OCI Distribution Spec v1.1.1](https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers), a registry with no referrers should return an empty `manifests` array. However, some registries (e.g. `dhi.io`) return `null`. `oras` (Go) and `oras-go` tolerate this because a JSON `null` decodes to a `nil` slice, and `len(nil)`/`range nil` are safe no-ops. oras-dotnet's `Index.Manifests` is a non-nullable `required IList<Descriptor>`, so `System.Text.Json` set it to `null`, and enumerating it in `FetchReferrersByApi`/`PullReferrersIndexList` threw.

## Change

- `Oci.Index.Manifests` now coalesces a `null` value to an empty list via a backing field, so it is never null after deserialization — mirroring Go's nil-slice semantics.

## Tests

- `Deserialize_NullManifests_CoalescesToEmptyList` and a new `"manifests": null` fixture in the index serialization tests.
- `Repository_ReferrersByApi_NullManifests_ReturnsEmpty` — end-to-end test where the mocked Referrers API returns `"manifests": null`.

All 555 tests pass.

Fixes #398