### PR TITLE
fix(auth)!: partition ScopeManager scope state by partitionId

### DIFF
--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -687,7 +687,7 @@ public class Client : IClient
                     }
                 case Challenge.Scheme.Bearer:
                     {
-                        var scopes = ScopeManager.GetScopesStringForHost(host);
+                        var scopes = ScopeManager.GetScopesStringForHost(host, partitionId);
                         attemptedKey = string.Join(" ", scopes);
                         if (Cache.TryGetToken(host, schemeFromCache, attemptedKey, out var bearerToken, partitionId))
                         {
@@ -729,7 +729,7 @@ public class Client : IClient
                         throw new AuthenticationException("Missing parameters in the Www-Authenticate challenge.");
                     }
 
-                    var existingScopes = ScopeManager.GetScopesForHost(host);
+                    var existingScopes = ScopeManager.GetScopesForHost(host, partitionId);
                     var newScopes = new SortedSet<Scope>(existingScopes);
                     if (parameters.TryGetValue("scope", out var scopesString))
                     {

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ScopeManager.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ScopeManager.cs
@@ -46,12 +46,13 @@ public class ScopeManager
     /// </summary>
     /// <param name="registry"></param>
     /// <param name="partitionId">
-    /// Optional scope partition identifier. When provided, scopes are isolated by this ID,
-    /// mirroring the token <see cref="Cache"/> partitioning. A null or empty value (the default)
-    /// selects the default partition.
+    /// Scope partition identifier isolating scopes per ID, mirroring the token
+    /// <see cref="Cache"/> partitioning. A null or empty value selects the default partition.
+    /// Required (pass null explicitly for the default) so a forgotten argument cannot silently
+    /// bleed scope state across partitions.
     /// </param>
     /// <returns></returns>
-    public SortedSet<Scope> GetScopesForHost(string registry, string? partitionId = null)
+    public SortedSet<Scope> GetScopesForHost(string registry, string? partitionId)
     {
         return Scopes.TryGetValue(GetScopeKey(registry, partitionId), out var scopes) ? scopes : new();
     }
@@ -63,11 +64,12 @@ public class ScopeManager
     /// </summary>
     /// <param name="registry"></param>
     /// <param name="partitionId">
-    /// Optional scope partition identifier. A null or empty value (the default) selects the
-    /// default partition.
+    /// Scope partition identifier. A null or empty value selects the default partition. Required
+    /// (pass null explicitly for the default) so a forgotten argument cannot silently bleed scope
+    /// state across partitions.
     /// </param>
     /// <returns></returns>
-    public List<string> GetScopesStringForHost(string registry, string? partitionId = null)
+    public List<string> GetScopesStringForHost(string registry, string? partitionId)
     {
         return Scopes.TryGetValue(GetScopeKey(registry, partitionId), out var scopes)
             ? scopes.Select(scope => scope.ToString()).ToList()
@@ -136,10 +138,11 @@ public class ScopeManager
     /// <param name="registry"></param>
     /// <param name="scope"></param>
     /// <param name="partitionId">
-    /// Optional scope partition identifier. A null or empty value (the default) selects the
-    /// default partition.
+    /// Scope partition identifier. A null or empty value selects the default partition. Required
+    /// (pass null explicitly for the default) so a forgotten argument cannot silently bleed scope
+    /// state across partitions.
     /// </param>
-    public static void SetScopeForRegistry(IClient client, string registry, Scope scope, string? partitionId = null)
+    public static void SetScopeForRegistry(IClient client, string registry, Scope scope, string? partitionId)
     {
         if (client is Client authClient)
         {
@@ -156,10 +159,11 @@ public class ScopeManager
     /// <param name="registry">The registry for which the scope is being set.</param>
     /// <param name="scope">The scope to be set for the registry, including its actions.</param>
     /// <param name="partitionId">
-    /// Optional scope partition identifier. A null or empty value (the default) selects the
-    /// default partition, preserving the original unpartitioned behavior.
+    /// Scope partition identifier. A null or empty value selects the default partition, preserving
+    /// the original unpartitioned behavior. Required (pass null explicitly for the default) so a
+    /// forgotten argument cannot silently bleed scope state across partitions.
     /// </param>
-    public void SetScopeForRegistry(string registry, Scope scope, string? partitionId = null)
+    public void SetScopeForRegistry(string registry, Scope scope, string? partitionId)
     {
         if (scope.Actions.Contains(Scope.ActionWildcard))
         {

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ScopeManager.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ScopeManager.cs
@@ -27,48 +27,85 @@ public class ScopeManager
     private ConcurrentDictionary<string, SortedSet<Scope>> Scopes { get; } = new();
 
     /// <summary>
-    /// GetScopesForHost returns a sorted set of scopes for the given registry if found,
-    /// otherwise, returns empty sorted set.
+    /// GetScopeKey generates the storage key for scope state from the registry host and an
+    /// optional <paramref name="partitionId"/>, mirroring <see cref="Cache"/>'s partitioning
+    /// scheme. Pipe (|) is used as the delimiter since it cannot appear in registry hostnames.
+    /// When <paramref name="partitionId"/> is null or empty, the key is the registry alone,
+    /// preserving the default (unpartitioned) behavior.
+    /// </summary>
+    /// <param name="registry">The registry host.</param>
+    /// <param name="partitionId">Optional scope partition identifier.</param>
+    /// <returns>A composite key isolating scope state per (partitionId, registry).</returns>
+    private static string GetScopeKey(string registry, string? partitionId) =>
+        string.IsNullOrEmpty(partitionId) ? registry : $"{partitionId}|{registry}";
+
+    /// <summary>
+    /// GetScopesForHost returns a sorted set of scopes for the given registry within the scope
+    /// partition identified by <paramref name="partitionId"/> if found, otherwise, returns an
+    /// empty sorted set. Scope state is isolated per (partitionId, registry).
     /// </summary>
     /// <param name="registry"></param>
+    /// <param name="partitionId">
+    /// Optional scope partition identifier. When provided, scopes are isolated by this ID,
+    /// mirroring the token <see cref="Cache"/> partitioning. A null or empty value (the default)
+    /// selects the default partition.
+    /// </param>
     /// <returns></returns>
-    public SortedSet<Scope> GetScopesForHost(string registry)
+    public SortedSet<Scope> GetScopesForHost(string registry, string? partitionId = null)
     {
-        return Scopes.TryGetValue(registry, out var scopes) ? scopes : new();
+        return Scopes.TryGetValue(GetScopeKey(registry, partitionId), out var scopes) ? scopes : new();
     }
 
     /// <summary>
-    /// GetScopesStringForHost returns a list of scopes string for the given registry if found,
-    /// otherwise, returns empty list.
+    /// GetScopesStringForHost returns a list of scope strings for the given registry within the
+    /// scope partition identified by <paramref name="partitionId"/> if found, otherwise, returns
+    /// empty list. Scope state is isolated per (partitionId, registry).
     /// </summary>
     /// <param name="registry"></param>
+    /// <param name="partitionId">
+    /// Optional scope partition identifier. A null or empty value (the default) selects the
+    /// default partition.
+    /// </param>
     /// <returns></returns>
-    public List<string> GetScopesStringForHost(string registry)
+    public List<string> GetScopesStringForHost(string registry, string? partitionId = null)
     {
-        return Scopes.TryGetValue(registry, out var scopes)
+        return Scopes.TryGetValue(GetScopeKey(registry, partitionId), out var scopes)
             ? scopes.Select(scope => scope.ToString()).ToList()
             : new();
     }
 
     /// <summary>
-    /// SetActionsForRepository sets actions for the given repository if the client is auth.Client.
+    /// SetActionsForRepository sets actions for the given repository within the scope partition
+    /// identified by <paramref name="partitionId"/> if the client is auth.Client.
     /// </summary>
     /// <param name="client"></param>
     /// <param name="reference"></param>
+    /// <param name="partitionId">
+    /// Scope partition identifier. A null or empty value selects the default partition.
+    /// </param>
     /// <param name="actions"></param>
-    public static void SetActionsForRepository(IClient client, Reference reference, params Scope.Action[] actions)
+    public static void SetActionsForRepository(
+        IClient client,
+        Reference reference,
+        string? partitionId,
+        params Scope.Action[] actions)
     {
         if (client is Client authClient)
         {
-            authClient.ScopeManager.SetActionsForRepository(reference, actions);
+            authClient.ScopeManager.SetActionsForRepository(reference, partitionId, actions);
         }
     }
 
     /// <summary>
-    /// SetActionsForRepository sets the actions for a repository by creating a scope and associating it with the specified registry.
+    /// SetActionsForRepository sets the actions for a repository by creating a scope and
+    /// associating it with the specified registry within the scope partition identified by
+    /// <paramref name="partitionId"/>.
     /// </summary>
     /// <param name="reference">
     /// The reference object containing the registry and repository information.
+    /// </param>
+    /// <param name="partitionId">
+    /// Scope partition identifier. A null or empty value selects the default partition.
     /// </param>
     /// <param name="actions">
     /// The actions to be associated with the repository scope.
@@ -76,41 +113,53 @@ public class ScopeManager
     /// <exception cref="ArgumentNullException">
     /// Thrown when the registry or repository in the <paramref name="reference"/> is null.
     /// </exception>
-    public void SetActionsForRepository(Reference reference, params Scope.Action[] actions)
+    public void SetActionsForRepository(Reference reference, string? partitionId, params Scope.Action[] actions)
     {
-        var registry = reference.Registry ?? throw new ArgumentNullException(reference.Registry);
-        var repository = reference.Repository ?? throw new ArgumentNullException(reference.Repository);
+        var registry = reference.Registry
+            ?? throw new ArgumentNullException(nameof(reference), "Reference.Registry is null.");
+        var repository = reference.Repository
+            ?? throw new ArgumentNullException(nameof(reference), "Reference.Repository is null.");
 
         var scope = new Scope(
             resourceType: "repository",
             resourceName: repository,
             actions: actions.Select(Scope.ActionToString).ToHashSet(StringComparer.OrdinalIgnoreCase));
 
-        SetScopeForRegistry(registry, scope);
+        SetScopeForRegistry(registry, scope, partitionId);
     }
 
     /// <summary>
-    /// SetScopeForRegistry sets scope for the given registry when the client is auth.Client.
+    /// SetScopeForRegistry sets scope for the given registry within the scope partition
+    /// identified by <paramref name="partitionId"/> when the client is auth.Client.
     /// </summary>
     /// <param name="client"></param>
     /// <param name="registry"></param>
     /// <param name="scope"></param>
-    public static void SetScopeForRegistry(IClient client, string registry, Scope scope)
+    /// <param name="partitionId">
+    /// Optional scope partition identifier. A null or empty value (the default) selects the
+    /// default partition.
+    /// </param>
+    public static void SetScopeForRegistry(IClient client, string registry, Scope scope, string? partitionId = null)
     {
         if (client is Client authClient)
         {
-            authClient.ScopeManager.SetScopeForRegistry(registry, scope);
+            authClient.ScopeManager.SetScopeForRegistry(registry, scope, partitionId);
         }
     }
 
     /// <summary>
-    /// SetScopeForRegistry sets the scope for a specific registry. If the scope contains the "All" action, 
-    /// it ensures that only the "All" action is retained. Otherwise, it merges the actions 
-    /// of the provided scope with any existing scope for the registry.
+    /// SetScopeForRegistry sets the scope for a specific registry within the scope partition
+    /// identified by <paramref name="partitionId"/>. If the scope contains the "All" action, it
+    /// ensures that only the "All" action is retained. Otherwise, it merges the actions of the
+    /// provided scope with any existing scope for the (partitionId, registry).
     /// </summary>
     /// <param name="registry">The registry for which the scope is being set.</param>
     /// <param name="scope">The scope to be set for the registry, including its actions.</param>
-    public void SetScopeForRegistry(string registry, Scope scope)
+    /// <param name="partitionId">
+    /// Optional scope partition identifier. A null or empty value (the default) selects the
+    /// default partition, preserving the original unpartitioned behavior.
+    /// </param>
+    public void SetScopeForRegistry(string registry, Scope scope, string? partitionId = null)
     {
         if (scope.Actions.Contains(Scope.ActionWildcard))
         {
@@ -118,7 +167,7 @@ public class ScopeManager
             scope.Actions.Add(Scope.ActionWildcard);
         }
 
-        Scopes.AddOrUpdate(registry,
+        Scopes.AddOrUpdate(GetScopeKey(registry, partitionId),
             new SortedSet<Scope> { scope },
             (_, existingScopes) => Scope.AddOrMergeScope(existingScopes, scope));
     }

--- a/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
+++ b/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
@@ -42,7 +42,11 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
     /// <exception cref="Exceptions.ResponseException"></exception>
     public async Task<Stream> FetchAsync(Descriptor target, CancellationToken cancellationToken = default)
     {
-        ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(
+            Repository.Options.Client,
+            Repository.Options.Reference,
+            Repository.Options.PartitionId,
+            Scope.Action.Pull);
         var remoteReference = Repository.ParseReferenceFromDigest(target.Digest);
         var url = new UriFactory(remoteReference, Repository.Options.PlainHttp).BuildRepositoryBlob();
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -105,7 +109,11 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
         FetchOptions options,
         CancellationToken cancellationToken = default)
     {
-        ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(
+            Repository.Options.Client,
+            Repository.Options.Reference,
+            Repository.Options.PartitionId,
+            Scope.Action.Pull);
         var remoteReference = Repository.ParseReference(reference);
         var refDigest = remoteReference.Digest;
         var url = new UriFactory(remoteReference, Repository.Options.PlainHttp).BuildRepositoryBlob();
@@ -183,7 +191,12 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
     {
         // pushing usually requires both pull and push actions.
         // Reference: https://github.com/distribution/distribution/blob/v2.7.1/registry/handlers/app.go#L921-L930
-        ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull, Scope.Action.Push);
+        ScopeManager.SetActionsForRepository(
+            Repository.Options.Client,
+            Repository.Options.Reference,
+            Repository.Options.PartitionId,
+            Scope.Action.Pull,
+            Scope.Action.Push);
         var url = new UriFactory(Repository.Options).BuildRepositoryBlobUpload();
         using var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
         using (var response = await Repository.Options.Client.SendAsync(
@@ -230,7 +243,11 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
         ResolveOptions options,
         CancellationToken cancellationToken = default)
     {
-        ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(
+            Repository.Options.Client,
+            Repository.Options.Reference,
+            Repository.Options.PartitionId,
+            Scope.Action.Pull);
         var remoteReference = Repository.ParseReference(reference);
         var refDigest = remoteReference.Digest;
         var url = new UriFactory(remoteReference, Repository.Options.PlainHttp).BuildRepositoryBlob();
@@ -266,7 +283,11 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
     /// <exception cref="Exceptions.ResponseException">Thrown when the request fails</exception>
     public async Task<Uri?> GetBlobLocationAsync(Descriptor target, CancellationToken cancellationToken = default)
     {
-        ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(
+            Repository.Options.Client,
+            Repository.Options.Reference,
+            Repository.Options.PartitionId,
+            Scope.Action.Pull);
         var remoteReference = Repository.ParseReferenceFromDigest(target.Digest);
         var url = new UriFactory(remoteReference, Repository.Options.PlainHttp).BuildRepositoryBlob();
 
@@ -371,12 +392,21 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
     {
         // pushing usually requires both pull and push actions.
         // Reference: https://github.com/distribution/distribution/blob/v2.7.1/registry/handlers/app.go#L921-L930
-        ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull, Scope.Action.Push);
+        ScopeManager.SetActionsForRepository(
+            Repository.Options.Client,
+            Repository.Options.Reference,
+            Repository.Options.PartitionId,
+            Scope.Action.Pull,
+            Scope.Action.Push);
 
         // We also need pull access to the source repo.
         if (Reference.TryParse(fromRepository, out var fromReference))
         {
-            ScopeManager.SetActionsForRepository(Repository.Options.Client, fromReference, Scope.Action.Pull);
+            ScopeManager.SetActionsForRepository(
+                Repository.Options.Client,
+                fromReference,
+                Repository.Options.PartitionId,
+                Scope.Action.Pull);
         }
 
         var url = new UriFactory(Repository.Options).BuildRepositoryBlobUpload();

--- a/src/OrasProject.Oras/Registry/Remote/ManifestStore.cs
+++ b/src/OrasProject.Oras/Registry/Remote/ManifestStore.cs
@@ -41,7 +41,11 @@ public class ManifestStore(Repository repository) : IManifestStore
     /// <exception cref="Exception"></exception>
     public async Task<Stream> FetchAsync(Descriptor target, CancellationToken cancellationToken = default)
     {
-        ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(
+            Repository.Options.Client,
+            Repository.Options.Reference,
+            Repository.Options.PartitionId,
+            Scope.Action.Pull);
         var remoteReference = Repository.ParseReferenceFromDigest(target.Digest);
         var url = new UriFactory(remoteReference, Repository.Options.PlainHttp).BuildRepositoryManifest();
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -109,7 +113,11 @@ public class ManifestStore(Repository repository) : IManifestStore
         FetchOptions options,
         CancellationToken cancellationToken = default)
     {
-        ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(
+            Repository.Options.Client,
+            Repository.Options.Reference,
+            Repository.Options.PartitionId,
+            Scope.Action.Pull);
         var remoteReference = Repository.ParseReference(reference);
         var url = new UriFactory(remoteReference, Repository.Options.PlainHttp).BuildRepositoryManifest();
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -356,7 +364,12 @@ public class ManifestStore(Repository repository) : IManifestStore
     {
         // pushing usually requires both pull and push actions.
         // Reference: https://github.com/distribution/distribution/blob/v2.7.1/registry/handlers/app.go#L921-L930
-        ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull, Scope.Action.Push);
+        ScopeManager.SetActionsForRepository(
+            Repository.Options.Client,
+            Repository.Options.Reference,
+            Repository.Options.PartitionId,
+            Scope.Action.Pull,
+            Scope.Action.Push);
         var url = new UriFactory(remoteReference, Repository.Options.PlainHttp).BuildRepositoryManifest();
         var request = new HttpRequestMessage(HttpMethod.Put, url)
         {
@@ -398,7 +411,11 @@ public class ManifestStore(Repository repository) : IManifestStore
         ResolveOptions options,
         CancellationToken cancellationToken = default)
     {
-        ScopeManager.SetActionsForRepository(Repository.Options.Client, Repository.Options.Reference, Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(
+            Repository.Options.Client,
+            Repository.Options.Reference,
+            Repository.Options.PartitionId,
+            Scope.Action.Pull);
         var remoteReference = Repository.ParseReference(reference);
         var url = new UriFactory(remoteReference, Repository.Options.PlainHttp).BuildRepositoryManifest();
         using var request = new HttpRequestMessage(HttpMethod.Head, url);

--- a/src/OrasProject.Oras/Registry/Remote/Registry.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Registry.cs
@@ -95,7 +95,11 @@ public class Registry : IRegistry
     {
         if (Scope.TryParse(Scope.ScopeRegistryCatalog, out var scope))
         {
-            ScopeManager.SetScopeForRegistry(RepositoryOptions.Client, RepositoryOptions.Reference.Registry, scope);
+            ScopeManager.SetScopeForRegistry(
+                RepositoryOptions.Client,
+                RepositoryOptions.Reference.Registry,
+                scope,
+                RepositoryOptions.PartitionId);
         }
 
         var url = new UriFactory(_opts).BuildRegistryCatalog();

--- a/src/OrasProject.Oras/Registry/Remote/Repository.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Repository.cs
@@ -270,7 +270,11 @@ public class Repository : IRepository
     /// <returns></returns>
     public async IAsyncEnumerable<string> ListTagsAsync(string? last = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        ScopeManager.SetActionsForRepository(Options.Client, Options.Reference, Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(
+            Options.Client,
+            Options.Reference,
+            Options.PartitionId,
+            Scope.Action.Pull);
         var url = new UriFactory(_opts).BuildRepositoryTagList();
         do
         {
@@ -340,7 +344,11 @@ public class Repository : IRepository
     /// <exception cref="NotFoundException"></exception>
     internal async Task DeleteAsync(Descriptor target, bool isManifest, CancellationToken cancellationToken = default)
     {
-        ScopeManager.SetActionsForRepository(Options.Client, Options.Reference, Scope.Action.Delete);
+        ScopeManager.SetActionsForRepository(
+            Options.Client,
+            Options.Reference,
+            Options.PartitionId,
+            Scope.Action.Delete);
         var remoteReference = ParseReferenceFromDigest(target.Digest);
         var uriFactory = new UriFactory(remoteReference, _opts.PlainHttp);
         var url = isManifest ? uriFactory.BuildRepositoryManifest() : uriFactory.BuildRepositoryBlob();
@@ -536,7 +544,11 @@ public class Repository : IRepository
     internal async IAsyncEnumerable<Descriptor> FetchReferrersByApi(Descriptor descriptor, string? artifactType,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        ScopeManager.SetActionsForRepository(Options.Client, Options.Reference, Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(
+            Options.Client,
+            Options.Reference,
+            Options.PartitionId,
+            Scope.Action.Pull);
         var reference = new Reference(Options.Reference)
         {
             ContentReference = descriptor.Digest
@@ -681,7 +693,11 @@ public class Repository : IRepository
     {
         try
         {
-            ScopeManager.SetActionsForRepository(Options.Client, Options.Reference, Scope.Action.Pull);
+            ScopeManager.SetActionsForRepository(
+                Options.Client,
+                Options.Reference,
+                Options.PartitionId,
+                Scope.Action.Pull);
             var result = await FetchAsync(referrersTag, cancellationToken).ConfigureAwait(false);
             result.Descriptor.LimitSize(Options.MaxMetadataBytes);
             using var stream = result.Stream;
@@ -728,7 +744,11 @@ public class Repository : IRepository
             // referrers state is unknown
             // lock to limit the rate of pinging referrers API
 
-            ScopeManager.SetActionsForRepository(Options.Client, Options.Reference, Scope.Action.Pull);
+            ScopeManager.SetActionsForRepository(
+                Options.Client,
+                Options.Reference,
+                Options.PartitionId,
+                Scope.Action.Pull);
             var reference = new Reference(Options.Reference)
             {
                 ContentReference = Referrers.ZeroDigest

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -2735,4 +2735,91 @@ public class ClientTest
                 cancellationToken: CancellationToken.None));
         Assert.Contains("not allowed", ex.Message);
     }
+
+    [Fact]
+    public async Task SendAsync_BearerAuth_IsolatesScopesByPartition()
+    {
+        // Arrange: one shared Client/ScopeManager serving two partitions against the same
+        // host. Each partition has a distinct repository scope; the token request issued for
+        // one partition must carry ONLY that partition's scope (no cross-partition bleed).
+        var host = "example.com";
+        var realm = "https://auth.example.com";
+        var authHost = "auth.example.com";
+        var service = "test_service";
+        var token = "access_token";
+
+        var tokenRequestScopes = new List<string>();
+
+        HttpResponseMessage MockHttpRequestHandler(HttpRequestMessage req, CancellationToken ct)
+        {
+            // Distribution token endpoint (GET) — no credentials configured.
+            if (req.Method == HttpMethod.Get && req.RequestUri?.Host == authHost)
+            {
+                var query = System.Web.HttpUtility.ParseQueryString(req.RequestUri.Query);
+                tokenRequestScopes.Add(query["scope"] ?? string.Empty);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent($"{{\"access_token\": \"{token}\"}}"),
+                    RequestMessage = req
+                };
+            }
+
+            // Registry endpoint: 200 only with the issued token, otherwise a Bearer challenge.
+            if (req.Method == HttpMethod.Get && req.RequestUri?.Host == host)
+            {
+                if (req.Headers.Authorization?.Scheme == "Bearer"
+                    && req.Headers.Authorization.Parameter == token)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = req };
+                }
+
+                var unauthorized = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    RequestMessage = req
+                };
+                unauthorized.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(
+                    "Bearer", $"realm=\"{realm}\",service=\"{service}\""));
+                return unauthorized;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = req };
+        }
+
+        var mockHandler = CustomHandler(MockHttpRequestHandler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    authHost
+                }
+            }
+        };
+
+        // Pre-seed distinct scopes per partition on the same host.
+        Assert.True(Scope.TryParse("repository:repo-a:pull", out var scopeA));
+        client.ScopeManager.SetScopeForRegistry(host, scopeA, "partition-a");
+        Assert.True(Scope.TryParse("repository:repo-b:pull", out var scopeB));
+        client.ScopeManager.SetScopeForRegistry(host, scopeB, "partition-b");
+
+        // Act: send a request for each partition against the same host.
+        using var requestA = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+        using var responseA = await client.SendAsync(
+            requestA, partitionId: "partition-a", cancellationToken: CancellationToken.None);
+
+        using var requestB = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
+        using var responseB = await client.SendAsync(
+            requestB, partitionId: "partition-b", cancellationToken: CancellationToken.None);
+
+        // Assert: both succeed, and each partition's token request carried only its own scope.
+        Assert.Equal(HttpStatusCode.OK, responseA.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, responseB.StatusCode);
+
+        Assert.Equal(2, tokenRequestScopes.Count);
+        Assert.Equal("repository:repo-a:pull", tokenRequestScopes[0]);
+        Assert.DoesNotContain("repo-b", tokenRequestScopes[0]);
+        Assert.Equal("repository:repo-b:pull", tokenRequestScopes[1]);
+        Assert.DoesNotContain("repo-a", tokenRequestScopes[1]);
+    }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ClientTest.cs
@@ -902,9 +902,9 @@ public class ClientTest
         var client = new Client(new HttpClient(mockHandler.Object));
         client.Cache.SetCache(host, Challenge.Scheme.Bearer, string.Join(" ", scopes), token);
         Assert.True(Scope.TryParse(scopes[0], out var scope1));
-        client.ScopeManager.SetScopeForRegistry(host, scope1);
+        client.ScopeManager.SetScopeForRegistry(host, scope1, null);
         Assert.True(Scope.TryParse(scopes[1], out var scope2));
-        client.ScopeManager.SetScopeForRegistry(host, scope2);
+        client.ScopeManager.SetScopeForRegistry(host, scope2, null);
         client.CustomHeaders["foo"] = ["bar"];
         client.CustomHeaders["foo"] = ["newBar"];
         client.CustomHeaders["key1"] = ["value1"];
@@ -1156,7 +1156,7 @@ public class ClientTest
         };
         // Populate scope manager to ensure scopes passed into token request
         Assert.True(Scope.TryParse(scopes[0], out var scope));
-        client.ScopeManager.SetScopeForRegistry(host, scope);
+        client.ScopeManager.SetScopeForRegistry(host, scope, null);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
 
@@ -1204,7 +1204,7 @@ public class ClientTest
 
         var client = new Client(new HttpClient(CustomHandler(MockHttpRequestHandler).Object));
         Assert.True(Scope.TryParse(scopes[0], out var scope));
-        client.ScopeManager.SetScopeForRegistry(host, scope);
+        client.ScopeManager.SetScopeForRegistry(host, scope, null);
 
         using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}");
 
@@ -1605,9 +1605,9 @@ public class ClientTest
         var client = new Client(new HttpClient(handler.Object));
         // Inject scopes for the authority so the client builds the same key
         Assert.True(Scope.TryParse(scopes[0], out var s1));
-        client.ScopeManager.SetScopeForRegistry(authority, s1);
+        client.ScopeManager.SetScopeForRegistry(authority, s1, null);
         Assert.True(Scope.TryParse(scopes[1], out var s2));
-        client.ScopeManager.SetScopeForRegistry(authority, s2);
+        client.ScopeManager.SetScopeForRegistry(authority, s2, null);
 
         // Inject mocked ICache to supply pre-cached token
         var cacheMock = new Mock<ICache>(MockBehavior.Strict);

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ScopeManagerTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ScopeManagerTest.cs
@@ -32,8 +32,8 @@ public class ScopeManagerTest
         );
 
         // Act
-        scopeManager.SetScopeForRegistry("registry1", scope);
-        var result = scopeManager.GetScopesForHost("registry1");
+        scopeManager.SetScopeForRegistry("registry1", scope, null);
+        var result = scopeManager.GetScopesForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -66,11 +66,11 @@ public class ScopeManagerTest
         );
 
         // Act
-        scopeManager.SetScopeForRegistry("registry1", scope1);
-        scopeManager.SetScopeForRegistry("registry1", scope2);
-        scopeManager.SetScopeForRegistry("registry1", scope3);
+        scopeManager.SetScopeForRegistry("registry1", scope1, null);
+        scopeManager.SetScopeForRegistry("registry1", scope2, null);
+        scopeManager.SetScopeForRegistry("registry1", scope3, null);
 
-        var result = scopeManager.GetScopesForHost("registry1");
+        var result = scopeManager.GetScopesForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -107,11 +107,11 @@ public class ScopeManagerTest
         );
 
         // Act
-        scopeManager.SetScopeForRegistry("registry1", scope1);
-        scopeManager.SetScopeForRegistry("registry1", scope2);
-        scopeManager.SetScopeForRegistry("registry1", scope3);
+        scopeManager.SetScopeForRegistry("registry1", scope1, null);
+        scopeManager.SetScopeForRegistry("registry1", scope2, null);
+        scopeManager.SetScopeForRegistry("registry1", scope3, null);
 
-        var results = scopeManager.GetScopesForHost("registry1");
+        var results = scopeManager.GetScopesForHost("registry1", null);
 
         string[] expectedResources = ["registry", "catalog", "repository", "repo1"];
         string[] expectedActions = [Scope.ActionWildcard, Scope.ActionPull];
@@ -137,9 +137,9 @@ public class ScopeManagerTest
         var scope2 = new Scope("repository", "repo1", new() { Scope.ActionPush });
 
         // Act
-        scopeManager.SetScopeForRegistry("registry1", scope1);
-        scopeManager.SetScopeForRegistry("registry1", scope2);
-        var result = scopeManager.GetScopesForHost("registry1");
+        scopeManager.SetScopeForRegistry("registry1", scope1, null);
+        scopeManager.SetScopeForRegistry("registry1", scope2, null);
+        var result = scopeManager.GetScopesForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -171,9 +171,9 @@ public class ScopeManagerTest
         var scope2 = new Scope("repository", "repo1", new() { Scope.ActionWildcard });
 
         // Act
-        scopeManager.SetScopeForRegistry("registry1", scope1);
-        scopeManager.SetScopeForRegistry("registry1", scope2);
-        var result = scopeManager.GetScopesForHost("registry1");
+        scopeManager.SetScopeForRegistry("registry1", scope1, null);
+        scopeManager.SetScopeForRegistry("registry1", scope2, null);
+        var result = scopeManager.GetScopesForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -190,9 +190,9 @@ public class ScopeManagerTest
         var scope = new Scope("repository", "repo1", new() { Scope.ActionPull });
 
         // Act
-        scopeManager.SetScopeForRegistry("registry1", scope);
-        scopeManager.SetScopeForRegistry("registry1", scope);
-        var result = scopeManager.GetScopesForHost("registry1");
+        scopeManager.SetScopeForRegistry("registry1", scope, null);
+        scopeManager.SetScopeForRegistry("registry1", scope, null);
+        var result = scopeManager.GetScopesForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -210,9 +210,9 @@ public class ScopeManagerTest
         var scope2 = new Scope("repository", "repo2", new() { Scope.ActionPush });
 
         // Act
-        scopeManager.SetScopeForRegistry("registry1", scope1);
-        scopeManager.SetScopeForRegistry("registry1", scope2);
-        var result = scopeManager.GetScopesForHost("registry1");
+        scopeManager.SetScopeForRegistry("registry1", scope1, null);
+        scopeManager.SetScopeForRegistry("registry1", scope2, null);
+        var result = scopeManager.GetScopesForHost("registry1", null);
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -233,10 +233,10 @@ public class ScopeManagerTest
             "repo1",
             new() { Scope.ActionPush, Scope.ActionPull }
         );
-        scopeManager.SetScopeForRegistry("registry1", scope);
+        scopeManager.SetScopeForRegistry("registry1", scope, null);
 
         // Act
-        var result = scopeManager.GetScopesStringForHost("registry1");
+        var result = scopeManager.GetScopesStringForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -252,7 +252,7 @@ public class ScopeManagerTest
         var scopeManager = new ScopeManager();
 
         // Act
-        var result = scopeManager.GetScopesStringForHost("empty-registry");
+        var result = scopeManager.GetScopesStringForHost("empty-registry", null);
 
         // Assert
         Assert.NotNull(result);
@@ -267,10 +267,10 @@ public class ScopeManagerTest
         // Arrange
         var scopeManager = new ScopeManager();
         var scope = new Scope("repository", "repo1", new() { Scope.ActionPush, Scope.ActionPull, Scope.ActionDelete });
-        scopeManager.SetScopeForRegistry("registry1", scope);
+        scopeManager.SetScopeForRegistry("registry1", scope, null);
 
         // Act
-        var result = scopeManager.GetScopesStringForHost("registry1");
+        var result = scopeManager.GetScopesStringForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -311,13 +311,13 @@ public class ScopeManagerTest
             "catalog",
             new() { Scope.ActionPush, Scope.ActionPull, Scope.ActionDelete, Scope.ActionWildcard }
         );
-        scopeManager.SetScopeForRegistry("registry1", scope1);
-        scopeManager.SetScopeForRegistry("registry1", scope2);
-        scopeManager.SetScopeForRegistry("registry1", scope3);
-        scopeManager.SetScopeForRegistry("registry1", scope4);
+        scopeManager.SetScopeForRegistry("registry1", scope1, null);
+        scopeManager.SetScopeForRegistry("registry1", scope2, null);
+        scopeManager.SetScopeForRegistry("registry1", scope3, null);
+        scopeManager.SetScopeForRegistry("registry1", scope4, null);
 
         // Act
-        var result = scopeManager.GetScopesStringForHost("registry1");
+        var result = scopeManager.GetScopesStringForHost("registry1", null);
 
         // Assert
         Assert.Equal(4, result.Count);
@@ -340,10 +340,10 @@ public class ScopeManagerTest
             "repo1",
             new() { Scope.ActionWildcard, Scope.ActionPull, Scope.ActionDelete }
         );
-        scopeManager.SetScopeForRegistry("registry1", scope);
+        scopeManager.SetScopeForRegistry("registry1", scope, null);
 
         // Act
-        var result = scopeManager.GetScopesStringForHost("registry1");
+        var result = scopeManager.GetScopesStringForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -359,7 +359,7 @@ public class ScopeManagerTest
         var scopeManager = new ScopeManager();
 
         // Act
-        var result = scopeManager.GetScopesForHost("nonexistent-registry");
+        var result = scopeManager.GetScopesForHost("nonexistent-registry", null);
 
         // Assert
         Assert.NotNull(result);
@@ -380,7 +380,7 @@ public class ScopeManagerTest
 
         // Act
         scopeManager.SetActionsForRepository(reference, null, Scope.Action.Pull);
-        var result = scopeManager.GetScopesForHost("registry1");
+        var result = scopeManager.GetScopesForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -405,7 +405,7 @@ public class ScopeManagerTest
 
         // Act
         scopeManager.SetActionsForRepository(reference, null, Scope.Action.Pull, Scope.Action.Push, Scope.Action.Push);
-        var result = scopeManager.GetScopesForHost("registry1");
+        var result = scopeManager.GetScopesForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -432,7 +432,7 @@ public class ScopeManagerTest
 
         // Act
         scopeManager.SetActionsForRepository(reference, null, Scope.Action.All, Scope.Action.Pull);
-        var result = scopeManager.GetScopesForHost("registry1");
+        var result = scopeManager.GetScopesForHost("registry1", null);
 
         // Assert
         Assert.Single(result);
@@ -468,7 +468,7 @@ public class ScopeManagerTest
         ScopeManager.SetActionsForRepository(client, reference, null, Scope.Action.Pull, Scope.Action.Push);
 
         // Assert
-        var scopes = client.ScopeManager.GetScopesForHost("registry1");
+        var scopes = client.ScopeManager.GetScopesForHost("registry1", null);
         Assert.Single(scopes);
         var scope = scopes.First();
         Assert.Equal("repository", scope.ResourceType);
@@ -489,7 +489,7 @@ public class ScopeManagerTest
         ScopeManager.SetActionsForRepository(client, reference, null, Scope.Action.All);
 
         // Assert
-        var scopes = client.ScopeManager.GetScopesForHost("registry1");
+        var scopes = client.ScopeManager.GetScopesForHost("registry1", null);
         Assert.Single(scopes);
         var scope = scopes.First();
         Assert.Single(scope.Actions);
@@ -505,7 +505,7 @@ public class ScopeManagerTest
 
         // Act / Assert
         var ex = Record.Exception(() =>
-            ScopeManager.SetScopeForRegistry(httpClient, "registry1", scope));
+            ScopeManager.SetScopeForRegistry(httpClient, "registry1", scope, null));
 
         // no exception, no scopes stored anywhere
         Assert.Null(ex);
@@ -519,10 +519,10 @@ public class ScopeManagerTest
         var scope = new Scope("repository", "repo1", new() { Scope.ActionPull, Scope.ActionPush });
 
         // Act
-        ScopeManager.SetScopeForRegistry(client, "registry1", scope);
+        ScopeManager.SetScopeForRegistry(client, "registry1", scope, null);
 
         // Assert
-        var scopes = client.ScopeManager.GetScopesForHost("registry1");
+        var scopes = client.ScopeManager.GetScopesForHost("registry1", null);
         Assert.Single(scopes);
         var result = scopes.First();
         Assert.Equal("repository", result.ResourceType);
@@ -540,11 +540,11 @@ public class ScopeManagerTest
         var s2 = new Scope("repository", "repo1", new() { Scope.ActionPush });
 
         // Act
-        ScopeManager.SetScopeForRegistry(client, "registry1", s1);
-        ScopeManager.SetScopeForRegistry(client, "registry1", s2);
+        ScopeManager.SetScopeForRegistry(client, "registry1", s1, null);
+        ScopeManager.SetScopeForRegistry(client, "registry1", s2, null);
 
         // Assert
-        var scopes = client.ScopeManager.GetScopesForHost("registry1");
+        var scopes = client.ScopeManager.GetScopesForHost("registry1", null);
         Assert.Single(scopes);
         var merged = scopes.First();
         Assert.Contains(Scope.ActionPull, merged.Actions);
@@ -560,11 +560,11 @@ public class ScopeManagerTest
         var s2 = new Scope("repository", "repo1", new() { Scope.ActionWildcard });
 
         // Act
-        ScopeManager.SetScopeForRegistry(client, "registry1", s1);
-        ScopeManager.SetScopeForRegistry(client, "registry1", s2);
+        ScopeManager.SetScopeForRegistry(client, "registry1", s1, null);
+        ScopeManager.SetScopeForRegistry(client, "registry1", s2, null);
 
         // Assert
-        var scopes = client.ScopeManager.GetScopesForHost("registry1");
+        var scopes = client.ScopeManager.GetScopesForHost("registry1", null);
         Assert.Single(scopes);
         var updated = scopes.First();
         Assert.Single(updated.Actions);
@@ -604,11 +604,11 @@ public class ScopeManagerTest
         var namedScope = new Scope("repository", "repo-named", new() { Scope.ActionPull });
 
         // Act: default (no partition) vs a named partition on the same host.
-        scopeManager.SetScopeForRegistry("registry1", defaultScope);
+        scopeManager.SetScopeForRegistry("registry1", defaultScope, null);
         scopeManager.SetScopeForRegistry("registry1", namedScope, "partition-a");
 
         // Assert
-        var defaultScopes = scopeManager.GetScopesForHost("registry1");
+        var defaultScopes = scopeManager.GetScopesForHost("registry1", null);
         Assert.Single(defaultScopes);
         Assert.Contains(defaultScope, defaultScopes);
         Assert.DoesNotContain(namedScope, defaultScopes);
@@ -630,14 +630,11 @@ public class ScopeManagerTest
         scopeManager.SetScopeForRegistry("registry1", scope, null);
 
         // Assert: null and "" both select the default partition (consistent with Cache).
-        var viaNoArg = scopeManager.GetScopesForHost("registry1");
         var viaNull = scopeManager.GetScopesForHost("registry1", null);
         var viaEmpty = scopeManager.GetScopesForHost("registry1", string.Empty);
 
-        Assert.Single(viaNoArg);
         Assert.Single(viaNull);
         Assert.Single(viaEmpty);
-        Assert.Contains(scope, viaNoArg);
         Assert.Contains(scope, viaNull);
         Assert.Contains(scope, viaEmpty);
     }
@@ -665,18 +662,18 @@ public class ScopeManagerTest
     }
 
     [Fact]
-    public void GetScopesStringForHost_DefaultPartition_OmittedPartitionMatchesNull()
+    public void GetScopesStringForHost_NullAndEmptyPartition_SelectSameDefaultPartition()
     {
         // Arrange
         var scopeManager = new ScopeManager();
         var scope = new Scope("repository", "repo1", new() { Scope.ActionPull, Scope.ActionPush });
-        scopeManager.SetScopeForRegistry("registry1", scope);
+        scopeManager.SetScopeForRegistry("registry1", scope, null);
 
-        // Act / Assert: omitting partitionId (defaulting to null) selects the default partition.
-        var omitted = scopeManager.GetScopesStringForHost("registry1");
+        // Act / Assert: null and "" both select the default partition.
         var nullPartition = scopeManager.GetScopesStringForHost("registry1", null);
+        var emptyPartition = scopeManager.GetScopesStringForHost("registry1", string.Empty);
 
-        Assert.Equal(omitted, nullPartition);
+        Assert.Equal(nullPartition, emptyPartition);
         Assert.Single(nullPartition);
         Assert.Equal("repository:repo1:pull,push", nullPartition.First());
     }
@@ -737,7 +734,7 @@ public class ScopeManagerTest
         scopeManager.SetActionsForRepository(reference, null, Scope.Action.Pull, Scope.Action.Push);
 
         // Assert: present in the default partition, absent from a named partition.
-        var defaultScopes = scopeManager.GetScopesForHost("registry1");
+        var defaultScopes = scopeManager.GetScopesForHost("registry1", null);
         Assert.Single(defaultScopes);
         Assert.Contains(Scope.ActionPull, defaultScopes.First().Actions);
         Assert.Contains(Scope.ActionPush, defaultScopes.First().Actions);

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ScopeManagerTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ScopeManagerTest.cs
@@ -379,7 +379,7 @@ public class ScopeManagerTest
         );
 
         // Act
-        scopeManager.SetActionsForRepository(reference, Scope.Action.Pull);
+        scopeManager.SetActionsForRepository(reference, null, Scope.Action.Pull);
         var result = scopeManager.GetScopesForHost("registry1");
 
         // Assert
@@ -404,7 +404,7 @@ public class ScopeManagerTest
         );
 
         // Act
-        scopeManager.SetActionsForRepository(reference, Scope.Action.Pull, Scope.Action.Push, Scope.Action.Push);
+        scopeManager.SetActionsForRepository(reference, null, Scope.Action.Pull, Scope.Action.Push, Scope.Action.Push);
         var result = scopeManager.GetScopesForHost("registry1");
 
         // Assert
@@ -431,7 +431,7 @@ public class ScopeManagerTest
         );
 
         // Act
-        scopeManager.SetActionsForRepository(reference, Scope.Action.All, Scope.Action.Pull);
+        scopeManager.SetActionsForRepository(reference, null, Scope.Action.All, Scope.Action.Pull);
         var result = scopeManager.GetScopesForHost("registry1");
 
         // Assert
@@ -451,7 +451,7 @@ public class ScopeManagerTest
 
         // Act
         var exc = Record.Exception(() =>
-            ScopeManager.SetActionsForRepository(httpClient, reference, Scope.Action.Pull));
+            ScopeManager.SetActionsForRepository(httpClient, reference, null, Scope.Action.Pull));
 
         // Assert
         Assert.Null(exc);
@@ -465,7 +465,7 @@ public class ScopeManagerTest
         var reference = new Reference("registry1", "repo1");
 
         // Act
-        ScopeManager.SetActionsForRepository(client, reference, Scope.Action.Pull, Scope.Action.Push);
+        ScopeManager.SetActionsForRepository(client, reference, null, Scope.Action.Pull, Scope.Action.Push);
 
         // Assert
         var scopes = client.ScopeManager.GetScopesForHost("registry1");
@@ -485,8 +485,8 @@ public class ScopeManagerTest
         var reference = new Reference("registry1", "repo1");
 
         // Act
-        ScopeManager.SetActionsForRepository(client, reference, Scope.Action.Pull);
-        ScopeManager.SetActionsForRepository(client, reference, Scope.Action.All);
+        ScopeManager.SetActionsForRepository(client, reference, null, Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(client, reference, null, Scope.Action.All);
 
         // Assert
         var scopes = client.ScopeManager.GetScopesForHost("registry1");
@@ -569,5 +569,245 @@ public class ScopeManagerTest
         var updated = scopes.First();
         Assert.Single(updated.Actions);
         Assert.Contains(Scope.ActionWildcard, updated.Actions);
+    }
+
+    [Fact]
+    public void GetScopesForHost_IsolatesScopes_ByPartition()
+    {
+        // Arrange
+        var scopeManager = new ScopeManager();
+        var scopeA = new Scope("repository", "repo-a", new() { Scope.ActionPull });
+        var scopeB = new Scope("repository", "repo-b", new() { Scope.ActionPush });
+
+        // Act: same host, two partitions, different scopes.
+        scopeManager.SetScopeForRegistry("registry1", scopeA, "partition-a");
+        scopeManager.SetScopeForRegistry("registry1", scopeB, "partition-b");
+
+        // Assert: each partition sees only its own scope.
+        var scopesA = scopeManager.GetScopesForHost("registry1", "partition-a");
+        Assert.Single(scopesA);
+        Assert.Contains(scopeA, scopesA);
+        Assert.DoesNotContain(scopeB, scopesA);
+
+        var scopesB = scopeManager.GetScopesForHost("registry1", "partition-b");
+        Assert.Single(scopesB);
+        Assert.Contains(scopeB, scopesB);
+        Assert.DoesNotContain(scopeA, scopesB);
+    }
+
+    [Fact]
+    public void GetScopesForHost_DefaultPartition_IsIsolatedFromNamedPartition()
+    {
+        // Arrange
+        var scopeManager = new ScopeManager();
+        var defaultScope = new Scope("repository", "repo-default", new() { Scope.ActionPull });
+        var namedScope = new Scope("repository", "repo-named", new() { Scope.ActionPull });
+
+        // Act: default (no partition) vs a named partition on the same host.
+        scopeManager.SetScopeForRegistry("registry1", defaultScope);
+        scopeManager.SetScopeForRegistry("registry1", namedScope, "partition-a");
+
+        // Assert
+        var defaultScopes = scopeManager.GetScopesForHost("registry1");
+        Assert.Single(defaultScopes);
+        Assert.Contains(defaultScope, defaultScopes);
+        Assert.DoesNotContain(namedScope, defaultScopes);
+
+        var namedScopes = scopeManager.GetScopesForHost("registry1", "partition-a");
+        Assert.Single(namedScopes);
+        Assert.Contains(namedScope, namedScopes);
+        Assert.DoesNotContain(defaultScope, namedScopes);
+    }
+
+    [Fact]
+    public void GetScopesForHost_NullAndEmptyPartition_SelectSameDefaultPartition()
+    {
+        // Arrange
+        var scopeManager = new ScopeManager();
+        var scope = new Scope("repository", "repo1", new() { Scope.ActionPull });
+
+        // Act: store with null partition.
+        scopeManager.SetScopeForRegistry("registry1", scope, null);
+
+        // Assert: null and "" both select the default partition (consistent with Cache).
+        var viaNoArg = scopeManager.GetScopesForHost("registry1");
+        var viaNull = scopeManager.GetScopesForHost("registry1", null);
+        var viaEmpty = scopeManager.GetScopesForHost("registry1", string.Empty);
+
+        Assert.Single(viaNoArg);
+        Assert.Single(viaNull);
+        Assert.Single(viaEmpty);
+        Assert.Contains(scope, viaNoArg);
+        Assert.Contains(scope, viaNull);
+        Assert.Contains(scope, viaEmpty);
+    }
+
+    [Fact]
+    public void GetScopesStringForHost_IsolatesScopes_ByPartition()
+    {
+        // Arrange
+        var scopeManager = new ScopeManager();
+        var scopeA = new Scope("repository", "repo-a", new() { Scope.ActionPull });
+        var scopeB = new Scope("repository", "repo-b", new() { Scope.ActionPush });
+
+        // Act
+        scopeManager.SetScopeForRegistry("registry1", scopeA, "partition-a");
+        scopeManager.SetScopeForRegistry("registry1", scopeB, "partition-b");
+
+        // Assert
+        var stringsA = scopeManager.GetScopesStringForHost("registry1", "partition-a");
+        Assert.Single(stringsA);
+        Assert.Equal("repository:repo-a:pull", stringsA.First());
+
+        var stringsB = scopeManager.GetScopesStringForHost("registry1", "partition-b");
+        Assert.Single(stringsB);
+        Assert.Equal("repository:repo-b:push", stringsB.First());
+    }
+
+    [Fact]
+    public void GetScopesStringForHost_DefaultPartition_OmittedPartitionMatchesNull()
+    {
+        // Arrange
+        var scopeManager = new ScopeManager();
+        var scope = new Scope("repository", "repo1", new() { Scope.ActionPull, Scope.ActionPush });
+        scopeManager.SetScopeForRegistry("registry1", scope);
+
+        // Act / Assert: omitting partitionId (defaulting to null) selects the default partition.
+        var omitted = scopeManager.GetScopesStringForHost("registry1");
+        var nullPartition = scopeManager.GetScopesStringForHost("registry1", null);
+
+        Assert.Equal(omitted, nullPartition);
+        Assert.Single(nullPartition);
+        Assert.Equal("repository:repo1:pull,push", nullPartition.First());
+    }
+
+    [Fact]
+    public void SetActionsForRepository_Instance_IsolatesByPartition()
+    {
+        // Arrange
+        var scopeManager = new ScopeManager();
+        var reference = new Reference("registry1", "repo1");
+
+        // Act: same repository, different partitions, different actions.
+        scopeManager.SetActionsForRepository(reference, "partition-a", Scope.Action.Pull);
+        scopeManager.SetActionsForRepository(reference, "partition-b", Scope.Action.Push);
+
+        // Assert
+        var scopesA = scopeManager.GetScopesForHost("registry1", "partition-a");
+        Assert.Single(scopesA);
+        Assert.Contains(Scope.ActionPull, scopesA.First().Actions);
+        Assert.DoesNotContain(Scope.ActionPush, scopesA.First().Actions);
+
+        var scopesB = scopeManager.GetScopesForHost("registry1", "partition-b");
+        Assert.Single(scopesB);
+        Assert.Contains(Scope.ActionPush, scopesB.First().Actions);
+        Assert.DoesNotContain(Scope.ActionPull, scopesB.First().Actions);
+    }
+
+    [Fact]
+    public void SetActionsForRepository_Static_IsolatesByPartition()
+    {
+        // Arrange
+        var client = new Client(new HttpClient());
+        var reference = new Reference("registry1", "repo1");
+
+        // Act
+        ScopeManager.SetActionsForRepository(client, reference, "partition-a", Scope.Action.Pull);
+        ScopeManager.SetActionsForRepository(client, reference, "partition-b", Scope.Action.Push);
+
+        // Assert
+        var scopesA = client.ScopeManager.GetScopesForHost("registry1", "partition-a");
+        Assert.Single(scopesA);
+        Assert.Contains(Scope.ActionPull, scopesA.First().Actions);
+        Assert.DoesNotContain(Scope.ActionPush, scopesA.First().Actions);
+
+        var scopesB = client.ScopeManager.GetScopesForHost("registry1", "partition-b");
+        Assert.Single(scopesB);
+        Assert.Contains(Scope.ActionPush, scopesB.First().Actions);
+    }
+
+    [Fact]
+    public void SetActionsForRepository_DefaultPartition_PreservesExistingBehavior()
+    {
+        // Arrange: a null partitionId must behave exactly as before (default partition).
+        var scopeManager = new ScopeManager();
+        var reference = new Reference("registry1", "repo1");
+
+        // Act
+        scopeManager.SetActionsForRepository(reference, null, Scope.Action.Pull, Scope.Action.Push);
+
+        // Assert: present in the default partition, absent from a named partition.
+        var defaultScopes = scopeManager.GetScopesForHost("registry1");
+        Assert.Single(defaultScopes);
+        Assert.Contains(Scope.ActionPull, defaultScopes.First().Actions);
+        Assert.Contains(Scope.ActionPush, defaultScopes.First().Actions);
+
+        Assert.Empty(scopeManager.GetScopesForHost("registry1", "partition-a"));
+    }
+
+    [Fact]
+    public void SetScopeForRegistry_Static_IsolatesByPartition()
+    {
+        // Arrange
+        var client = new Client(new HttpClient());
+        var scopeA = new Scope("repository", "repo-a", new() { Scope.ActionPull });
+        var scopeB = new Scope("repository", "repo-b", new() { Scope.ActionPush });
+
+        // Act
+        ScopeManager.SetScopeForRegistry(client, "registry1", scopeA, "partition-a");
+        ScopeManager.SetScopeForRegistry(client, "registry1", scopeB, "partition-b");
+
+        // Assert
+        var scopesA = client.ScopeManager.GetScopesForHost("registry1", "partition-a");
+        Assert.Single(scopesA);
+        Assert.Contains(scopeA, scopesA);
+
+        var scopesB = client.ScopeManager.GetScopesForHost("registry1", "partition-b");
+        Assert.Single(scopesB);
+        Assert.Contains(scopeB, scopesB);
+    }
+
+    [Fact]
+    public void SetScopeForRegistry_PartitionIdContainingPipe_StaysDistinct()
+    {
+        // Arrange: a partitionId containing the '|' delimiter must not collide with another
+        // (partitionId, registry) pair, since registry hostnames cannot contain '|'.
+        var scopeManager = new ScopeManager();
+        var scope1 = new Scope("repository", "repo1", new() { Scope.ActionPull });
+        var scope2 = new Scope("repository", "repo2", new() { Scope.ActionPush });
+
+        // Act: keys are "tenant|x|registry1" and "tenant|registry1" respectively.
+        scopeManager.SetScopeForRegistry("registry1", scope1, "tenant|x");
+        scopeManager.SetScopeForRegistry("registry1", scope2, "tenant");
+
+        // Assert
+        var scopesPipe = scopeManager.GetScopesForHost("registry1", "tenant|x");
+        Assert.Single(scopesPipe);
+        Assert.Contains(scope1, scopesPipe);
+        Assert.DoesNotContain(scope2, scopesPipe);
+
+        var scopesPlain = scopeManager.GetScopesForHost("registry1", "tenant");
+        Assert.Single(scopesPlain);
+        Assert.Contains(scope2, scopesPlain);
+        Assert.DoesNotContain(scope1, scopesPlain);
+    }
+
+    [Fact]
+    public void SetScopeForRegistry_SamePartition_MergesActions()
+    {
+        // Arrange: merge semantics must still apply within a single partition.
+        var scopeManager = new ScopeManager();
+        var pull = new Scope("repository", "repo1", new() { Scope.ActionPull });
+        var push = new Scope("repository", "repo1", new() { Scope.ActionPush });
+
+        // Act
+        scopeManager.SetScopeForRegistry("registry1", pull, "partition-a");
+        scopeManager.SetScopeForRegistry("registry1", push, "partition-a");
+
+        // Assert
+        var scopes = scopeManager.GetScopesForHost("registry1", "partition-a");
+        Assert.Single(scopes);
+        Assert.Contains(Scope.ActionPull, scopes.First().Actions);
+        Assert.Contains(Scope.ActionPush, scopes.First().Actions);
     }
 }


