### PR TITLE
feat(auth): add pluggable IAuthChallengeHandler for 401 handling

### DIFF
--- a/OrasProject.Oras.sln
+++ b/OrasProject.Oras.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -12,9 +12,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrasProject.Oras.Examples.ExternalTokenBroker", "examples\OrasProject.Oras.Examples.ExternalTokenBroker\OrasProject.Oras.Examples.ExternalTokenBroker.csproj", "{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrasProject.Oras.Examples.RealmValidation", "examples\OrasProject.Oras.Examples.RealmValidation\OrasProject.Oras.Examples.RealmValidation.csproj", "{667D44C5-0DF2-4FC3-B228-0032CA585002}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrasProject.Oras.Examples.AuthChallengeRecovery", "examples\OrasProject.Oras.Examples.AuthChallengeRecovery\OrasProject.Oras.Examples.AuthChallengeRecovery.csproj", "{0C387E08-9992-46B4-BA84-C56B550E693E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -86,6 +89,18 @@ Global
 		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Release|x64.Build.0 = Release|Any CPU
 		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Release|x86.ActiveCfg = Release|Any CPU
 		{667D44C5-0DF2-4FC3-B228-0032CA585002}.Release|x86.Build.0 = Release|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Debug|x64.Build.0 = Debug|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Debug|x86.Build.0 = Debug|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Release|x64.ActiveCfg = Release|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Release|x64.Build.0 = Release|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Release|x86.ActiveCfg = Release|Any CPU
+		{0C387E08-9992-46B4-BA84-C56B550E693E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -93,5 +108,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{443703EE-D73C-4EE3-882D-5DD7DFFD09B6} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
 		{667D44C5-0DF2-4FC3-B228-0032CA585002} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
+		{0C387E08-9992-46B4-BA84-C56B550E693E} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
 	EndGlobalSection
 EndGlobal

--- a/examples/OrasProject.Oras.Examples.AuthChallengeRecovery/AuthChallengeRecoveryExamples.cs
+++ b/examples/OrasProject.Oras.Examples.AuthChallengeRecovery/AuthChallengeRecoveryExamples.cs
@@ -1,0 +1,157 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#region Usage
+using System.Net;
+using OrasProject.Oras.Registry.Remote.Auth;
+
+namespace OrasProject.Oras.Examples.AuthChallengeRecovery;
+
+/// <summary>
+/// Demonstrates supplying a custom <see cref="IAuthChallengeHandler"/> that recovers from
+/// non-conformant registries whose token-carrying <c>401</c> response is unusable — for example
+/// a registry that omits the <c>WWW-Authenticate</c> challenge when a stale token is presented,
+/// or returns one whose realm points at a different host — by re-deriving a usable challenge
+/// from a credential-free probe.
+/// </summary>
+public static class AuthChallengeRecoveryExamples
+{
+    /// <summary>
+    /// Creates a <see cref="Client"/> that falls back to cold-probe recovery when a cached token
+    /// is rejected with an unusable challenge. Compliant registries are unaffected.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client the registry client should use.</param>
+    /// <returns>A configured <see cref="Client"/>.</returns>
+    public static Client CreateClientWithChallengeRecovery(HttpClient httpClient)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+
+        return new Client(httpClient)
+        {
+            AuthChallengeHandler = new ColdReDeriveAuthChallengeHandler(),
+        };
+    }
+}
+
+/// <summary>
+/// An <see cref="IAuthChallengeHandler"/> that runs the standard OCI challenge flow and, when the
+/// token-carrying <c>401</c>'s challenge is UNUSABLE (absent, or a missing / malformed / disallowed
+/// realm) and a cached token was attached, re-derives a usable challenge from a credential-free
+/// probe and acquires a fresh token.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The handler is host-agnostic: it keys off the <em>shape</em> of the failure, not specific
+/// registry names. Compliant registries incur no extra request, and a genuine credential failure
+/// behind an allowed realm is surfaced rather than masked.
+/// </para>
+/// <para>
+/// The recovery is gated on <see cref="AuthChallengeContext.AttachedCachedToken"/> (so a first-time
+/// cold 401 is handled normally) and <see cref="AuthChallengeContext.CanReplayOriginalRequest"/>
+/// (so non-idempotent requests are never replayed). The cold probe carries no token, so it cannot
+/// re-enter this path — recovery is bounded to a single extra request.
+/// </para>
+/// </remarks>
+public sealed class ColdReDeriveAuthChallengeHandler : IAuthChallengeHandler
+{
+    /// <inheritdoc />
+    public async Task<AuthChallengeResolution?> ResolveAuthorizationAsync(
+        AuthChallengeContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        // 1. Try the original challenge. TryResolveAsync is non-throwing: an unusable challenge
+        //    yields null, while a credential failure behind an allowed realm still throws.
+        var resolution = await TryResolveAsync(
+            context, context.Scheme, context.ChallengeParameters, cancellationToken);
+        if (resolution != null)
+        {
+            return resolution;
+        }
+
+        // 2. Recover only when this looks like a stale-token rejection we can safely retry.
+        if (!context.AttachedCachedToken || !context.CanReplayOriginalRequest)
+        {
+            return null;
+        }
+
+        // 3. Cold (no-auth) probe to elicit a usable challenge the upstream withheld.
+        using var cold = await context.SendWithoutAuthorizationAsync(cancellationToken);
+        if (cold.StatusCode != HttpStatusCode.Unauthorized)
+        {
+            return null;
+        }
+
+        Challenge.Scheme coldScheme;
+        IReadOnlyDictionary<string, string>? coldParameters;
+        try
+        {
+            (coldScheme, coldParameters) = Challenge.ParseChallenge(
+                cold.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
+        }
+        catch (Exception ex) when (ex is FormatException or ArgumentException)
+        {
+            return null;
+        }
+
+        // 4. Resolve from the cold challenge (give up if it is also unusable).
+        return await TryResolveAsync(context, coldScheme, coldParameters, cancellationToken);
+    }
+
+    /// <summary>
+    /// Standard OCI resolution that returns <c>null</c> for an unusable challenge (no/unknown
+    /// scheme, or a missing / malformed / disallowed realm) instead of throwing, so the caller can
+    /// choose to recover. A token-endpoint failure behind an ALLOWED realm still throws, preserving
+    /// genuine credential errors.
+    /// </summary>
+    private static async Task<AuthChallengeResolution?> TryResolveAsync(
+        AuthChallengeContext context,
+        Challenge.Scheme scheme,
+        IReadOnlyDictionary<string, string>? parameters,
+        CancellationToken cancellationToken)
+    {
+        switch (scheme)
+        {
+            case Challenge.Scheme.Basic:
+                return new AuthChallengeResolution
+                {
+                    Scheme = Challenge.Scheme.Basic,
+                    Token = await context.FetchBasicTokenAsync(cancellationToken),
+                    CacheScopeKey = string.Empty,
+                };
+
+            case Challenge.Scheme.Bearer:
+                if (parameters == null ||
+                    !parameters.TryGetValue("realm", out var realm) ||
+                    !Uri.TryCreate(realm, UriKind.Absolute, out var realmUri) ||
+                    !await context.IsRealmAllowedAsync(realmUri, cancellationToken))
+                {
+                    return null; // unusable challenge -> recoverable
+                }
+
+                var (scopes, cacheKey) = context.MergeChallengeScopes(parameters.GetValueOrDefault("scope"));
+                parameters.TryGetValue("service", out var service);
+                return new AuthChallengeResolution
+                {
+                    Scheme = Challenge.Scheme.Bearer,
+                    Token = await context.FetchBearerTokenAsync(
+                        realm, service ?? string.Empty, scopes, cancellationToken),
+                    CacheScopeKey = cacheKey,
+                };
+
+            default:
+                return null; // no/unknown challenge -> recoverable
+        }
+    }
+}
+#endregion

--- a/examples/OrasProject.Oras.Examples.AuthChallengeRecovery/OrasProject.Oras.Examples.AuthChallengeRecovery.csproj
+++ b/examples/OrasProject.Oras.Examples.AuthChallengeRecovery/OrasProject.Oras.Examples.AuthChallengeRecovery.csproj
@@ -19,28 +19,13 @@ limitations under the License.
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    
+
     <!-- Disable requiring ConfigureAwait(false) for awaited tasks -->
     <NoWarn>CA2007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\OrasProject.Oras\OrasProject.Oras.csproj" />
-    <ProjectReference Include="..\..\examples\OrasProject.Oras.Examples.AuthChallengeRecovery\OrasProject.Oras.Examples.AuthChallengeRecovery.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/AuthChallengeContext.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/AuthChallengeContext.cs
@@ -1,0 +1,242 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Per-request context supplied to an <see cref="IAuthChallengeHandler"/> when a request
+/// receives an HTTP 401 response. Exposes the unauthorized exchange plus capabilities —
+/// token fetch, realm validation, scope merging, cached-token lookup, and a credential-free
+/// probe — that delegate to the owning <see cref="Client"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The context is valid only for the duration of the
+/// <see cref="IAuthChallengeHandler.ResolveAuthorizationAsync"/> call and must not be
+/// retained. <see cref="OriginalRequest"/> and <see cref="UnauthorizedResponse"/> are owned
+/// by the client and must not be disposed by the handler. Any response returned from
+/// <see cref="SendWithoutAuthorizationAsync"/> is owned by the caller and must be disposed.
+/// </para>
+/// <para>
+/// <b>Security:</b> a custom handler that fetches a token via
+/// <see cref="FetchBearerTokenAsync"/> is responsible for validating the realm first (see
+/// <see cref="IsRealmAllowedAsync"/>). The default handler always validates the realm.
+/// </para>
+/// </remarks>
+public sealed class AuthChallengeContext
+{
+    private readonly Client _client;
+    private readonly bool _allowAutoRedirect;
+
+    internal AuthChallengeContext(
+        Client client,
+        HttpRequestMessage originalRequest,
+        HttpResponseMessage unauthorizedResponse,
+        string host,
+        string? partitionId,
+        bool attachedCachedToken,
+        IReadOnlyList<string> requestedScopes,
+        bool allowAutoRedirect,
+        Challenge.Scheme scheme,
+        IReadOnlyDictionary<string, string>? challengeParameters)
+    {
+        _client = client;
+        _allowAutoRedirect = allowAutoRedirect;
+        OriginalRequest = originalRequest;
+        UnauthorizedResponse = unauthorizedResponse;
+        Host = host;
+        PartitionId = partitionId;
+        AttachedCachedToken = attachedCachedToken;
+        RequestedScopes = requestedScopes;
+        Scheme = scheme;
+        ChallengeParameters = challengeParameters;
+        CanReplayOriginalRequest =
+            originalRequest.Method == HttpMethod.Get ||
+            originalRequest.Method == HttpMethod.Head;
+    }
+
+    /// <summary>
+    /// The original request that received the 401. Its <c>Authorization</c> header is unset.
+    /// </summary>
+    public HttpRequestMessage OriginalRequest { get; }
+
+    /// <summary>
+    /// The 401 (Unauthorized) response, including its <c>WWW-Authenticate</c> challenge.
+    /// </summary>
+    public HttpResponseMessage UnauthorizedResponse { get; }
+
+    /// <summary>
+    /// The scheme of the original challenge, parsed from <see cref="UnauthorizedResponse"/>.
+    /// <see cref="Challenge.Scheme.Unknown"/> when there is no usable challenge (e.g. a
+    /// non-conformant registry that omits the header on a token-carrying 401).
+    /// </summary>
+    public Challenge.Scheme Scheme { get; }
+
+    /// <summary>
+    /// The parameters of the original Bearer challenge (e.g. <c>realm</c>, <c>service</c>,
+    /// <c>scope</c>), or <c>null</c> for a non-Bearer or absent challenge. This is the parsed
+    /// form of <see cref="UnauthorizedResponse"/>'s challenge; a handler that probes for a
+    /// fresh challenge must parse that probe response itself.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? ChallengeParameters { get; }
+
+    /// <summary>
+    /// The registry authority (host, with port when non-default) that issued the challenge.
+    /// </summary>
+    public string Host { get; }
+
+    /// <summary>
+    /// The cache partition identifier for the request, if any.
+    /// </summary>
+    public string? PartitionId { get; }
+
+    /// <summary>
+    /// <c>true</c> when the failed attempt carried a cached token — i.e., this 401 may be a
+    /// stale-token rejection rather than a first-time challenge. Useful for gating recovery so
+    /// that genuine bad-credential failures on a cold request are not masked.
+    /// </summary>
+    public bool AttachedCachedToken { get; }
+
+    /// <summary>
+    /// The scopes the client computed for <see cref="Host"/> prior to this challenge.
+    /// </summary>
+    public IReadOnlyList<string> RequestedScopes { get; }
+
+    /// <summary>
+    /// <c>true</c> when <see cref="OriginalRequest"/> can be safely re-sent without
+    /// authorization — that is, an idempotent <c>GET</c> or <c>HEAD</c>. Gates
+    /// <see cref="SendWithoutAuthorizationAsync"/> so that non-idempotent uploads are never
+    /// replayed.
+    /// </summary>
+    public bool CanReplayOriginalRequest { get; }
+
+    /// <summary>
+    /// Re-sends <see cref="OriginalRequest"/> with no <c>Authorization</c> header to elicit a
+    /// fresh <c>WWW-Authenticate</c> challenge. This is the recovery primitive for registries
+    /// whose token-carrying 401 is unusable. The returned response is owned by the caller and
+    /// must be disposed.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The response to the credential-free request.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="CanReplayOriginalRequest"/> is <c>false</c>.
+    /// </exception>
+    public async Task<HttpResponseMessage> SendWithoutAuthorizationAsync(
+        CancellationToken cancellationToken = default)
+    {
+        if (!CanReplayOriginalRequest)
+        {
+            throw new InvalidOperationException(
+                "The original request cannot be safely replayed without authorization " +
+                "because it is not an idempotent GET or HEAD request.");
+        }
+
+        var coldRequest = await OriginalRequest
+            .CloneAsync(rewindContent: true, cancellationToken)
+            .ConfigureAwait(false);
+        coldRequest.Headers.Authorization = null;
+        return await _client
+            .SendRequestAsync(coldRequest, _allowAutoRedirect, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Validates a realm URL against the original request URI using the client's
+    /// <see cref="Client.RealmValidator"/>.
+    /// </summary>
+    /// <param name="realmUri">The realm URL to validate.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns><c>true</c> if the realm is allowed for the original request; otherwise <c>false</c>.</returns>
+    public Task<bool> IsRealmAllowedAsync(
+        Uri realmUri,
+        CancellationToken cancellationToken = default)
+        => _client.RealmValidator.IsRealmAllowedAsync(
+            OriginalRequest.RequestUri!, realmUri, cancellationToken);
+
+    /// <summary>
+    /// Fetches a bearer token from the given realm, reusing the client's access-token and
+    /// credential providers. Anonymous-token behavior is preserved when no credentials exist.
+    /// </summary>
+    /// <param name="realm">The token endpoint URL from the challenge.</param>
+    /// <param name="service">The service identifier from the challenge.</param>
+    /// <param name="scopes">The scopes to request for the token.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The fetched bearer token.</returns>
+    public Task<string> FetchBearerTokenAsync(
+        string realm,
+        string service,
+        IReadOnlyList<string> scopes,
+        CancellationToken cancellationToken = default)
+        => _client.FetchBearerAuthAsync(
+            Host,
+            realm,
+            service,
+            scopes as IList<string> ?? scopes.ToList(),
+            forceRefresh: true,
+            cancellationToken);
+
+    /// <summary>
+    /// Fetches a Basic authentication token (base64 <c>username:password</c>) for
+    /// <see cref="Host"/> from the client's credential provider.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The base64-encoded Basic credential.</returns>
+    public Task<string> FetchBasicTokenAsync(CancellationToken cancellationToken = default)
+        => _client.FetchBasicAuthAsync(Host, cancellationToken);
+
+    /// <summary>
+    /// Attempts to read a still-cached token for <see cref="Host"/> at the given scheme and
+    /// scope key.
+    /// </summary>
+    /// <param name="scheme">The authentication scheme to look up.</param>
+    /// <param name="scopeKey">The scope key to look up.</param>
+    /// <param name="token">When this method returns, the cached token, or an empty string.</param>
+    /// <returns><c>true</c> if a matching token was found; otherwise <c>false</c>.</returns>
+    public bool TryGetCachedToken(Challenge.Scheme scheme, string scopeKey, out string token)
+        => _client.Cache.TryGetToken(Host, scheme, scopeKey, out token, PartitionId);
+
+    /// <summary>
+    /// Merges the challenge's <c>scope</c> parameter with the existing scopes for
+    /// <see cref="Host"/>, returning the token-request scope list and the cache key
+    /// (the space-joined merged scope set).
+    /// </summary>
+    /// <param name="scopeParameter">
+    /// The raw <c>scope</c> parameter value from the challenge, or <c>null</c> when absent.
+    /// </param>
+    /// <returns>The merged scopes for the token request and the cache key to store it under.</returns>
+    public (IReadOnlyList<string> Scopes, string CacheKey) MergeChallengeScopes(string? scopeParameter)
+    {
+        var newScopes = new SortedSet<Scope>(_client.ScopeManager.GetScopesForHost(Host));
+        if (!string.IsNullOrEmpty(scopeParameter))
+        {
+            foreach (var scopeStr in scopeParameter.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (Scope.TryParse(scopeStr, out var scope))
+                {
+                    Scope.AddOrMergeScope(newScopes, scope);
+                }
+            }
+        }
+
+        var cacheKey = string.Join(" ", newScopes);
+        var scopes = newScopes.Select(scope => scope.ToString()).ToList();
+        return (scopes, cacheKey);
+    }
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/AuthChallengeResolution.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/AuthChallengeResolution.cs
@@ -1,0 +1,54 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// The authorization an <see cref="IAuthChallengeHandler"/> produces to retry a request
+/// that received an HTTP 401 (Unauthorized) response.
+/// </summary>
+/// <remarks>
+/// A <c>null</c> result from
+/// <see cref="IAuthChallengeHandler.ResolveAuthorizationAsync"/> means "give up" — the
+/// client returns the original 401 response unchanged. A non-null result instructs the
+/// client to cache the token (when <see cref="Cache"/> is <c>true</c>) and retry the
+/// original request with the produced <c>Authorization</c> header.
+/// </remarks>
+public sealed class AuthChallengeResolution
+{
+    /// <summary>
+    /// The authentication scheme of the produced authorization. Only
+    /// <see cref="Challenge.Scheme.Basic"/> and <see cref="Challenge.Scheme.Bearer"/>
+    /// are valid; any other value is treated as Bearer.
+    /// </summary>
+    public required Challenge.Scheme Scheme { get; init; }
+
+    /// <summary>
+    /// The credential parameter placed in the <c>Authorization</c> header: a base64
+    /// <c>username:password</c> string for Basic, or the bearer token for Bearer.
+    /// </summary>
+    public required string Token { get; init; }
+
+    /// <summary>
+    /// The scope key under which the client should cache <see cref="Token"/>. For Bearer
+    /// this is the space-joined merged scope set; for Basic it is the empty string.
+    /// Ignored when <see cref="Cache"/> is <c>false</c>.
+    /// </summary>
+    public string CacheScopeKey { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether the client should cache <see cref="Token"/> for reuse on subsequent
+    /// requests. Defaults to <c>true</c>.
+    /// </summary>
+    public bool Cache { get; init; } = true;
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -271,6 +271,24 @@ public class Client : IClient
     private IRealmValidator _realmValidator = new DefaultRealmValidator();
 
     /// <summary>
+    /// Resolves the authorization used to retry a request after an HTTP 401 response.
+    /// Defaults to <see cref="DefaultAuthChallengeHandler"/>, which performs the standard
+    /// OCI distribution flow. Provide a custom handler to recover from registries whose
+    /// token-carrying 401 is unusable (e.g., a missing or wrong-host challenge).
+    /// </summary>
+    /// <remarks>
+    /// This property is init-only and cannot be null.
+    /// </remarks>
+    public IAuthChallengeHandler AuthChallengeHandler
+    {
+        get => _authChallengeHandler;
+        init => _authChallengeHandler = value
+            ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    private IAuthChallengeHandler _authChallengeHandler = new DefaultAuthChallengeHandler();
+
+    /// <summary>
     /// ScopeManager is an instance to manage scopes.
     /// </summary>
     public ScopeManager ScopeManager { get; set; } = new();
@@ -669,7 +687,9 @@ public class Client : IClient
         var host = originalRequest.RequestUri?.Authority ??
                     throw new ArgumentException("originalRequest.RequestUri or originalRequest.RequestUri.Authority property is null.", nameof(originalRequest));
         var requestAttempt1 = await originalRequest.CloneAsync(rewindContent: false, cancellationToken).ConfigureAwait(false);
-        var attemptedKey = string.Empty;
+        var requestedScopes = ScopeManager.GetScopesStringForHost(host);
+        var attemptedKey = string.Join(" ", requestedScopes);
+        var attachedCachedToken = false;
 
         // attempt to send request with cached auth token
         if (Cache.TryGetScheme(host, out var schemeFromCache, partitionId))
@@ -681,18 +701,19 @@ public class Client : IClient
                         if (Cache.TryGetToken(host, schemeFromCache, string.Empty, out var basicToken, partitionId))
                         {
                             requestAttempt1.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicToken);
+                            attachedCachedToken = true;
                         }
 
                         break;
                     }
                 case Challenge.Scheme.Bearer:
                     {
-                        var scopes = ScopeManager.GetScopesStringForHost(host);
-                        attemptedKey = string.Join(" ", scopes);
                         if (Cache.TryGetToken(host, schemeFromCache, attemptedKey, out var bearerToken, partitionId))
                         {
                             requestAttempt1.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+                            attachedCachedToken = true;
                         }
+
                         break;
                     }
             }
@@ -704,107 +725,99 @@ public class Client : IClient
             return response1;
         }
 
-        var (schemeFromChallenge, parameters) =
-            Challenge.ParseChallenge(response1.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
-
-        // Attempt again with credentials for recognized schemes
-        switch (schemeFromChallenge)
+        // Parse the original challenge once. Degrade to Unknown on malformed input so a
+        // non-conformant challenge still reaches the handler (which may recover) rather than
+        // throwing. The parsed result is shared by the cache shortcut below and the context.
+        Challenge.Scheme schemeFromChallenge;
+        Dictionary<string, string>? challengeParameters;
+        try
         {
-            case Challenge.Scheme.Basic:
-                {
-                    response1.Dispose();
-                    var basicAuthToken = await FetchBasicAuthAsync(host, cancellationToken).ConfigureAwait(false);
-                    Cache.SetCache(host, schemeFromChallenge, string.Empty, basicAuthToken, partitionId);
+            (schemeFromChallenge, challengeParameters) = Challenge.ParseChallenge(
+                response1.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
+        }
+        catch (Exception ex) when (ex is FormatException or ArgumentException)
+        {
+            (schemeFromChallenge, challengeParameters) = (Challenge.Scheme.Unknown, null);
+        }
 
-                    // Attempt again with basic token
+        var challengeContext = new AuthChallengeContext(
+            this,
+            originalRequest,
+            response1,
+            host,
+            partitionId,
+            attachedCachedToken,
+            requestedScopes,
+            allowAutoRedirect,
+            schemeFromChallenge,
+            challengeParameters);
+
+        // From here every path either hands response1 back to the caller (a null resolution, or
+        // the non-401 return above) or disposes it — including on any exception or cancellation.
+        try
+        {
+            // Scope-changed cache shortcut: when the challenge implies a different scope key than
+            // attempt-1 used and a token is already cached for it, try that token before acquiring
+            // a new one. This is a cache optimization owned by the client; token acquisition (and
+            // any recovery for non-conformant registries) is delegated to the handler below.
+            if (schemeFromChallenge == Challenge.Scheme.Bearer && challengeParameters != null)
+            {
+                var (_, newKey) = challengeContext.MergeChallengeScopes(
+                    challengeParameters.GetValueOrDefault("scope"));
+                if (newKey != attemptedKey &&
+                    Cache.TryGetToken(host, Challenge.Scheme.Bearer, newKey, out var cachedToken, partitionId))
+                {
                     var requestAttempt2 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
-                    requestAttempt2.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicAuthToken);
-                    return await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    requestAttempt2.Headers.Authorization = new AuthenticationHeaderValue("Bearer", cachedToken);
+                    var response2 = await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    if (response2.StatusCode != HttpStatusCode.Unauthorized)
+                    {
+                        response1.Dispose();
+                        return response2;
+                    }
+
+                    response2.Dispose();
                 }
-            case Challenge.Scheme.Bearer:
-                {
-                    response1.Dispose();
-                    if (parameters == null)
-                    {
-                        throw new AuthenticationException("Missing parameters in the Www-Authenticate challenge.");
-                    }
+            }
 
-                    var existingScopes = ScopeManager.GetScopesForHost(host);
-                    var newScopes = new SortedSet<Scope>(existingScopes);
-                    if (parameters.TryGetValue("scope", out var scopesString))
-                    {
-                        foreach (var scopeStr in scopesString.Split(' ', StringSplitOptions.RemoveEmptyEntries))
-                        {
-                            if (Scope.TryParse(scopeStr, out var scope))
-                            {
-                                Scope.AddOrMergeScope(newScopes, scope);
-                            }
-                        }
-                    }
-
-                    // Attempt to send request when the scope changes and a token cache hits
-                    var newKey = string.Join(" ", newScopes);
-                    if (newKey != attemptedKey &&
-                        Cache.TryGetToken(host, schemeFromChallenge, newKey, out var cachedToken, partitionId))
-                    {
-                        var requestAttempt2 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
-                        requestAttempt2.Headers.Authorization = new AuthenticationHeaderValue("Bearer", cachedToken);
-                        var response2 = await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
-
-                        if (response2.StatusCode != HttpStatusCode.Unauthorized)
-                        {
-                            return response2;
-                        }
-                        response2.Dispose();
-                    }
-
-                    if (!parameters.TryGetValue("realm", out var realm))
-                    {
-                        // 'realm' is required as it specifies the token endpoint URL for Bearer authentication.
-                        throw new KeyNotFoundException("Missing 'realm' parameter in WWW-Authenticate Bearer challenge.");
-                    }
-
-                    // Validate realm URL before sending credentials.
-                    if (!Uri.TryCreate(
-                            realm, UriKind.Absolute,
-                            out var realmUri))
-                    {
-                        throw new AuthenticationException(
-                            $"Invalid realm URL: '{realm}'");
-                    }
-
-                    var registryUri = originalRequest.RequestUri!;
-                    if (!await RealmValidator.IsRealmAllowedAsync(
-                            registryUri, realmUri, cancellationToken)
-                        .ConfigureAwait(false))
-                    {
-                        throw new AuthenticationException(
-                            $"Authentication realm '{realmUri}' is not allowed for registry '{registryUri.Authority}'.");
-                    }
-
-                    if (!parameters.TryGetValue("service", out var service))
-                    {
-                        // some registries may omit the `service` parameter; use an empty string when absent.
-                        service = string.Empty;
-                    }
-
-                    // Try to fetch bearer token based on the challenge header
-                    var bearerAuthToken = await FetchBearerAuthAsync(
-                        host,
-                        realm,
-                        service,
-                        newScopes.Select(newScope => newScope.ToString()).ToList(),
-                        forceRefresh: true,
-                        cancellationToken
-                    ).ConfigureAwait(false);
-                    Cache.SetCache(host, schemeFromChallenge, newKey, bearerAuthToken, partitionId);
-
-                    var requestAttempt3 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
-                    requestAttempt3.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerAuthToken);
-                    return await SendRequestAsync(requestAttempt3, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
-                }
-            default:
+            // Delegate the "401 -> authorization" decision (token acquisition and any recovery for
+            // non-conformant registries) to the configured handler.
+            var resolution = await AuthChallengeHandler
+                .ResolveAuthorizationAsync(challengeContext, cancellationToken)
+                .ConfigureAwait(false);
+            if (resolution == null)
+            {
+                // No authorization could be produced; hand the original 401 back to the caller.
                 return response1;
+            }
+
+            if (resolution.Scheme is not Challenge.Scheme.Basic and not Challenge.Scheme.Bearer)
+            {
+                throw new InvalidOperationException(
+                    $"The authentication challenge handler returned an unsupported scheme '{resolution.Scheme}'.");
+            }
+
+            if (string.IsNullOrEmpty(resolution.Token))
+            {
+                throw new InvalidOperationException(
+                    "The authentication challenge handler returned an empty token.");
+            }
+
+            if (resolution.Cache)
+            {
+                Cache.SetCache(host, resolution.Scheme, resolution.CacheScopeKey, resolution.Token, partitionId);
+            }
+
+            var schemeName = resolution.Scheme == Challenge.Scheme.Basic ? "Basic" : "Bearer";
+            var retryRequest = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
+            retryRequest.Headers.Authorization = new AuthenticationHeaderValue(schemeName, resolution.Token);
+            response1.Dispose();
+            return await SendRequestAsync(retryRequest, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            response1.Dispose();
+            throw;
         }
     }
 
@@ -817,7 +830,7 @@ public class Client : IClient
     /// <param name="allowAutoRedirect">Whether to allow automatic redirect following. Default is true.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>The HTTP response message.</returns>
-    private async Task<HttpResponseMessage> SendRequestAsync(
+    internal async Task<HttpResponseMessage> SendRequestAsync(
         HttpRequestMessage request,
         bool allowAutoRedirect = true,
         CancellationToken cancellationToken = default)

--- a/src/OrasProject.Oras/Registry/Remote/Auth/DefaultAuthChallengeHandler.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/DefaultAuthChallengeHandler.cs
@@ -1,0 +1,112 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// The default <see cref="IAuthChallengeHandler"/>: implements the standard OCI distribution
+/// authentication flow. It parses the <c>WWW-Authenticate</c> challenge, validates the realm,
+/// and fetches a Basic or Bearer token. An unrecognized (or absent) challenge yields
+/// <c>null</c>, mirroring the client's prior behavior of returning the original 401 unchanged.
+/// </summary>
+/// <remarks>
+/// This handler issues no extra requests beyond the standard token fetch — compliant
+/// registries are unaffected. It does not attempt to recover from non-conformant registries;
+/// supply a custom <see cref="IAuthChallengeHandler"/> for that.
+/// </remarks>
+public sealed class DefaultAuthChallengeHandler : IAuthChallengeHandler
+{
+    /// <inheritdoc />
+    public async Task<AuthChallengeResolution?> ResolveAuthorizationAsync(
+        AuthChallengeContext context,
+        CancellationToken cancellationToken = default)
+    {
+        switch (context.Scheme)
+        {
+            case Challenge.Scheme.Basic:
+                {
+                    var basicToken = await context
+                        .FetchBasicTokenAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                    return new AuthChallengeResolution
+                    {
+                        Scheme = Challenge.Scheme.Basic,
+                        Token = basicToken,
+                        CacheScopeKey = string.Empty,
+                    };
+                }
+            case Challenge.Scheme.Bearer:
+                return await ResolveBearerAsync(context, context.ChallengeParameters, cancellationToken)
+                    .ConfigureAwait(false);
+            default:
+                return null;
+        }
+    }
+
+    private static async Task<AuthChallengeResolution> ResolveBearerAsync(
+        AuthChallengeContext context,
+        IReadOnlyDictionary<string, string>? parameters,
+        CancellationToken cancellationToken)
+    {
+        if (parameters == null)
+        {
+            throw new AuthenticationException(
+                "Missing parameters in the Www-Authenticate challenge.");
+        }
+
+        var (scopes, cacheKey) = context.MergeChallengeScopes(
+            parameters.TryGetValue("scope", out var scopeValue) ? scopeValue : null);
+
+        if (!parameters.TryGetValue("realm", out var realm))
+        {
+            // 'realm' is required as it specifies the token endpoint URL for the challenge.
+            throw new KeyNotFoundException(
+                "Missing 'realm' parameter in WWW-Authenticate Bearer challenge.");
+        }
+
+        // Validate realm URL before sending credentials.
+        if (!Uri.TryCreate(realm, UriKind.Absolute, out var realmUri))
+        {
+            throw new AuthenticationException($"Invalid realm URL: '{realm}'");
+        }
+
+        if (!await context.IsRealmAllowedAsync(realmUri, cancellationToken).ConfigureAwait(false))
+        {
+            throw new AuthenticationException(
+                $"Authentication realm '{realmUri}' is not allowed for registry '{context.OriginalRequest.RequestUri!.Authority}'.");
+        }
+
+        if (!parameters.TryGetValue("service", out var service))
+        {
+            // some registries may omit the `service` parameter; use an empty string when absent.
+            service = string.Empty;
+        }
+
+        var bearerToken = await context
+            .FetchBearerTokenAsync(realm, service, scopes, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new AuthChallengeResolution
+        {
+            Scheme = Challenge.Scheme.Bearer,
+            Token = bearerToken,
+            CacheScopeKey = cacheKey,
+        };
+    }
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/IAuthChallengeHandler.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/IAuthChallengeHandler.cs
@@ -1,0 +1,71 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Resolves the authorization used to retry a request that received an HTTP 401
+/// (Unauthorized) response, given the server's <c>WWW-Authenticate</c> challenge.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the pluggable seam for token acquisition. <see cref="Client"/> attaches any
+/// cached token and sends the first request itself; when that returns 401 it delegates the
+/// "challenge → authorization" decision to this handler, then performs the retry send and
+/// caching using the returned <see cref="AuthChallengeResolution"/>.
+/// </para>
+/// <para>
+/// The default implementation, <see cref="DefaultAuthChallengeHandler"/>, performs the
+/// standard OCI distribution flow (parse challenge, validate realm, fetch a Basic or Bearer
+/// token). Consumers can supply a custom handler to recover from non-conformant registries
+/// whose token-carrying 401 is unusable — for example a missing challenge, or a challenge
+/// pointing at a different host — by issuing a credential-free probe via
+/// <see cref="AuthChallengeContext.SendWithoutAuthorizationAsync"/> to re-derive a usable
+/// challenge.
+/// </para>
+/// <para>
+/// Implementations must be thread-safe (a single handler may serve concurrent requests) and
+/// must not retain the supplied <see cref="AuthChallengeContext"/> beyond the call.
+/// </para>
+/// <para>
+/// Note: before invoking this handler on a Bearer challenge, the client may try a token it has
+/// already cached under the challenge's (merged) scope — a cache optimization that can satisfy
+/// the request without calling the handler. The handler is always invoked when that cached
+/// token is absent or itself rejected.
+/// </para>
+/// </remarks>
+/// <seealso href="https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#authorization">
+/// OCI Distribution Spec — Authorization
+/// </seealso>
+public interface IAuthChallengeHandler
+{
+    /// <summary>
+    /// Resolves the authorization to retry the original request with.
+    /// </summary>
+    /// <param name="context">
+    /// The context for the unauthorized request, exposing the original request, the 401
+    /// response, and capabilities to fetch tokens, validate realms, merge scopes, and probe
+    /// the registry without credentials.
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// The authorization to retry with, or <c>null</c> to give up — in which case the client
+    /// returns the original 401 response unchanged.
+    /// </returns>
+    Task<AuthChallengeResolution?> ResolveAuthorizationAsync(
+        AuthChallengeContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/AuthChallengeHandlerTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/AuthChallengeHandlerTest.cs
@@ -1,0 +1,285 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using OrasProject.Oras.Registry.Remote.Auth;
+using static OrasProject.Oras.Tests.Remote.Util.Util;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Registry.Remote.Auth;
+
+/// <summary>
+/// Tests for the pluggable <see cref="IAuthChallengeHandler"/> seam. These demonstrate that a
+/// custom handler can recover from a non-conformant registry whose token-carrying 401 is
+/// unusable (no <c>WWW-Authenticate</c> challenge) by issuing a credential-free probe — the
+/// scenario the default handler intentionally does not handle.
+/// </summary>
+public class AuthChallengeHandlerTest
+{
+    private const string _host = "dhi.example.com";
+    private const string _staleToken = "stale_token";
+    private const string _freshToken = "fresh_token";
+
+    /// <summary>
+    /// Simulates a registry (e.g. dhi.io) that returns a 401 with NO challenge when a stale
+    /// bearer token is presented, but returns a usable Bearer challenge on a cold (no-auth)
+    /// request, and issues a fresh token from its token endpoint.
+    /// </summary>
+    private static HttpResponseMessage NonConformantRegistry(HttpRequestMessage req, CancellationToken cancellationToken)
+    {
+        // Token endpoint: hand out a fresh token (anonymous fetch).
+        if (req.RequestUri!.AbsolutePath == "/token")
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"{{\"access_token\":\"{_freshToken}\"}}"),
+                RequestMessage = req,
+            };
+        }
+
+        var token = req.Headers.Authorization?.Parameter;
+
+        // Fresh token is accepted.
+        if (token == _freshToken)
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = req };
+        }
+
+        // Stale token is rejected WITHOUT a challenge (the non-conformant behavior).
+        if (token == _staleToken)
+        {
+            return new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req };
+        }
+
+        // Cold (no-auth) request yields a usable, same-host Bearer challenge.
+        var unauthorized = new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req };
+        unauthorized.Headers.WwwAuthenticate.Add(
+            new AuthenticationHeaderValue("Bearer", $"realm=\"https://{_host}/token\",service=\"{_host}\""));
+        return unauthorized;
+    }
+
+    [Fact]
+    public async Task CustomHandler_RecoversFromMissingChallenge_WhenCachedTokenIsStale()
+    {
+        // Arrange: a client whose cache holds a stale token, using a custom handler that
+        // cold-probes to recover when the token-carrying 401 has no usable challenge.
+        var client = new Client(new HttpClient(CustomHandler(NonConformantRegistry).Object))
+        {
+            AuthChallengeHandler = new ColdReDeriveHandler(),
+        };
+        client.Cache.SetCache(_host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{_host}/v2/");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: the cold-probe recovery produced a fresh token and the retry succeeded.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DefaultHandler_DoesNotRecoverFromMissingChallenge_ReturnsUnauthorized()
+    {
+        // Arrange: identical setup, but with the default handler (no custom recovery).
+        var client = new Client(new HttpClient(CustomHandler(NonConformantRegistry).Object));
+        client.Cache.SetCache(_host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{_host}/v2/");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: the unusable 401 is surfaced unchanged — the seam is what enables recovery.
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CustomHandler_ReturningNull_ReturnsOriginalUnauthorized()
+    {
+        // Arrange: a handler that always gives up.
+        var client = new Client(new HttpClient(CustomHandler(NonConformantRegistry).Object))
+        {
+            AuthChallengeHandler = new GiveUpHandler(),
+        };
+        client.Cache.SetCache(_host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{_host}/v2/");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SendWithoutAuthorizationAsync_ThrowsForNonReplayableRequest()
+    {
+        // Arrange: a POST is not idempotent, so the cold-probe primitive must refuse to replay it.
+        InvalidOperationException? captured = null;
+        var handler = new DelegateHandler(async (context, ct) =>
+        {
+            Assert.False(context.CanReplayOriginalRequest);
+            captured = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => context.SendWithoutAuthorizationAsync(ct));
+            return null;
+        });
+
+        var client = new Client(new HttpClient(CustomHandler(NonConformantRegistry).Object))
+        {
+            AuthChallengeHandler = handler,
+        };
+        client.Cache.SetCache(_host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"https://{_host}/v2/")
+        {
+            Content = new StringContent("payload"),
+        };
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(captured);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvalidResolution_UnsupportedScheme_Throws()
+    {
+        // A handler must return Basic or Bearer; Unknown must be rejected, not silently sent.
+        var handler = new DelegateHandler((context, ct) => Task.FromResult<AuthChallengeResolution?>(
+            new AuthChallengeResolution { Scheme = Challenge.Scheme.Unknown, Token = "x" }));
+        var client = new Client(new HttpClient(CustomHandler(NonConformantRegistry).Object))
+        {
+            AuthChallengeHandler = handler,
+        };
+        client.Cache.SetCache(_host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{_host}/v2/");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.SendAsync(request, cancellationToken: CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task InvalidResolution_EmptyToken_Throws()
+    {
+        // A handler must return a non-empty token.
+        var handler = new DelegateHandler((context, ct) => Task.FromResult<AuthChallengeResolution?>(
+            new AuthChallengeResolution { Scheme = Challenge.Scheme.Bearer, Token = string.Empty }));
+        var client = new Client(new HttpClient(CustomHandler(NonConformantRegistry).Object))
+        {
+            AuthChallengeHandler = handler,
+        };
+        client.Cache.SetCache(_host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{_host}/v2/");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.SendAsync(request, cancellationToken: CancellationToken.None));
+    }
+
+    /// <summary>
+    /// A handler that, on an unusable (missing/unknown) challenge with a stale cached token,
+    /// re-derives a usable challenge from a credential-free probe and acquires a fresh token.
+    /// This mirrors the recovery a pull-through-cache consumer would implement.
+    /// </summary>
+    private sealed class ColdReDeriveHandler : IAuthChallengeHandler
+    {
+        private static readonly DefaultAuthChallengeHandler _standard = new();
+
+        public async Task<AuthChallengeResolution?> ResolveAuthorizationAsync(
+            AuthChallengeContext context,
+            CancellationToken cancellationToken = default)
+        {
+            var standardResolution = await _standard
+                .ResolveAuthorizationAsync(context, cancellationToken)
+                .ConfigureAwait(false);
+            if (standardResolution != null)
+            {
+                return standardResolution;
+            }
+
+            // The challenge was unusable. Only recover when a cached token was attached (so a
+            // genuine cold bad-credential failure is not masked) and the request is replayable.
+            if (!context.AttachedCachedToken || !context.CanReplayOriginalRequest)
+            {
+                return null;
+            }
+
+            using var cold = await context
+                .SendWithoutAuthorizationAsync(cancellationToken)
+                .ConfigureAwait(false);
+            if (cold.StatusCode != HttpStatusCode.Unauthorized)
+            {
+                return null;
+            }
+
+            var (scheme, parameters) = Challenge.ParseChallenge(
+                cold.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
+            if (scheme != Challenge.Scheme.Bearer || parameters == null ||
+                !parameters.TryGetValue("realm", out var realm) ||
+                !Uri.TryCreate(realm, UriKind.Absolute, out var realmUri))
+            {
+                return null;
+            }
+
+            if (!await context.IsRealmAllowedAsync(realmUri, cancellationToken).ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            var (scopes, cacheKey) = context.MergeChallengeScopes(
+                parameters.GetValueOrDefault("scope"));
+            parameters.TryGetValue("service", out var service);
+            var token = await context
+                .FetchBearerTokenAsync(realm, service ?? string.Empty, scopes, cancellationToken)
+                .ConfigureAwait(false);
+
+            return new AuthChallengeResolution
+            {
+                Scheme = Challenge.Scheme.Bearer,
+                Token = token,
+                CacheScopeKey = cacheKey,
+            };
+        }
+    }
+
+    private sealed class GiveUpHandler : IAuthChallengeHandler
+    {
+        public Task<AuthChallengeResolution?> ResolveAuthorizationAsync(
+            AuthChallengeContext context,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<AuthChallengeResolution?>(null);
+    }
+
+    private sealed class DelegateHandler : IAuthChallengeHandler
+    {
+        private readonly Func<AuthChallengeContext, CancellationToken, Task<AuthChallengeResolution?>> _func;
+
+        public DelegateHandler(Func<AuthChallengeContext, CancellationToken, Task<AuthChallengeResolution?>> func)
+            => _func = func;
+
+        public Task<AuthChallengeResolution?> ResolveAuthorizationAsync(
+            AuthChallengeContext context,
+            CancellationToken cancellationToken = default)
+            => _func(context, cancellationToken);
+    }
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/AuthChallengeRecoverySampleTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/AuthChallengeRecoverySampleTest.cs
@@ -1,0 +1,187 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+using OrasProject.Oras.Registry.Remote.Auth;
+using OrasProject.Oras.Examples.AuthChallengeRecovery;
+using static OrasProject.Oras.Tests.Remote.Util.Util;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Registry.Remote.Auth;
+
+/// <summary>
+/// Validates the <see cref="IAuthChallengeHandler"/> contract against the two real-world
+/// recovery scenarios it was designed for, implemented using ONLY the public API:
+/// <list type="bullet">
+/// <item>a registry that omits the challenge entirely on a stale-token 401, and</item>
+/// <item>a registry whose stale-token 401 challenge points at a foreign (different-host) realm.</item>
+/// </list>
+/// The <see cref="ColdReDeriveAuthChallengeHandler"/> below is a liftable reference
+/// implementation a pull-through-cache consumer would supply.
+/// </summary>
+public class AuthChallengeRecoverySampleTest
+{
+    private const string _staleToken = "stale_token";
+    private const string _freshToken = "fresh_token";
+
+    // ---- Scenario A: registry omits the challenge on a stale-token 401 (dhi-style) ----
+
+    [Fact]
+    public async Task Recovers_When_StaleToken401_HasNoChallenge()
+    {
+        const string host = "registry-omits-challenge.example.com";
+
+        HttpResponseMessage Registry(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (req.RequestUri!.AbsolutePath == "/token")
+            {
+                return Json($"{{\"access_token\":\"{_freshToken}\"}}");
+            }
+
+            return req.Headers.Authorization?.Parameter switch
+            {
+                _freshToken => new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = req },
+                // Stale token -> 401 with NO WWW-Authenticate challenge.
+                _staleToken => new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req },
+                // Cold (no-auth) request -> a usable, same-host Bearer challenge.
+                _ => Unauthorized(req, $"Bearer realm=\"https://{host}/token\",service=\"{host}\""),
+            };
+        }
+
+        var response = await RunWithStaleToken(host, Registry);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // ---- Scenario B: stale-token 401 challenge points at a foreign realm (nvcr-style) ----
+
+    [Fact]
+    public async Task Recovers_When_StaleToken401_PointsAtForeignRealm()
+    {
+        const string host = "registry-foreign-realm.example.com";
+        const string foreignIdp = "idp.example.com"; // different host -> realm validation denies it
+
+        HttpResponseMessage Registry(HttpRequestMessage req, CancellationToken ct)
+        {
+            // The cold, same-host realm endpoint hands out a fresh token.
+            if (req.RequestUri!.AbsolutePath == "/proxy_auth")
+            {
+                return Json($"{{\"access_token\":\"{_freshToken}\"}}");
+            }
+
+            return req.Headers.Authorization?.Parameter switch
+            {
+                _freshToken => new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = req },
+                // Stale token -> 401 whose realm is a FOREIGN host (its IdP).
+                _staleToken => Unauthorized(req, $"Bearer realm=\"https://{foreignIdp}/token\",service=\"{host}\""),
+                // Cold (no-auth) request -> a usable, SAME-host Bearer challenge.
+                _ => Unauthorized(req, $"Bearer realm=\"https://{host}/proxy_auth\",service=\"{host}\""),
+            };
+        }
+
+        var response = await RunWithStaleToken(host, Registry);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // ---- Compliant registry: handler defers to the standard flow, no cold probe ----
+
+    [Fact]
+    public async Task CompliantRegistry_SucceedsViaStandardFlow_WithoutColdProbe()
+    {
+        const string host = "registry-compliant.example.com";
+        var requests = new List<string>();
+
+        HttpResponseMessage Registry(HttpRequestMessage req, CancellationToken ct)
+        {
+            requests.Add($"{req.Method} {req.RequestUri!.AbsolutePath} auth={req.Headers.Authorization?.Parameter ?? "none"}");
+            if (req.RequestUri!.AbsolutePath == "/token")
+            {
+                return Json($"{{\"access_token\":\"{_freshToken}\"}}");
+            }
+
+            return req.Headers.Authorization?.Parameter == _freshToken
+                ? new HttpResponseMessage(HttpStatusCode.OK) { RequestMessage = req }
+                : Unauthorized(req, $"Bearer realm=\"https://{host}/token\",service=\"{host}\"");
+        }
+
+        var client = new Client(new HttpClient(CustomHandler(Registry).Object))
+        {
+            AuthChallengeHandler = new ColdReDeriveAuthChallengeHandler(),
+        };
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/");
+
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        // attempt-1 (401) + token fetch + retry (200) == 3 requests; a cold probe would add a 4th.
+        Assert.Equal(3, requests.Count);
+    }
+
+    // ---- Credential failure behind an ALLOWED realm must NOT be masked by recovery ----
+
+    [Fact]
+    public async Task CredentialFailure_BehindAllowedRealm_IsNotMaskedByRecovery()
+    {
+        const string host = "registry-badcreds.example.com";
+
+        HttpResponseMessage Registry(HttpRequestMessage req, CancellationToken ct)
+        {
+            // Token endpoint rejects the credentials.
+            if (req.RequestUri!.AbsolutePath == "/token")
+            {
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req };
+            }
+
+            // Same-host (allowed) realm — so this is a credential failure, not a challenge failure.
+            return Unauthorized(req, $"Bearer realm=\"https://{host}/token\",service=\"{host}\"");
+        }
+
+        // The token fetch failure must surface (not be swallowed and retried as a cold probe).
+        await Assert.ThrowsAnyAsync<Exception>(() => RunWithStaleToken(host, Registry));
+    }
+
+    // ---- helpers ----
+
+    private static Task<HttpResponseMessage> RunWithStaleToken(
+        string host,
+        Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> registry)
+    {
+        var client = new Client(new HttpClient(CustomHandler(registry).Object))
+        {
+            AuthChallengeHandler = new ColdReDeriveAuthChallengeHandler(),
+        };
+        // Seed a stale token so attempt-1 attaches it (AttachedCachedToken == true).
+        client.Cache.SetCache(host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}/v2/");
+        return client.SendAsync(request, cancellationToken: CancellationToken.None);
+    }
+
+    private static HttpResponseMessage Json(string body)
+        => new(HttpStatusCode.OK) { Content = new StringContent(body) };
+
+    private static HttpResponseMessage Unauthorized(HttpRequestMessage req, string wwwAuthenticate)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req };
+        var space = wwwAuthenticate.IndexOf(' ');
+        response.Headers.WwwAuthenticate.Add(
+            new AuthenticationHeaderValue(wwwAuthenticate[..space], wwwAuthenticate[(space + 1)..]));
+        return response;
+    }
+}


### PR DESCRIPTION
Closes #405.

## What

Adds an extension point for turning an HTTP 401 into the `Authorization` used to retry, so consumers can recover from registries whose token-carrying 401 is unusable (missing challenge, or a challenge pointing at a different host). The challenge-to-token flow was previously hard-coded in `SendCoreAsync`.

## API (new, in `Registry/Remote/Auth/`)

- **`IAuthChallengeHandler`** — `ResolveAuthorizationAsync(context) -> AuthChallengeResolution?` (`null` = give up, return the 401 unchanged).
- **`AuthChallengeContext`** — the failed exchange (original request, 401 response, parsed `Scheme`/`ChallengeParameters`, `Host`, `RequestedScopes`, `AttachedCachedToken`, `CanReplayOriginalRequest`) plus capabilities that delegate to the client: `SendWithoutAuthorizationAsync` (credential-free probe), `IsRealmAllowedAsync`, `MergeChallengeScopes`, `FetchBearerTokenAsync`/`FetchBasicTokenAsync`, `TryGetCachedToken`.
- **`AuthChallengeResolution`** — `Scheme` + `Token` (+ `CacheScopeKey`, `Cache`).
- **`DefaultAuthChallengeHandler`** — the standard OCI distribution flow; preserves prior behavior exactly (returns `null` for an unknown/absent challenge, throws on missing/invalid/denied realm).

## Client

`SendCoreAsync` attaches any cached token, sends, and on 401 delegates to the configured handler (defaulting to `DefaultAuthChallengeHandler`), then performs the retry send and caching. `response1` disposal is airtight across the success, give-up, and exception/cancellation paths; a resolution with an unsupported scheme or empty token is rejected; the scope-changed cache shortcut is retained as a client-owned cache optimization. `SendRequestAsync` is now `internal` so the context's probe can reuse it.

## Backward compatibility

Default behavior is unchanged — **no existing test was modified**. The full suite is green apart from one pre-existing, unrelated Windows-only realm test (`SendAsync_RealmValidation_RelativeRealm_Throws`, fails identically on `main`).

## Example

New `OrasProject.Oras.Examples.AuthChallengeRecovery` project — a host-agnostic cold-probe recovery handler — **exercised by the test suite** (missing-challenge recovery, foreign-realm recovery, compliant-registry no-extra-request, and credential-failure-not-masked).

## Testing

`dotnet test` across the suite; new handler and example tests included.
