### PR TITLE
fix(auth)!: least-permissive realm validation (no built-in trusted hosts)

### DIFF
--- a/docs/auth/realm-validation.md
+++ b/docs/auth/realm-validation.md
@@ -44,17 +44,16 @@ default** and must be opted into explicitly (see below).
 Add the realm's auth host(s) to `TrustedRealmHosts`:
 
 ```csharp
+using System.Collections.Immutable;
 using OrasProject.Oras.Registry.Remote.Auth;
 
 var validator = new DefaultRealmValidator
 {
-    TrustedRealmHosts = new HashSet<string>
-    {
-        "auth.docker.io",   // Docker Hub (registry-1.docker.io)
-        "gitlab.com",       // GitLab (registry.gitlab.com)
-        "authn.nvidia.com", // NVIDIA NGC (nvcr.io)
-        "login.mycompany.com", // your enterprise auth endpoint
-    }
+    TrustedRealmHosts = ImmutableHashSet.Create(
+        "auth.docker.io",       // Docker Hub (registry-1.docker.io)
+        "gitlab.com",           // GitLab (registry.gitlab.com)
+        "authn.nvidia.com",     // NVIDIA NGC (nvcr.io)
+        "login.mycompany.com")  // your enterprise auth endpoint
 };
 
 var client = new Client(httpClient)
@@ -62,6 +61,13 @@ var client = new Client(httpClient)
     RealmValidator = validator
 };
 ```