### PR DESCRIPTION
## Summary

`ScopeManager` stored requested OAuth scopes keyed by **registry host only**, while the token `Cache` (`ICache`) is keyed by **`(partitionId, registry)`**. In a shared single-`Client` / multi-partition deployment (one `Client` + one `ScopeManager` serving many partitions against the same registry host), scope state was **not** isolated per partition: scopes accumulated for one partition were merged into, and replayed in, the token requests of every other partition for that host — causing cross-partition scope bleed, unbounded scope growth (oversized token requests), and per-partition token-cache thrash.

This change partitions `ScopeManager` state by `partitionId`, mirroring how `Cache` is already partitioned.

## Changes

- **`ScopeManager`**: scope state is now keyed by `(partitionId, registry)` using a `{partitionId}|{registry}` composite key (the same delimiter scheme as `Cache.GetCacheKey`). When `partitionId` is `null`/empty the key is the registry alone, so **runtime behavior is unchanged for the default partition**.
- **Accepted breaking API change** ⚠️ (approved for this PR): `partitionId` is threaded through the scope APIs by extending each existing signature (rather than via additive overloads), and it is a **required** `string?` parameter on every partition-aware method:
  - `GetScopesForHost`, `GetScopesStringForHost`, and both `SetScopeForRegistry` overloads take a **required** trailing `string? partitionId`.
  - Both `SetActionsForRepository` overloads take a **required** `string? partitionId` positional parameter *before* the `params Scope.Action[]` array (C# forbids an optional parameter before `params`).
  - Existing callers must add a `partitionId` argument; pass `null` to select the default partition (which preserves the prior, unpartitioned behavior).
- **Why `partitionId` is required rather than optional (`= null`)**: an optional default would silently route a *forgotten* argument to the default partition — exactly the cross-partition scope bleed this PR closes. Making it required turns any missed propagation into a **compile error** instead of a silent isolation regression (per review feedback on this PR). Callers opt into the default explicitly by passing `null`.
- **Why the break is acceptable**: `ScopeManager` is a concrete type with **no `IScopeManager` interface**, reached only through `Client.ScopeManager`, and every call site is internal to the library. The blast radius is limited to external code that directly uses `ScopeManager`, which now explicitly acknowledges the partition dimension by passing `null`. Collapsing (rather than overloading) the signatures also avoids the source-breaking overload-resolution ambiguity that additive `params` overloads would otherwise introduce (e.g. an existing `SetActionsForRepository(client, reference, null)` call becoming ambiguous).
- **Call sites**: `Client.SendCoreAsync` and the scope writes in `BlobStore`, `ManifestStore`, `Repository`, and `Registry` now forward the same `PartitionId` already passed to the adjacent token-cache / `SendAsync` call.

## Testing

- New `ScopeManagerTest` cases: cross-partition isolation, default-partition (`null`/empty) isolation, equivalence when `partitionId == null`, instance + static `SetActionsForRepository` / `SetScopeForRegistry` isolation, a `partitionId` containing `|` hardening case, and same-partition merge.
- New `ClientTest.SendAsync_BearerAuth_IsolatesScopesByPartition`: end-to-end proof that two partitions on the same host each issue a token request carrying only their own scope.
- All relevant tests pass; diff coverage is 100% of changed `src` lines (`diff-cover` vs `main`).

## Out of scope (potential follow-ups)

- Bounding/evicting per-`(partition, registry)` scope sets.
- Scoping token requests to the current operation's repository rather than replaying the full accumulated set.
- Bounding `CacheEntry.Tokens` growth.
- Making the `Scope` type immutable to remove defensive cloning (#407).

Fixes #402
