### PR TITLE
fix(auth): trust NVIDIA NGC auth realm by default

### DIFF
--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -58,6 +58,8 @@ public sealed class DefaultRealmValidator : IRealmValidator
     /// (registry: registry-1.docker.io)</item>
     /// <item><c>gitlab.com</c> — GitLab Container Registry
     /// (registry: registry.gitlab.com)</item>
+    /// <item><c>authn.nvidia.com</c> — NVIDIA NGC
+    /// (registry: nvcr.io)</item>
     /// </list>
     /// <para>
     /// Values are normalized (lowercased, trailing dots stripped)
@@ -77,7 +79,7 @@ public sealed class DefaultRealmValidator : IRealmValidator
 
     private IReadOnlySet<string> _trustedRealmHosts =
         FrozenSet.ToFrozenSet(
-            new[] { "auth.docker.io", "gitlab.com" },
+            new[] { "auth.docker.io", "gitlab.com", "authn.nvidia.com" },
             StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -78,9 +78,9 @@ public sealed class DefaultRealmValidator : IRealmValidator
     }
 
     private IReadOnlySet<string> _trustedRealmHosts =
-        FrozenSet.ToFrozenSet(
-            new[] { "auth.docker.io", "gitlab.com", "authn.nvidia.com" },
-            StringComparer.OrdinalIgnoreCase);
+        new[] { "auth.docker.io", "gitlab.com", "authn.nvidia.com" }
+            .Select(NormalizeHost)
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public Task<bool> IsRealmAllowedAsync(

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
@@ -321,6 +321,25 @@ public class DefaultRealmValidatorTest
     }
 
     [Fact]
+    public async Task NvidiaRegistry_DefaultTrusted_Allowed()
+    {
+        // NVIDIA NGC: authn.nvidia.com is in the default trusted list.
+        var validator = new DefaultRealmValidator();
+        Assert.True(await validator.IsRealmAllowedAsync(
+            Reg("https://nvcr.io/v2/"),
+            Realm("https://authn.nvidia.com/token")));
+    }
+
+    [Fact]
+    public async Task NvidiaTrustedHost_NonDefaultPort_Rejected()
+    {
+        var validator = new DefaultRealmValidator();
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://nvcr.io/v2/"),
+            Realm("https://authn.nvidia.com:8443/token")));
+    }
+
+    [Fact]
     public async Task DataScheme_Rejected()
     {
         var validator = new DefaultRealmValidator();


### PR DESCRIPTION
## Summary

Add `authn.nvidia.com` to the default trusted realm host list so authenticated NVIDIA NGC / `nvcr.io` pulls can follow NVIDIA's cross-host auth challenge.

`DefaultRealmValidator` already allows well-known cross-host registry auth realms such as Docker Hub (`auth.docker.io`) and GitLab (`gitlab.com`). NVIDIA NGC uses `authn.nvidia.com` as its auth realm for authenticated pulls, so this PR adds it to the same default trusted-realm model.

## Notes

- The same URI safety checks still apply before trusted-host matching:
  - non-http(s) rejected
  - HTTP rejected unless insecure mode is explicitly enabled
  - userinfo rejected
  - trusted hosts must use the scheme default port
- This follows the existing global trusted realm-host model; it does not introduce registry-specific realm mappings.

## Tests

- `dotnet test ./tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj -c Debug --filter "FullyQualifiedName~OrasProject.Oras.Tests.Registry.Remote.Auth.DefaultRealmValidatorTest"`
  - 47/47 passed

Note: full-suite local Windows run reaches an unrelated pre-existing platform-sensitive assertion in `ClientTest.SendAsync_RealmValidation_RelativeRealm_Throws` (relative `/token` exception text differs on Windows vs Linux). This PR only changes `DefaultRealmValidator` defaults and tests.