+
+`TrustedRealmHosts` accepts any `IReadOnlySet<string>`. Prefer an
+[`ImmutableHashSet<string>`](https://learn.microsoft.com/dotnet/api/system.collections.immutable.immutablehashset-1):
+the trusted-host allowlist is fixed configuration, so an immutable set makes
+that intent explicit and is safe to share across clients. The validator also
+snapshots the set on assignment, so later mutations to a mutable collection you
+passed in have no effect.
 
 Hostnames are normalized (lowercased, trailing dots stripped) and the match is
 case-insensitive. A trusted host is still required to be on the default port for

--- a/docs/auth/realm-validation.md
+++ b/docs/auth/realm-validation.md
@@ -1,0 +1,113 @@
+# Realm Validation
+
+When a registry responds to a request with a `401 Unauthorized` and a
+`WWW-Authenticate: Bearer` challenge, that challenge contains a `realm` — the URL
+of the token endpoint the client should contact to obtain a bearer token. The
+`realm` is **supplied by the (potentially untrusted) registry**, so before the
+client sends credentials there, it validates the realm with an
+[`IRealmValidator`](../../src/OrasProject.Oras/Registry/Remote/Auth/IRealmValidator.cs).
+
+This guards against a malicious or compromised registry directing the client to
+send credentials/tokens to an attacker-controlled host.
+
+## Default behavior: least-permissive
+
+`Client` uses [`DefaultRealmValidator`](../../src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs)
+unless you supply your own. It applies these rules, in order:
+
+1. Reject non-HTTP(S) schemes.
+2. Reject `http` unless `AllowInsecureHttp` is enabled.
+3. Reject realm URLs containing userinfo (e.g. `https://user:pass@host/...`).
+4. **Allow** if the realm host matches the registry host (same host, port-aware).
+5. **Allow** if the realm host is in `TrustedRealmHosts`.
+6. Otherwise **deny**.
+
+> [!IMPORTANT]
+> `TrustedRealmHosts` is **empty by default**. Out of the box, only realms on the
+> **same host** as the registry are allowed (rule 4). The SDK is intentionally
+> host-agnostic and does **not** bake in trust for any specific registry.
+
+Many public registries serve their token endpoint from a **different** host than
+the registry itself, for example:
+
+| Registry            | Auth realm host     |
+| ------------------- | ------------------- |
+| `registry-1.docker.io` (Docker Hub) | `auth.docker.io`    |
+| `registry.gitlab.com` (GitLab)      | `gitlab.com`        |
+| `nvcr.io` (NVIDIA NGC)              | `authn.nvidia.com`  |
+
+Because these auth hosts differ from the registry host, they are **rejected by
+default** and must be opted into explicitly (see below).
+
+## Opting in to cross-host auth realms
+
+Add the realm's auth host(s) to `TrustedRealmHosts`:
+
+```csharp
+using OrasProject.Oras.Registry.Remote.Auth;
+
+var validator = new DefaultRealmValidator
+{
+    TrustedRealmHosts = new HashSet<string>
+    {
+        "auth.docker.io",   // Docker Hub (registry-1.docker.io)
+        "gitlab.com",       // GitLab (registry.gitlab.com)
+        "authn.nvidia.com", // NVIDIA NGC (nvcr.io)
+        "login.mycompany.com", // your enterprise auth endpoint
+    }
+};
+
+var client = new Client(httpClient)
+{
+    RealmValidator = validator
+};
+```
+
+Hostnames are normalized (lowercased, trailing dots stripped) and the match is
+case-insensitive. A trusted host is still required to be on the default port for
+its scheme and to pass the scheme/userinfo checks above.
+
+## Local development over HTTP
+
+For a registry running on `localhost` without TLS, enable `AllowInsecureHttp`:
+
+```csharp
+var validator = new DefaultRealmValidator { AllowInsecureHttp = true };
+var client = new Client(httpClient) { RealmValidator = validator };
+```
+
+This only relaxes the scheme check; the same-host / trusted-host rules still apply.
+
+## Custom validators
+
+For full control (for example, allowing any auth host within a corporate domain
+suffix), implement `IRealmValidator` and assign it to `Client.RealmValidator`:
+
+```csharp
+public class CorporateDomainRealmValidator : IRealmValidator
+{
+    private readonly string _allowedSuffix;
+
+    public CorporateDomainRealmValidator(string allowedDomainSuffix)
+        => _allowedSuffix = allowedDomainSuffix.ToLowerInvariant();
+
+    public Task<bool> IsRealmAllowedAsync(
+        Uri registryUri, Uri realmUri, CancellationToken cancellationToken = default)
+    {
+        if (!realmUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.FromResult(false);
+        }
+
+        var host = realmUri.Host.ToLowerInvariant();
+        return Task.FromResult(host.EndsWith(_allowedSuffix, StringComparison.Ordinal));
+    }
+}
+```
+
+## Runnable examples
+
+See
+[`examples/OrasProject.Oras.Examples.RealmValidation`](../../examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs)
+for runnable versions of the snippets above, including
+`CreateClientTrustingWellKnownPublicRegistries`.

--- a/docs/auth/realm-validation.md
+++ b/docs/auth/realm-validation.md
@@ -19,7 +19,7 @@ unless you supply your own. It applies these rules, in order:
 2. Reject `http` unless `AllowInsecureHttp` is enabled.
 3. Reject realm URLs containing userinfo (e.g. `https://user:pass@host/...`).
 4. **Allow** if the realm host matches the registry host (same host, port-aware).
-5. **Allow** if the realm host is in `TrustedRealmHosts`.
+5. **Allow** if the realm host is in `TrustedRealmHosts` and the realm is on the scheme-default port.
 6. Otherwise **deny**.
 
 > [!IMPORTANT]

--- a/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
+++ b/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
@@ -29,17 +29,44 @@ public static class RealmValidationExamples
     {
         ArgumentNullException.ThrowIfNull(httpClient);
 
-        // DefaultRealmValidator ships with auth.docker.io and
-        // gitlab.com pre-configured. You can override the trusted
-        // hosts to include your organization's auth endpoints.
+        // DefaultRealmValidator ships with NO trusted hosts: by default
+        // only realms on the same host as the registry are allowed. To
+        // trust a registry whose auth realm lives on a different host,
+        // list those auth hosts explicitly — for example your
+        // organization's auth endpoints.
         var validator = new DefaultRealmValidator
         {
             TrustedRealmHosts = new HashSet<string>
             {
-                "auth.docker.io",
-                "gitlab.com",
                 "login.mycompany.com",
                 "auth.internal.example.com",
+            }
+        };
+
+        return new Client(httpClient)
+        {
+            RealmValidator = validator
+        };
+    }
+
+    /// <summary>
+    /// Opts into well-known public registries whose auth realm host
+    /// differs from the registry host (Docker Hub, GitLab, NVIDIA NGC).
+    /// These are intentionally NOT trusted by default — the SDK is
+    /// host-agnostic — so callers enable them explicitly.
+    /// </summary>
+    public static Client CreateClientTrustingWellKnownPublicRegistries(
+        HttpClient httpClient)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>
+            {
+                "auth.docker.io",   // Docker Hub (registry-1.docker.io)
+                "gitlab.com",       // GitLab (registry.gitlab.com)
+                "authn.nvidia.com", // NVIDIA NGC (nvcr.io)
             }
         };
 

