### PR TITLE
fix(auth): cold re-derive challenge on unusable cached bearer 401

### DIFF
--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -670,6 +670,7 @@ public class Client : IClient
                     throw new ArgumentException("originalRequest.RequestUri or originalRequest.RequestUri.Authority property is null.", nameof(originalRequest));
         var requestAttempt1 = await originalRequest.CloneAsync(rewindContent: false, cancellationToken).ConfigureAwait(false);
         var attemptedKey = string.Empty;
+        var requestAttempt1UsedCachedBearerToken = false;
 
         // attempt to send request with cached auth token
         if (Cache.TryGetScheme(host, out var schemeFromCache, partitionId))
@@ -692,6 +693,7 @@ public class Client : IClient
                         if (Cache.TryGetToken(host, schemeFromCache, attemptedKey, out var bearerToken, partitionId))
                         {
                             requestAttempt1.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+                            requestAttempt1UsedCachedBearerToken = true;
                         }
                         break;
                     }
@@ -699,113 +701,207 @@ public class Client : IClient
         }
 
         var response1 = await SendRequestAsync(requestAttempt1, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
-        if (response1.StatusCode != HttpStatusCode.Unauthorized)
+        var attemptedColdChallenge = false;
+
+        async Task<bool> TryRetryWithColdChallengeAsync(bool disposeCurrentResponse = false)
         {
-            return response1;
+            if (!ShouldRetryWithColdChallenge(requestAttempt1UsedCachedBearerToken, attemptedColdChallenge) ||
+                !await CanReplayRequestContentAsync(originalRequest, cancellationToken).ConfigureAwait(false))
+            {
+                return false;
+            }
+
+            if (disposeCurrentResponse)
+            {
+                response1.Dispose();
+            }
+
+            response1 = await SendColdChallengeRequestAsync(originalRequest, allowAutoRedirect, cancellationToken)
+                .ConfigureAwait(false);
+            attemptedColdChallenge = true;
+            return true;
         }
 
-        var (schemeFromChallenge, parameters) =
-            Challenge.ParseChallenge(response1.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
-
-        // Attempt again with credentials for recognized schemes
-        switch (schemeFromChallenge)
+        while (true)
         {
-            case Challenge.Scheme.Basic:
-                {
-                    response1.Dispose();
-                    var basicAuthToken = await FetchBasicAuthAsync(host, cancellationToken).ConfigureAwait(false);
-                    Cache.SetCache(host, schemeFromChallenge, string.Empty, basicAuthToken, partitionId);
-
-                    // Attempt again with basic token
-                    var requestAttempt2 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
-                    requestAttempt2.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicAuthToken);
-                    return await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
-                }
-            case Challenge.Scheme.Bearer:
-                {
-                    response1.Dispose();
-                    if (parameters == null)
-                    {
-                        throw new AuthenticationException("Missing parameters in the Www-Authenticate challenge.");
-                    }
-
-                    var existingScopes = ScopeManager.GetScopesForHost(host);
-                    var newScopes = new SortedSet<Scope>(existingScopes);
-                    if (parameters.TryGetValue("scope", out var scopesString))
-                    {
-                        foreach (var scopeStr in scopesString.Split(' ', StringSplitOptions.RemoveEmptyEntries))
-                        {
-                            if (Scope.TryParse(scopeStr, out var scope))
-                            {
-                                Scope.AddOrMergeScope(newScopes, scope);
-                            }
-                        }
-                    }
-
-                    // Attempt to send request when the scope changes and a token cache hits
-                    var newKey = string.Join(" ", newScopes);
-                    if (newKey != attemptedKey &&
-                        Cache.TryGetToken(host, schemeFromChallenge, newKey, out var cachedToken, partitionId))
-                    {
-                        var requestAttempt2 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
-                        requestAttempt2.Headers.Authorization = new AuthenticationHeaderValue("Bearer", cachedToken);
-                        var response2 = await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
-
-                        if (response2.StatusCode != HttpStatusCode.Unauthorized)
-                        {
-                            return response2;
-                        }
-                        response2.Dispose();
-                    }
-
-                    if (!parameters.TryGetValue("realm", out var realm))
-                    {
-                        // 'realm' is required as it specifies the token endpoint URL for Bearer authentication.
-                        throw new KeyNotFoundException("Missing 'realm' parameter in WWW-Authenticate Bearer challenge.");
-                    }
-
-                    // Validate realm URL before sending credentials.
-                    if (!Uri.TryCreate(
-                            realm, UriKind.Absolute,
-                            out var realmUri))
-                    {
-                        throw new AuthenticationException(
-                            $"Invalid realm URL: '{realm}'");
-                    }
-
-                    var registryUri = originalRequest.RequestUri!;
-                    if (!await RealmValidator.IsRealmAllowedAsync(
-                            registryUri, realmUri, cancellationToken)
-                        .ConfigureAwait(false))
-                    {
-                        throw new AuthenticationException(
-                            $"Authentication realm '{realmUri}' is not allowed for registry '{registryUri.Authority}'.");
-                    }
-
-                    if (!parameters.TryGetValue("service", out var service))
-                    {
-                        // some registries may omit the `service` parameter; use an empty string when absent.
-                        service = string.Empty;
-                    }
-
-                    // Try to fetch bearer token based on the challenge header
-                    var bearerAuthToken = await FetchBearerAuthAsync(
-                        host,
-                        realm,
-                        service,
-                        newScopes.Select(newScope => newScope.ToString()).ToList(),
-                        forceRefresh: true,
-                        cancellationToken
-                    ).ConfigureAwait(false);
-                    Cache.SetCache(host, schemeFromChallenge, newKey, bearerAuthToken, partitionId);
-
-                    var requestAttempt3 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
-                    requestAttempt3.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerAuthToken);
-                    return await SendRequestAsync(requestAttempt3, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
-                }
-            default:
+            if (response1.StatusCode != HttpStatusCode.Unauthorized)
+            {
                 return response1;
+            }
+
+            var (schemeFromChallenge, parameters) =
+                Challenge.ParseChallenge(response1.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
+
+            // Attempt again with credentials for recognized schemes
+            switch (schemeFromChallenge)
+            {
+                case Challenge.Scheme.Basic:
+                    {
+                        response1.Dispose();
+                        var basicAuthToken = await FetchBasicAuthAsync(host, cancellationToken).ConfigureAwait(false);
+                        Cache.SetCache(host, schemeFromChallenge, string.Empty, basicAuthToken, partitionId);
+
+                        // Attempt again with basic token
+                        var requestAttempt2 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
+                        requestAttempt2.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicAuthToken);
+                        return await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    }
+                case Challenge.Scheme.Bearer:
+                    {
+                        response1.Dispose();
+                        if (parameters == null)
+                        {
+                            if (await TryRetryWithColdChallengeAsync().ConfigureAwait(false))
+                            {
+                                continue;
+                            }
+
+                            throw new AuthenticationException("Missing parameters in the Www-Authenticate challenge.");
+                        }
+
+                        var newScopes = MergeChallengeScopes(
+                            ScopeManager.GetScopesForHost(host),
+                            parameters.TryGetValue("scope", out var scopesString)
+                                ? scopesString
+                                : null);
+
+                        // Attempt to send request when the scope changes and a token cache hits
+                        var newKey = string.Join(" ", newScopes);
+                        if (newKey != attemptedKey &&
+                            Cache.TryGetToken(host, schemeFromChallenge, newKey, out var cachedToken, partitionId))
+                        {
+                            var requestAttempt2 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
+                            requestAttempt2.Headers.Authorization = new AuthenticationHeaderValue("Bearer", cachedToken);
+                            var response2 = await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+
+                            if (response2.StatusCode != HttpStatusCode.Unauthorized)
+                            {
+                                return response2;
+                            }
+                            response2.Dispose();
+                        }
+
+                        if (!parameters.TryGetValue("realm", out var realm))
+                        {
+                            if (await TryRetryWithColdChallengeAsync().ConfigureAwait(false))
+                            {
+                                continue;
+                            }
+
+                            // 'realm' is required as it specifies the token endpoint URL for Bearer authentication.
+                            throw new KeyNotFoundException("Missing 'realm' parameter in WWW-Authenticate Bearer challenge.");
+                        }
+
+                        // Validate realm URL before sending credentials.
+                        if (!Uri.TryCreate(
+                                realm, UriKind.Absolute,
+                                out var realmUri))
+                        {
+                            if (await TryRetryWithColdChallengeAsync().ConfigureAwait(false))
+                            {
+                                continue;
+                            }
+
+                            throw new AuthenticationException(
+                                $"Invalid realm URL: '{realm}'");
+                        }
+
+                        var registryUri = originalRequest.RequestUri!;
+                        if (!await RealmValidator.IsRealmAllowedAsync(
+                                registryUri, realmUri, cancellationToken)
+                            .ConfigureAwait(false))
+                        {
+                            if (await TryRetryWithColdChallengeAsync().ConfigureAwait(false))
+                            {
+                                continue;
+                            }
+
+                            throw new AuthenticationException(
+                                $"Authentication realm '{realmUri}' is not allowed for registry '{registryUri.Authority}'.");
+                        }
+
+                        if (!parameters.TryGetValue("service", out var service))
+                        {
+                            // some registries may omit the `service` parameter; use an empty string when absent.
+                            service = string.Empty;
+                        }
+
+                        // Try to fetch bearer token based on the challenge header
+                        var bearerAuthToken = await FetchBearerAuthAsync(
+                            host,
+                            realm,
+                            service,
+                            newScopes.Select(newScope => newScope.ToString()).ToList(),
+                            forceRefresh: true,
+                            cancellationToken
+                        ).ConfigureAwait(false);
+                        Cache.SetCache(host, schemeFromChallenge, newKey, bearerAuthToken, partitionId);
+
+                        var requestAttempt3 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
+                        requestAttempt3.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerAuthToken);
+                        return await SendRequestAsync(requestAttempt3, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    }
+                default:
+                    if (await TryRetryWithColdChallengeAsync(disposeCurrentResponse: true).ConfigureAwait(false))
+                    {
+                        continue;
+                    }
+
+                    return response1;
+            }
         }
+    }
+
+    private static SortedSet<Scope> MergeChallengeScopes(
+        IEnumerable<Scope> existingScopes,
+        string? scopesString)
+    {
+        var newScopes = new SortedSet<Scope>(existingScopes);
+        if (string.IsNullOrWhiteSpace(scopesString))
+        {
+            return newScopes;
+        }
+
+        foreach (var scopeStr in scopesString.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (Scope.TryParse(scopeStr, out var scope))
+            {
+                Scope.AddOrMergeScope(newScopes, scope);
+            }
+        }
+
+        return newScopes;
+    }
+
+    private static bool ShouldRetryWithColdChallenge(
+        bool requestAttempt1UsedCachedBearerToken,
+        bool attemptedColdChallenge)
+        => requestAttempt1UsedCachedBearerToken && !attemptedColdChallenge;
+
+    private static async Task<bool> CanReplayRequestContentAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Content == null)
+        {
+            return true;
+        }
+
+        var stream = await request.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        return stream.CanSeek;
+    }
+
+    private async Task<HttpResponseMessage> SendColdChallengeRequestAsync(
+        HttpRequestMessage originalRequest,
+        bool allowAutoRedirect,
+        CancellationToken cancellationToken)
+    {
+        // Re-send the same resource request rather than probing with a different method or URI:
+        // some registries derive the challenge from the exact resource and method being accessed.
+        // The content was already buffered/validated by BufferNonSeekableContentAsync above.
+        var coldRequest = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
+        coldRequest.Headers.Authorization = null;
+        return await SendRequestAsync(coldRequest, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -1069,6 +1069,601 @@ public class ClientTest
     }
 
     [Fact]
+    public async Task SendAsync_CachedBearerUnauthorizedWithoutChallenge_RederivesChallengeCold()
+    {
+        // Arrange
+        var host = "dhi.example.com";
+        var realm = $"https://{host}/token";
+        var scopeString = "repository:redis:pull";
+        var staleToken = "stale_token";
+        var freshToken = "fresh_token";
+        var noAuthResourceRequests = 0;
+        var staleResourceRequests = 0;
+        var freshResourceRequests = 0;
+
+        Task<HttpResponseMessage> MockHttpRequestHandler(HttpRequestMessage req, CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri?.AbsoluteUri.StartsWith(realm, StringComparison.Ordinal) == true)
+            {
+                return Task.FromResult(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent($"{{\"token\": \"{freshToken}\"}}"),
+                    RequestMessage = req
+                });
+            }
+
+            if (req.Method == HttpMethod.Get && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Parameter == staleToken)
+                {
+                    staleResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.Unauthorized,
+                        RequestMessage = req
+                    });
+                }
+
+                if (req.Headers.Authorization == null)
+                {
+                    noAuthResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.Unauthorized,
+                        Headers =
+                        {
+                            WwwAuthenticate =
+                            {
+                                new AuthenticationHeaderValue(
+                                    "Bearer",
+                                    $"realm=\"{realm}\",service=\"test_service\",scope=\"{scopeString}\"")
+                            }
+                        },
+                        RequestMessage = req
+                    });
+                }
+
+                if (req.Headers.Authorization.Parameter == freshToken)
+                {
+                    freshResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    });
+                }
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            });
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(new HttpClient(mockHandler.Object));
+        Assert.True(Scope.TryParse(scopeString, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        client.Cache.SetCache(host, Challenge.Scheme.Bearer, scopeString, staleToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/redis/manifests/latest");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, staleResourceRequests);
+        Assert.Equal(1, noAuthResourceRequests);
+        Assert.Equal(1, freshResourceRequests);
+
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/redis/manifests/latest");
+        response = await client.SendAsync(request2, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, staleResourceRequests);
+        Assert.Equal(1, noAuthResourceRequests);
+        Assert.Equal(2, freshResourceRequests);
+    }
+
+    [Fact]
+    public async Task SendAsync_CachedBearerColdChallengeAlsoUnusable_ReturnsColdResponseOnce()
+    {
+        // Arrange
+        var host = "still-broken.example.com";
+        var scopeString = "repository:repo:pull";
+        var staleToken = "stale_token";
+        var staleResourceRequests = 0;
+        var noAuthResourceRequests = 0;
+
+        Task<HttpResponseMessage> MockHttpRequestHandler(HttpRequestMessage req, CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Parameter == staleToken)
+                {
+                    staleResourceRequests++;
+                }
+                else if (req.Headers.Authorization == null)
+                {
+                    noAuthResourceRequests++;
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    RequestMessage = req
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            });
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(new HttpClient(mockHandler.Object));
+        Assert.True(Scope.TryParse(scopeString, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        client.Cache.SetCache(host, Challenge.Scheme.Bearer, scopeString, staleToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/repo/manifests/latest");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(1, staleResourceRequests);
+        Assert.Equal(1, noAuthResourceRequests);
+    }
+
+    [Fact]
+    public async Task SendAsync_CachedBearerUnusableChallengeWithNonReplayableContent_SkipsColdRetry()
+    {
+        // Arrange
+        var host = "large-upload.example.com";
+        var scopeString = "repository:repo:push";
+        var staleToken = "stale_token";
+        var staleResourceRequests = 0;
+        var noAuthResourceRequests = 0;
+
+        Task<HttpResponseMessage> MockHttpRequestHandler(HttpRequestMessage req, CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Put && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Parameter == staleToken)
+                {
+                    staleResourceRequests++;
+                }
+                else if (req.Headers.Authorization == null)
+                {
+                    noAuthResourceRequests++;
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    RequestMessage = req
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            });
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(new HttpClient(mockHandler.Object));
+        Assert.True(Scope.TryParse(scopeString, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        client.Cache.SetCache(host, Challenge.Scheme.Bearer, scopeString, staleToken);
+
+        var nonSeekableStream = new NonSeekableStream("payload"u8.ToArray());
+        var content = new StreamContent(nonSeekableStream);
+        content.Headers.ContentLength = Client.MaxBufferSize + 1;
+        using var request = new HttpRequestMessage(HttpMethod.Put, $"https://{host}/v2/repo/manifests/latest")
+        {
+            Content = content
+        };
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(1, staleResourceRequests);
+        Assert.Equal(0, noAuthResourceRequests);
+    }
+
+    [Fact]
+    public async Task SendAsync_CachedBearerUnauthorizedWithMissingRealm_RederivesChallengeCold()
+    {
+        // Arrange
+        var host = "missing-realm.example.com";
+        var realm = $"https://{host}/token";
+        var scopeString = "repository:repo:pull";
+        var staleToken = "stale_token";
+        var freshToken = "fresh_token";
+        var staleResourceRequests = 0;
+        var noAuthResourceRequests = 0;
+
+        Task<HttpResponseMessage> MockHttpRequestHandler(HttpRequestMessage req, CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri?.AbsoluteUri.StartsWith(realm, StringComparison.Ordinal) == true)
+            {
+                return Task.FromResult(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent($"{{\"token\": \"{freshToken}\"}}"),
+                    RequestMessage = req
+                });
+            }
+
+            if (req.Method == HttpMethod.Get && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Parameter == staleToken)
+                {
+                    staleResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.Unauthorized,
+                        Headers =
+                        {
+                            WwwAuthenticate =
+                            {
+                                new AuthenticationHeaderValue(
+                                    "Bearer",
+                                    $"service=\"test_service\",scope=\"{scopeString}\"")
+                            }
+                        },
+                        RequestMessage = req
+                    });
+                }
+
+                if (req.Headers.Authorization == null)
+                {
+                    noAuthResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.Unauthorized,
+                        Headers =
+                        {
+                            WwwAuthenticate =
+                            {
+                                new AuthenticationHeaderValue(
+                                    "Bearer",
+                                    $"realm=\"{realm}\",service=\"test_service\",scope=\"{scopeString}\"")
+                            }
+                        },
+                        RequestMessage = req
+                    });
+                }
+
+                if (req.Headers.Authorization.Parameter == freshToken)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    });
+                }
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            });
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(new HttpClient(mockHandler.Object));
+        Assert.True(Scope.TryParse(scopeString, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        client.Cache.SetCache(host, Challenge.Scheme.Bearer, scopeString, staleToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/repo/manifests/latest");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, staleResourceRequests);
+        Assert.Equal(1, noAuthResourceRequests);
+    }
+
+    [Fact]
+    public async Task SendAsync_CachedBearerUnauthorizedWithDeniedRealm_RederivesChallengeCold()
+    {
+        // Arrange
+        var host = "registry.example.com";
+        var deniedRealm = "https://denied-auth.example.com/token";
+        var coldRealm = $"https://{host}/proxy_auth";
+        var scopeString = "repository:sample/repo:pull";
+        var staleToken = "stale_token";
+        var freshToken = "fresh_token";
+        var staleResourceRequests = 0;
+        var noAuthResourceRequests = 0;
+        var deniedRealmTokenRequests = 0;
+        var coldRealmTokenRequests = 0;
+
+        Task<HttpResponseMessage> MockHttpRequestHandler(HttpRequestMessage req, CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri?.AbsoluteUri.StartsWith(deniedRealm, StringComparison.Ordinal) == true)
+            {
+                deniedRealmTokenRequests++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    RequestMessage = req
+                });
+            }
+
+            if (req.Method == HttpMethod.Get && req.RequestUri?.AbsoluteUri.StartsWith(coldRealm, StringComparison.Ordinal) == true)
+            {
+                coldRealmTokenRequests++;
+                return Task.FromResult(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent($"{{\"token\": \"{freshToken}\"}}"),
+                    RequestMessage = req
+                });
+            }
+
+            if (req.Method == HttpMethod.Get && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Parameter == staleToken)
+                {
+                    staleResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.Unauthorized,
+                        Headers =
+                        {
+                            WwwAuthenticate =
+                            {
+                                new AuthenticationHeaderValue(
+                                    "Bearer",
+                                    $"realm=\"{deniedRealm}\",service=\"registry\",scope=\"{scopeString}\"")
+                            }
+                        },
+                        RequestMessage = req
+                    });
+                }
+
+                if (req.Headers.Authorization == null)
+                {
+                    noAuthResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.Unauthorized,
+                        Headers =
+                        {
+                            WwwAuthenticate =
+                            {
+                                new AuthenticationHeaderValue(
+                                    "Bearer",
+                                    $"realm=\"{coldRealm}\",scope=\"{scopeString}\"")
+                            }
+                        },
+                        RequestMessage = req
+                    });
+                }
+
+                if (req.Headers.Authorization.Parameter == freshToken)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    });
+                }
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            });
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(new HttpClient(mockHandler.Object));
+        Assert.True(Scope.TryParse(scopeString, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        client.Cache.SetCache(host, Challenge.Scheme.Bearer, scopeString, staleToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/sample/repo/manifests/latest");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, staleResourceRequests);
+        Assert.Equal(1, noAuthResourceRequests);
+        Assert.Equal(0, deniedRealmTokenRequests);
+        Assert.Equal(1, coldRealmTokenRequests);
+    }
+
+    [Fact]
+    public async Task SendAsync_CachedBearerUnauthorizedWithUsableChallenge_DoesNotRederiveChallengeCold()
+    {
+        // Arrange
+        var host = "compliant.example.com";
+        var realm = "https://auth.compliant.example.com/token";
+        var scopeString = "repository:repo:pull";
+        var staleToken = "stale_token";
+        var freshToken = "fresh_token";
+        var staleResourceRequests = 0;
+        var noAuthResourceRequests = 0;
+
+        Task<HttpResponseMessage> MockHttpRequestHandler(HttpRequestMessage req, CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri?.AbsoluteUri.StartsWith(realm, StringComparison.Ordinal) == true)
+            {
+                return Task.FromResult(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent($"{{\"token\": \"{freshToken}\"}}"),
+                    RequestMessage = req
+                });
+            }
+
+            if (req.Method == HttpMethod.Get && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization == null)
+                {
+                    noAuthResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                    {
+                        RequestMessage = req
+                    });
+                }
+
+                if (req.Headers.Authorization.Parameter == staleToken)
+                {
+                    staleResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.Unauthorized,
+                        Headers =
+                        {
+                            WwwAuthenticate =
+                            {
+                                new AuthenticationHeaderValue(
+                                    "Bearer",
+                                    $"realm=\"{realm}\",service=\"test_service\",scope=\"{scopeString}\"")
+                            }
+                        },
+                        RequestMessage = req
+                    });
+                }
+
+                if (req.Headers.Authorization.Parameter == freshToken)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        RequestMessage = req
+                    });
+                }
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            });
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "auth.compliant.example.com"
+                }
+            }
+        };
+        Assert.True(Scope.TryParse(scopeString, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        client.Cache.SetCache(host, Challenge.Scheme.Bearer, scopeString, staleToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/repo/manifests/latest");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, staleResourceRequests);
+        Assert.Equal(0, noAuthResourceRequests);
+    }
+
+    [Fact]
+    public async Task SendAsync_CachedBearerUnauthorizedWithAllowedRealmTokenFailure_DoesNotRederiveChallengeCold()
+    {
+        // Arrange
+        var host = "badcreds.example.com";
+        var realm = "https://auth.badcreds.example.com/token";
+        var scopeString = "repository:repo:pull";
+        var staleToken = "stale_token";
+        var staleResourceRequests = 0;
+        var noAuthResourceRequests = 0;
+
+        Task<HttpResponseMessage> MockHttpRequestHandler(HttpRequestMessage req, CancellationToken cancellationToken = default)
+        {
+            if (req.Method == HttpMethod.Get && req.RequestUri?.AbsoluteUri.StartsWith(realm, StringComparison.Ordinal) == true)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    RequestMessage = req
+                });
+            }
+
+            if (req.Method == HttpMethod.Get && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization == null)
+                {
+                    noAuthResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                    {
+                        RequestMessage = req
+                    });
+                }
+
+                if (req.Headers.Authorization.Parameter == staleToken)
+                {
+                    staleResourceRequests++;
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.Unauthorized,
+                        Headers =
+                        {
+                            WwwAuthenticate =
+                            {
+                                new AuthenticationHeaderValue(
+                                    "Bearer",
+                                    $"realm=\"{realm}\",service=\"test_service\",scope=\"{scopeString}\"")
+                            }
+                        },
+                        RequestMessage = req
+                    });
+                }
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = req
+            });
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "auth.badcreds.example.com"
+                }
+            }
+        };
+        Assert.True(Scope.TryParse(scopeString, out var scope));
+        client.ScopeManager.SetScopeForRegistry(host, scope);
+        client.Cache.SetCache(host, Challenge.Scheme.Bearer, scopeString, staleToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/repo/manifests/latest");
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ResponseException>(
+            () => client.SendAsync(request, cancellationToken: CancellationToken.None));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
+        Assert.Equal(1, staleResourceRequests);
+        Assert.Equal(0, noAuthResourceRequests);
+    }
+
+    [Fact]
     public async Task SendAsync_UnauthorizedResponse_BearerChallengeWithoutService_OmitsServiceInTokenRequest()
     {
         // Arrange
@@ -2730,9 +3325,13 @@ public class ClientTest
 
         // Act & Assert — /token parses as file:///token on Linux,
         // which is rejected by the scheme check in the validator.
+        // On Windows it can be rejected earlier as an invalid absolute URI.
         var ex = await Assert.ThrowsAsync<AuthenticationException>(
             () => client.SendAsync(request,
                 cancellationToken: CancellationToken.None));
-        Assert.Contains("not allowed", ex.Message);
+        Assert.True(
+            ex.Message.Contains("not allowed", StringComparison.Ordinal) ||
+            ex.Message.Contains("Invalid realm URL", StringComparison.Ordinal),
+            $"Unexpected exception message: {ex.Message}");
     }
 }


### PR DESCRIPTION
## Summary

Recover from a cached Bearer token rejection when the registry's token-carrying `401` response does not provide a usable challenge.

When the first attempt used a cached Bearer token and the resulting `401` has either:
- no/unknown challenge scheme, or
- a missing, invalid, or denied realm,

ORAS now re-sends the original request once without `Authorization` to re-derive the registry's cold challenge, then continues through the existing auth flow. Registries that already return a usable challenge keep the existing path and do not pay an extra cold request.

## Notes

- The cold retry is gated on a cached Bearer token having been attached.
- It is bounded to one retry to avoid loops if the cold challenge is also unusable.
- Token fetch failures after an allowed/usable realm are not masked.
- The cold request intentionally re-sends the same method/URI/content because challenge semantics can be resource-specific.

## Tests

- `dotnet test ./tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj -c Debug --filter "FullyQualifiedName~OrasProject.Oras.Tests.Registry.Remote.Auth.ClientTest"`
  - 60/60 passed
- `dotnet test ./tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj -c Debug`
  - 558/558 passed