--- a/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
+++ b/examples/OrasProject.Oras.Examples.RealmValidation/RealmValidationExamples.cs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #region Usage
+using System.Collections.Immutable;
 using OrasProject.Oras.Registry.Remote.Auth;
 
 namespace OrasProject.Oras.Examples.RealmValidation;
@@ -34,13 +35,15 @@ public static class RealmValidationExamples
         // trust a registry whose auth realm lives on a different host,
         // list those auth hosts explicitly — for example your
         // organization's auth endpoints.
+        //
+        // Prefer an ImmutableHashSet<string> here: the trusted-host
+        // allowlist is fixed configuration, and an immutable set makes
+        // that intent explicit and is safe to share across clients.
         var validator = new DefaultRealmValidator
         {
-            TrustedRealmHosts = new HashSet<string>
-            {
+            TrustedRealmHosts = ImmutableHashSet.Create(
                 "login.mycompany.com",
-                "auth.internal.example.com",
-            }
+                "auth.internal.example.com")
         };
 
         return new Client(httpClient)
@@ -62,12 +65,10 @@ public static class RealmValidationExamples
 
         var validator = new DefaultRealmValidator
         {
-            TrustedRealmHosts = new HashSet<string>
-            {
-                "auth.docker.io",   // Docker Hub (registry-1.docker.io)
-                "gitlab.com",       // GitLab (registry.gitlab.com)
-                "authn.nvidia.com", // NVIDIA NGC (nvcr.io)
-            }
+            TrustedRealmHosts = ImmutableHashSet.Create(
+                "auth.docker.io",    // Docker Hub (registry-1.docker.io)
+                "gitlab.com",        // GitLab (registry.gitlab.com)
+                "authn.nvidia.com")  // NVIDIA NGC (nvcr.io)
         };
 
         return new Client(httpClient)

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -31,7 +31,8 @@ namespace OrasProject.Oras.Registry.Remote.Auth;
 /// <item>Reject HTTP unless <see cref="AllowInsecureHttp"/> is true.</item>
 /// <item>Reject realm URLs containing userinfo.</item>
 /// <item>Allow if realm host matches the registry host (same host).</item>
-/// <item>Allow if realm host is in <see cref="TrustedRealmHosts"/>.</item>
+/// <item>Allow if realm host is in <see cref="TrustedRealmHosts"/>
+/// (empty by default).</item>
 /// <item>Default deny.</item>
 /// </list>
 /// </remarks>
@@ -44,21 +45,27 @@ public sealed class DefaultRealmValidator : IRealmValidator
     public bool AllowInsecureHttp { get; init; }
 
     /// <summary>
-    /// Explicit set of trusted realm hostnames (case-insensitive).
-    /// Realms matching these hosts are allowed after basic URI safety
-    /// checks (scheme policy and userinfo rejection).
+    /// Explicit set of trusted realm hostnames (case-insensitive) whose
+    /// auth realm host differs from the registry host. Realms matching
+    /// these hosts are allowed after basic URI safety checks (scheme
+    /// policy and userinfo rejection).
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Pre-populated with well-known registries whose auth realm
-    /// host differs from the registry host:
+    /// <b>Empty by default.</b> The validator ships with no trusted
+    /// hosts, so out of the box only realms on the <em>same host</em>
+    /// as the registry are allowed. The SDK is intentionally
+    /// host-agnostic and does not bake in trust for any specific
+    /// registry.
     /// </para>
-    /// <list type="bullet">
-    /// <item><c>auth.docker.io</c> — Docker Hub
-    /// (registry: registry-1.docker.io)</item>
-    /// <item><c>gitlab.com</c> — GitLab Container Registry
-    /// (registry: registry.gitlab.com)</item>
-    /// </list>
+    /// <para>
+    /// To allow a registry whose auth realm lives on a different host
+    /// (for example Docker Hub's <c>auth.docker.io</c>, GitLab's
+    /// <c>gitlab.com</c>, or NVIDIA NGC's <c>authn.nvidia.com</c>),
+    /// configure this set explicitly or supply a custom
+    /// <see cref="IRealmValidator"/>. See the realm-validation examples
+    /// and <c>docs/auth/realm-validation.md</c>.
+    /// </para>
     /// <para>
     /// Values are normalized (lowercased, trailing dots stripped)
     /// and frozen on assignment. Mutations to the original
@@ -75,10 +82,7 @@ public sealed class DefaultRealmValidator : IRealmValidator
             .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
 
-    private IReadOnlySet<string> _trustedRealmHosts =
-        FrozenSet.ToFrozenSet(
-            new[] { "auth.docker.io", "gitlab.com" },
-            StringComparer.OrdinalIgnoreCase);
+    private IReadOnlySet<string> _trustedRealmHosts = FrozenSet<string>.Empty;
 
     /// <inheritdoc/>
     public Task<bool> IsRealmAllowedAsync(

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -30,9 +30,10 @@ namespace OrasProject.Oras.Registry.Remote.Auth;
 /// <item>Reject non-HTTP(S) schemes.</item>
 /// <item>Reject HTTP unless <see cref="AllowInsecureHttp"/> is true.</item>
 /// <item>Reject realm URLs containing userinfo.</item>
-/// <item>Allow if realm host matches the registry host (same host).</item>
-/// <item>Allow if realm host is in <see cref="TrustedRealmHosts"/>
-/// (empty by default).</item>
+/// <item>Allow if the realm host and effective port match the
+/// registry (same host and port).</item>
+/// <item>Allow if the realm host is in <see cref="TrustedRealmHosts"/>
+/// (empty by default) and the realm is on the scheme-default port.</item>
 /// <item>Default deny.</item>
 /// </list>
 /// </remarks>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultRealmValidator.cs
@@ -55,9 +55,9 @@ public sealed class DefaultRealmValidator : IRealmValidator
     /// <para>
     /// <b>Empty by default.</b> The validator ships with no trusted
     /// hosts, so out of the box only realms on the <em>same host</em>
-    /// as the registry are allowed. The SDK is intentionally
-    /// host-agnostic and does not bake in trust for any specific
-    /// registry.
+    /// (and effective port) as the registry are allowed. The SDK is
+    /// intentionally host-agnostic and does not bake in trust for any
+    /// specific registry.
     /// </para>
     /// <para>
     /// To allow a registry whose auth realm lives on a different host

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
@@ -299,25 +299,57 @@ public class DefaultRealmValidatorTest
             Realm("http://myreg.io/token")));
     }
 
-    [Fact]
-    public async Task TrustedHostNotAffectedBySchemeBlock()
+    [Theory]
+    [InlineData(
+        "https://registry-1.docker.io/v2/",
+        "https://auth.docker.io/token",
+        "auth.docker.io")]
+    [InlineData(
+        "https://registry.gitlab.com/v2/",
+        "https://gitlab.com/jwt/auth",
+        "gitlab.com")]
+    [InlineData(
+        "https://nvcr.io/v2/",
+        "https://authn.nvidia.com/token",
+        "authn.nvidia.com")]
+    public async Task WellKnownPublicRegistry_RejectedByDefault_AllowedWhenConfigured(
+        string registry, string realm, string trustedHost)
     {
-        // Docker Hub: auth.docker.io is in the default trusted
-        // list — works without explicit TrustedRealmHosts.
-        var validator = new DefaultRealmValidator();
-        Assert.True(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
-            Realm("https://auth.docker.io/token")));
+        // Default ships with no trusted hosts: well-known public
+        // registries whose auth realm is on a different host are
+        // rejected until explicitly opted in.
+        var defaultValidator = new DefaultRealmValidator();
+        Assert.False(await defaultValidator.IsRealmAllowedAsync(
+            Reg(registry), Realm(realm)));
+
+        // Opt in by configuring the realm's auth host.
+        var configured = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                trustedHost
+            }
+        };
+        Assert.True(await configured.IsRealmAllowedAsync(
+            Reg(registry), Realm(realm)));
     }
 
     [Fact]
-    public async Task GitLabRegistry_DefaultTrusted_Allowed()
+    public async Task TrustedHost_NonDefaultPort_Rejected()
     {
-        // GitLab: gitlab.com is in the default trusted list.
-        var validator = new DefaultRealmValidator();
-        Assert.True(await validator.IsRealmAllowedAsync(
-            Reg("https://registry.gitlab.com/v2/"),
-            Realm("https://gitlab.com/jwt/auth")));
+        // A configured trusted host must still be on the default port.
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
+        Assert.False(await validator.IsRealmAllowedAsync(
+            Reg("https://registry.example.com/v2/"),
+            Realm("https://auth.example.com:8443/token")));
     }
 
     [Fact]
@@ -452,21 +484,35 @@ public class DefaultRealmValidatorTest
     public async Task UserinfoOnTrustedHost_Rejected()
     {
         // Userinfo check fires before trusted host check.
-        var validator = new DefaultRealmValidator();
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
         Assert.False(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
+            Reg("https://registry.example.com/v2/"),
             Realm(
-                "https://user@auth.docker.io/token")));
+                "https://user@auth.example.com/token")));
     }
 
     [Fact]
     public async Task HttpOnTrustedHost_RejectedByDefault()
     {
         // HTTP scheme block applies even to trusted hosts.
-        var validator = new DefaultRealmValidator();
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
         Assert.False(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
-            Realm("http://auth.docker.io/token")));
+            Reg("https://registry.example.com/v2/"),
+            Realm("http://auth.example.com/token")));
     }
 
     [Fact]
@@ -483,12 +529,19 @@ public class DefaultRealmValidatorTest
     [Fact]
     public async Task SuperstringHostname_Rejected()
     {
-        // "auth.docker.io.evil.com" is NOT "auth.docker.io"
-        var validator = new DefaultRealmValidator();
+        // "auth.example.com.evil.com" is NOT "auth.example.com"
+        var validator = new DefaultRealmValidator
+        {
+            TrustedRealmHosts = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                "auth.example.com"
+            }
+        };
         Assert.False(await validator.IsRealmAllowedAsync(
-            Reg("https://registry-1.docker.io/v2/"),
+            Reg("https://registry.example.com/v2/"),
             Realm(
-                "https://auth.docker.io.evil.com/tok"
+                "https://auth.example.com.evil.com/tok"
                 )));
     }
 


### PR DESCRIPTION
## What

Make the SDK's realm validation **least-permissive by default**: `DefaultRealmValidator` no
longer ships with any pre-populated trusted realm hosts. Out of the box, only realms on the
**same host** as the registry are allowed. The SDK is intentionally host-agnostic and does not
bake in trust for any specific registry.

Registries whose auth realm host differs from the registry host are now opt-in, via
`DefaultRealmValidator.TrustedRealmHosts` or a custom `IRealmValidator`.

## Why

Baking host-specific trust (Docker Hub, GitLab, NVIDIA NGC, …) into the SDK implies endorsement,
grows without bound as registries are added, and pushes a trust decision into the library that
belongs with the application. A least-permissive default is the safer posture; consumers
explicitly choose which cross-host auth realms to trust.

## ⚠️ BREAKING CHANGE

Registries whose auth realm lives on a different host than the registry are **rejected by
default** and must be opted in. This includes common public registries:

| Registry | Auth realm host |
| --- | --- |
| `registry-1.docker.io` (Docker Hub) | `auth.docker.io` |
| `registry.gitlab.com` (GitLab) | `gitlab.com` |
| `nvcr.io` (NVIDIA NGC) | `authn.nvidia.com` |

### Migration

```csharp
var validator = new DefaultRealmValidator
{
    TrustedRealmHosts = new ImmutableHashSet<string>
    {
        "auth.docker.io",   // Docker Hub
        "gitlab.com",       // GitLab
        "authn.nvidia.com", // NVIDIA NGC
        // ...your enterprise auth endpoints
    }
};

var client = new Client(httpClient) { RealmValidator = validator };
```

Same-host realms (the common case for most private registries) continue to work with no changes.

## Changes

- `DefaultRealmValidator`: default `TrustedRealmHosts` is now empty (`FrozenSet<string>.Empty`);
  XML docs updated to describe the deny-by-default posture and point to the opt-in.
- `DefaultRealmValidatorTest`: converted the docker/gitlab default-trust tests into a parameterized
  test asserting these well-known registries are **rejected by default** and **allowed when
  configured**; re-expressed the userinfo/http/superstring/non-default-port precedence tests using a
  configured trusted host.
- `examples/OrasProject.Oras.Examples.RealmValidation`: fixed the now-stale comment and added
  `CreateClientTrustingWellKnownPublicRegistries`.
- Added `docs/auth/realm-validation.md`.

## Testing

- `dotnet build OrasProject.Oras.sln` — 0 warnings / 0 errors (warnings-as-errors), examples included.
- `DefaultRealmValidatorTest`: 47/47 pass.
- Full suite green on CI. (Locally, the pre-existing Windows-only `SendAsync_RealmValidation_RelativeRealm_Throws` in `ClientTest` is unaffected by this change and passes on Linux/CI.)

## Notes

Supersedes #401 (which added `authn.nvidia.com` to the built-in list — the opposite direction).
#401 will be closed in favor of this.
