### PR TITLE
feat(auth): add opt-in ChallengeRecovery seam for unusable 401 challenges

### DIFF
--- a/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveries.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveries.cs
@@ -11,10 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
 /// <summary>
-/// Built-in <see cref="ChallengeRecoveryHandler"/> strategies.
+/// Built-in <see cref="IChallengeRecovery"/> strategies.
 /// </summary>
 public static class ChallengeRecoveries
 {
@@ -24,8 +28,21 @@ public static class ChallengeRecoveries
     /// request is replayable; the client then re-runs the recovered response through its standard
     /// flow. This is host-agnostic — it keys off the shape of the failure, not registry names.
     /// </summary>
-    public static ChallengeRecoveryHandler ColdProbe { get; } = static async (context, cancellationToken) =>
-        context.AttachedCachedToken && context.CanReplay
+    public static IChallengeRecovery ColdProbe { get; } = new ColdProbeChallengeRecovery();
+}
+
+/// <summary>
+/// The built-in cold-probe recovery exposed by <see cref="ChallengeRecoveries.ColdProbe"/>: re-derives
+/// the challenge from a credential-free request when the failed attempt carried a cached token and the
+/// request is replayable; otherwise declines (returns <c>null</c>). Host-agnostic.
+/// </summary>
+internal sealed class ColdProbeChallengeRecovery : IChallengeRecovery
+{
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage?> RecoverAsync(
+        FailedChallenge context,
+        CancellationToken cancellationToken = default)
+        => context.AttachedCachedToken && context.CanReplay
             ? await context.ProbeWithoutAuthorizationAsync(cancellationToken).ConfigureAwait(false)
             : null;
 }

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveries.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveries.cs
@@ -1,0 +1,31 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Built-in <see cref="ChallengeRecoveryHandler"/> strategies.
+/// </summary>
+public static class ChallengeRecoveries
+{
+    /// <summary>
+    /// Recovers by re-deriving the challenge from a credential-free request to the same URL. It
+    /// applies only when the failed attempt carried a cached token (a stale-token rejection) and the
+    /// request is replayable; the client then re-runs the recovered response through its standard
+    /// flow. This is host-agnostic — it keys off the shape of the failure, not registry names.
+    /// </summary>
+    public static ChallengeRecoveryHandler ColdProbe { get; } = static async (context, cancellationToken) =>
+        context.AttachedCachedToken && context.CanReplay
+            ? await context.ProbeWithoutAuthorizationAsync(cancellationToken).ConfigureAwait(false)
+            : null;
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveryHandler.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveryHandler.cs
@@ -24,18 +24,21 @@ namespace OrasProject.Oras.Registry.Remote.Auth;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The client consults a recovery handler only after standard resolution of the 401 has failed to
-/// produce a usable challenge, and only for a request that carried a cached token
-/// (<see cref="FailedChallenge.AttachedCachedToken"/>) and is replayable
-/// (<see cref="FailedChallenge.CanReplay"/>). Credential and token-endpoint failures are surfaced as
-/// exceptions and never reach a recovery handler, so recovery cannot mask a real authentication error.
+/// The client consults a recovery handler whenever standard resolution of a 401 fails to produce a
+/// usable challenge — for <em>every</em> such 401, regardless of whether the request carried a cached
+/// token or is replayable. The handler is expected to <b>self-gate</b>: inspect
+/// <see cref="FailedChallenge.AttachedCachedToken"/> and <see cref="FailedChallenge.CanReplay"/> and
+/// return <c>null</c> when recovery does not apply. (The built-in
+/// <see cref="ChallengeRecoveries.ColdProbe"/> recovers only when both are <c>true</c>.) Credential and
+/// token-endpoint failures are surfaced as exceptions <em>before</em> any handler is consulted, so
+/// recovery cannot mask a real authentication error.
 /// </para>
 /// <para>
 /// Return a replacement response for the client to continue from — typically the result of
-/// <see cref="FailedChallenge.ProbeWithoutAuthorizationAsync"/>, which the client re-runs through the
-/// standard flow (so a recovered challenge is fetched/cached normally, and an already-successful
-/// response is returned as-is) — or <c>null</c> to give up, in which case the client falls back to its
-/// default behavior for the original 401.
+/// <see cref="FailedChallenge.ProbeWithoutAuthorizationAsync"/>. If that response is itself a fresh
+/// 401, the client re-runs it through the standard flow once (so a recovered challenge is
+/// fetched/cached normally); if it is a success, it is returned as-is. Return <c>null</c> to give up,
+/// in which case the client falls back to its default behavior for the original 401.
 /// </para>
 /// <para>See <see cref="ChallengeRecoveries.ColdProbe"/> for the built-in cold-probe recovery.</para>
 /// </remarks>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveryHandler.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveryHandler.cs
@@ -20,7 +20,10 @@ namespace OrasProject.Oras.Registry.Remote.Auth;
 /// <summary>
 /// Attempts to recover from an HTTP 401 whose challenge the standard authentication flow could not
 /// use — for example a registry that omits the <c>WWW-Authenticate</c> challenge when a stale token
-/// is presented, or returns one whose realm points at a different host.
+/// is presented, or one whose challenge is followed to its token endpoint only for that endpoint to
+/// reject the token request with a 401 (a challenge derived from a stale cached token that the
+/// registry cannot honor). In both cases a credential-free request to the same URL yields a usable
+/// challenge.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -29,9 +32,12 @@ namespace OrasProject.Oras.Registry.Remote.Auth;
 /// token or is replayable. The handler is expected to <b>self-gate</b>: inspect
 /// <see cref="FailedChallenge.AttachedCachedToken"/> and <see cref="FailedChallenge.CanReplay"/> and
 /// return <c>null</c> when recovery does not apply. (The built-in
-/// <see cref="ChallengeRecoveries.ColdProbe"/> recovers only when both are <c>true</c>.) Credential and
-/// token-endpoint failures are surfaced as exceptions <em>before</em> any handler is consulted, so
-/// recovery cannot mask a real authentication error.
+/// <see cref="ChallengeRecoveries.ColdProbe"/> recovers only when both are <c>true</c>.) Genuine
+/// credential failures, and any non-401 token-endpoint failure, are surfaced as exceptions
+/// <em>before</em> any handler is consulted, so recovery cannot mask a real authentication error. The
+/// one token-endpoint outcome offered to recovery is a <b>401</b> from following the challenge's realm
+/// — the stale-token failure this seam exists to tolerate; if recovery declines, that exact exception
+/// is rethrown unchanged.
 /// </para>
 /// <para>
 /// Return a replacement response for the client to continue from — typically the result of

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveryHandler.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ChallengeRecoveryHandler.cs
@@ -1,0 +1,47 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// Attempts to recover from an HTTP 401 whose challenge the standard authentication flow could not
+/// use — for example a registry that omits the <c>WWW-Authenticate</c> challenge when a stale token
+/// is presented, or returns one whose realm points at a different host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The client consults a recovery handler only after standard resolution of the 401 has failed to
+/// produce a usable challenge, and only for a request that carried a cached token
+/// (<see cref="FailedChallenge.AttachedCachedToken"/>) and is replayable
+/// (<see cref="FailedChallenge.CanReplay"/>). Credential and token-endpoint failures are surfaced as
+/// exceptions and never reach a recovery handler, so recovery cannot mask a real authentication error.
+/// </para>
+/// <para>
+/// Return a replacement response for the client to continue from — typically the result of
+/// <see cref="FailedChallenge.ProbeWithoutAuthorizationAsync"/>, which the client re-runs through the
+/// standard flow (so a recovered challenge is fetched/cached normally, and an already-successful
+/// response is returned as-is) — or <c>null</c> to give up, in which case the client falls back to its
+/// default behavior for the original 401.
+/// </para>
+/// <para>See <see cref="ChallengeRecoveries.ColdProbe"/> for the built-in cold-probe recovery.</para>
+/// </remarks>
+/// <param name="context">The failed 401 exchange, plus a credential-free probe primitive.</param>
+/// <param name="cancellationToken">A token to cancel the operation.</param>
+/// <returns>A replacement response to continue from, or <c>null</c> to give up.</returns>
+public delegate Task<HttpResponseMessage?> ChallengeRecoveryHandler(
+    FailedChallenge context,
+    CancellationToken cancellationToken);

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -277,7 +277,7 @@ public class Client : IClient
     /// standard give-up behavior. Set to <see cref="ChallengeRecoveries.ColdProbe"/> (or a custom
     /// handler) to opt in.
     /// </summary>
-    public ChallengeRecoveryHandler? ChallengeRecovery { get; set; }
+    public ChallengeRecoveryHandler? ChallengeRecovery { get; init; }
 
     /// <summary>
     /// ScopeManager is an instance to manage scopes.
@@ -743,15 +743,13 @@ public class Client : IClient
         // Standard resolution dead-ended on a challenge it could not use. Consult the optional recovery
         // handler; it decides whether the failure is recoverable (e.g. a stale-token rejection) and, if
         // so, returns a response to continue from. Conformant registries never reach here.
-        // Capture the handler once so a concurrent reconfiguration can't null it out mid-flight.
-        var challengeRecovery = ChallengeRecovery;
-        if (challengeRecovery != null)
+        if (ChallengeRecovery != null)
         {
             HttpResponseMessage? recovered;
             try
             {
                 recovered = await InvokeChallengeRecoveryAsync(
-                    challengeRecovery, originalRequest, response1, host, partitionId, attemptedKey, attachedCachedToken, allowAutoRedirect, cancellationToken)
+                    originalRequest, response1, host, partitionId, attemptedKey, attachedCachedToken, allowAutoRedirect, cancellationToken)
                     .ConfigureAwait(false);
             }
             catch
@@ -820,6 +818,11 @@ public class Client : IClient
                 }
             case Challenge.Scheme.Bearer:
                 {
+                    // Usable recognized scheme: release the original 401 up front (matching the client's
+                    // long-standing eager dispose). Its status and headers remain readable afterward for
+                    // the recovery path.
+                    unauthorizedResponse.Dispose();
+
                     if (parameters == null)
                     {
                         return StandardAuthResult.Unusable(ChallengeFailureKind.MissingParameters);
@@ -849,11 +852,8 @@ public class Client : IClient
 
                         if (response2.StatusCode != HttpStatusCode.Unauthorized)
                         {
-                            if (refreshAttemptedScopeKey && !string.Equals(newKey, attemptedKey, StringComparison.Ordinal))
-                            {
-                                Cache.SetCache(host, schemeFromChallenge, attemptedKey, cachedToken, partitionId);
-                            }
-                            unauthorizedResponse.Dispose();
+                            RefreshAttemptedScopeKeyIfNeeded(
+                                refreshAttemptedScopeKey, response2.StatusCode, host, schemeFromChallenge, attemptedKey, newKey, cachedToken, partitionId);
                             return StandardAuthResult.Resolved(response2);
                         }
                         response2.Dispose();
@@ -883,9 +883,6 @@ public class Client : IClient
                         service = string.Empty;
                     }
 
-                    // Usable challenge: release the original 401 before the token round-trip.
-                    unauthorizedResponse.Dispose();
-
                     // Try to fetch bearer token based on the challenge header
                     var bearerAuthToken = await FetchBearerAuthAsync(
                         host,
@@ -896,17 +893,12 @@ public class Client : IClient
                         cancellationToken
                     ).ConfigureAwait(false);
                     Cache.SetCache(host, schemeFromChallenge, newKey, bearerAuthToken, partitionId);
-                    if (refreshAttemptedScopeKey && !string.Equals(newKey, attemptedKey, StringComparison.Ordinal))
-                    {
-                        // Recovery: the token cached under the originally attempted scope key was stale
-                        // (it provoked this 401). Overwrite it so future requests under that key succeed
-                        // directly instead of re-entering recovery.
-                        Cache.SetCache(host, schemeFromChallenge, attemptedKey, bearerAuthToken, partitionId);
-                    }
 
                     var requestAttempt3 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
                     requestAttempt3.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerAuthToken);
                     var bearerResponse = await SendRequestAsync(requestAttempt3, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    RefreshAttemptedScopeKeyIfNeeded(
+                        refreshAttemptedScopeKey, bearerResponse.StatusCode, host, schemeFromChallenge, attemptedKey, newKey, bearerAuthToken, partitionId);
                     return StandardAuthResult.Resolved(bearerResponse);
                 }
             default:
@@ -917,13 +909,13 @@ public class Client : IClient
     /// <summary>
     /// Invokes the configured <see cref="ChallengeRecovery"/> handler for an unusable 401 and continues
     /// from whatever it returns: a fresh 401 is re-run through <see cref="ResolveStandardChallengeAsync"/>
-    /// exactly once (using this client's own collaborators); a success (2xx) is returned as-is (e.g.
-    /// anonymous access); any other status is discarded so it does not mask the original 401. Returns the
+    /// exactly once (using this client's own collaborators); a success or redirect (2xx/3xx) is returned
+    /// as-is (e.g. anonymous access, or a captured blob-location redirect); any other status is discarded
+    /// so it does not mask the original 401. Returns the
     /// response to continue from, or <c>null</c> to give up. The cold probe carries no token, so a
     /// recovered 401 cannot re-enter recovery — bounded to one pass.
     /// </summary>
     private async Task<HttpResponseMessage?> InvokeChallengeRecoveryAsync(
-        ChallengeRecoveryHandler challengeRecovery,
         HttpRequestMessage originalRequest,
         HttpResponseMessage unauthorizedResponse,
         string host,
@@ -935,13 +927,13 @@ public class Client : IClient
     {
         var context = new FailedChallenge(
             unauthorizedResponse.StatusCode,
-            unauthorizedResponse.Headers,
+            unauthorizedResponse.Headers.WwwAuthenticate.Select(h => h.ToString()).ToArray(),
             host,
             attachedCachedToken,
             canReplay: CanReplayWithoutAuthorization(originalRequest),
             probe: ct => ProbeWithoutAuthorizationAsync(originalRequest, allowAutoRedirect, ct));
 
-        var recovered = await challengeRecovery(context, cancellationToken).ConfigureAwait(false);
+        var recovered = await ChallengeRecovery!(context, cancellationToken).ConfigureAwait(false);
         if (recovered == null)
         {
             return null;
@@ -976,14 +968,15 @@ public class Client : IClient
             return retry.Response;
         }
 
-        if (recovered.IsSuccessStatusCode)
+        if (IsSuccessOrRedirect(recovered.StatusCode))
         {
-            // The registry served the request without (usable) authorization, e.g. anonymous access.
+            // The registry served the request without (usable) authorization: a success, or a redirect
+            // (e.g. an anonymous blob-location 307 for a caller that captures redirects).
             return recovered;
         }
 
-        // A non-401, non-success cold response (e.g. 403/404/5xx) is not a recovery; returning it would
-        // mask the original 401, which is the more meaningful signal for an auth problem. Give up.
+        // A non-401, non-success/redirect cold response (e.g. 403/404/5xx) is not a recovery; returning it
+        // would mask the original 401, which is the more meaningful signal for an auth problem. Give up.
         recovered.Dispose();
         return null;
     }
@@ -1008,6 +1001,33 @@ public class Client : IClient
     /// </summary>
     private static bool CanReplayWithoutAuthorization(HttpRequestMessage request)
         => request.Method == HttpMethod.Get || request.Method == HttpMethod.Head;
+
+    /// <summary>Whether <paramref name="statusCode"/> is a 2xx success or a 3xx redirect (200–399).</summary>
+    private static bool IsSuccessOrRedirect(HttpStatusCode statusCode)
+        => (int)statusCode is >= 200 and < 400;
+
+    /// <summary>
+    /// Recovery only: once a token has demonstrably worked (a 2xx/3xx final response), replace the stale
+    /// token cached under the originally attempted scope key so future requests under that key succeed
+    /// directly instead of re-entering recovery. No-op unless the key actually changed.
+    /// </summary>
+    private void RefreshAttemptedScopeKeyIfNeeded(
+        bool refresh,
+        HttpStatusCode resolvedStatus,
+        string host,
+        Challenge.Scheme scheme,
+        string attemptedKey,
+        string newKey,
+        string token,
+        string? partitionId)
+    {
+        if (refresh
+            && IsSuccessOrRedirect(resolvedStatus)
+            && !string.Equals(newKey, attemptedKey, StringComparison.Ordinal))
+        {
+            Cache.SetCache(host, scheme, attemptedKey, token, partitionId);
+        }
+    }
 
     /// <summary>
     /// Reproduces the client's default behavior for a structurally unusable challenge when no recovery

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -277,7 +277,7 @@ public class Client : IClient
     /// standard give-up behavior. Set to <see cref="ChallengeRecoveries.ColdProbe"/> (or a custom
     /// handler) to opt in.
     /// </summary>
-    public ChallengeRecoveryHandler? ChallengeRecovery { get; init; }
+    public ChallengeRecoveryHandler? ChallengeRecovery { get; set; }
 
     /// <summary>
     /// ScopeManager is an instance to manage scopes.
@@ -691,7 +691,9 @@ public class Client : IClient
                         if (Cache.TryGetToken(host, schemeFromCache, string.Empty, out var basicToken, partitionId))
                         {
                             requestAttempt1.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicToken);
-                            attachedCachedToken = true;
+                            // Not flagged as a recoverable cached token: a credential-free re-derive can't
+                            // help Basic auth (the same credentials are simply re-sent). Recovery targets
+                            // stale Bearer tokens.
                         }
 
                         break;
@@ -741,13 +743,15 @@ public class Client : IClient
         // Standard resolution dead-ended on a challenge it could not use. Consult the optional recovery
         // handler; it decides whether the failure is recoverable (e.g. a stale-token rejection) and, if
         // so, returns a response to continue from. Conformant registries never reach here.
-        if (ChallengeRecovery != null)
+        // Capture the handler once so a concurrent reconfiguration can't null it out mid-flight.
+        var challengeRecovery = ChallengeRecovery;
+        if (challengeRecovery != null)
         {
             HttpResponseMessage? recovered;
             try
             {
                 recovered = await InvokeChallengeRecoveryAsync(
-                    originalRequest, response1, host, partitionId, attemptedKey, attachedCachedToken, allowAutoRedirect, cancellationToken)
+                    challengeRecovery, originalRequest, response1, host, partitionId, attemptedKey, attachedCachedToken, allowAutoRedirect, cancellationToken)
                     .ConfigureAwait(false);
             }
             catch
@@ -919,6 +923,7 @@ public class Client : IClient
     /// recovered 401 cannot re-enter recovery — bounded to one pass.
     /// </summary>
     private async Task<HttpResponseMessage?> InvokeChallengeRecoveryAsync(
+        ChallengeRecoveryHandler challengeRecovery,
         HttpRequestMessage originalRequest,
         HttpResponseMessage unauthorizedResponse,
         string host,
@@ -936,7 +941,7 @@ public class Client : IClient
             canReplay: CanReplayWithoutAuthorization(originalRequest),
             probe: ct => ProbeWithoutAuthorizationAsync(originalRequest, allowAutoRedirect, ct));
 
-        var recovered = await ChallengeRecovery!(context, cancellationToken).ConfigureAwait(false);
+        var recovered = await challengeRecovery(context, cancellationToken).ConfigureAwait(false);
         if (recovered == null)
         {
             return null;
@@ -1037,7 +1042,7 @@ public class Client : IClient
     /// The outcome of <see cref="ResolveStandardChallengeAsync"/>: either a resolved response, or the
     /// reason the challenge could not be used.
     /// </summary>
-    private readonly struct StandardAuthResult
+    private sealed class StandardAuthResult
     {
         private StandardAuthResult(HttpResponseMessage? response, ChallengeFailureKind failureKind, string? realm, Uri? realmUri)
         {

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -21,11 +21,13 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Mime;
+using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using OrasProject.Oras.Registry.Remote.Exceptions;
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
@@ -273,7 +275,8 @@ public class Client : IClient
     /// <summary>
     /// An optional recovery handler consulted when standard resolution of a 401 fails to produce a
     /// usable challenge (e.g. a non-conformant registry that omits the challenge on a token-carrying
-    /// 401, or points its realm at a different host). Defaults to <c>null</c> — no recovery, i.e. the
+    /// 401, or one whose challenge is followed to its token endpoint only to be rejected there with a
+    /// 401). Defaults to <c>null</c> — no recovery, i.e. the
     /// standard give-up behavior. Set to <see cref="ChallengeRecoveries.ColdProbe"/> (or a custom
     /// handler) to opt in.
     /// </summary>
@@ -462,26 +465,38 @@ public class Client : IClient
         {
             return credential.AccessToken;
         }
-        if (credential.IsEmpty() ||
-            (string.IsNullOrWhiteSpace(credential.RefreshToken) && !ForceAttemptOAuth2))
+        // The calls below follow the challenge to its token endpoint (the realm). Scope any 401 from
+        // that round-trip into a distinct marker so the standard resolver can offer it to an optional
+        // challenge-recovery handler instead of failing outright. A cached out-of-band token from an
+        // AccessTokenProvider (handled above) is deliberately excluded — it does not follow the
+        // challenge — and non-401 token-endpoint errors propagate unchanged.
+        try
         {
-            return await FetchDistributionTokenAsync(
+            if (credential.IsEmpty() ||
+                (string.IsNullOrWhiteSpace(credential.RefreshToken) && !ForceAttemptOAuth2))
+            {
+                return await FetchDistributionTokenAsync(
+                    realm,
+                    service,
+                    scopes,
+                    credential.Username,
+                    credential.Password,
+                    cancellationToken
+                ).ConfigureAwait(false);
+            }
+
+            return await FetchOauth2TokenAsync(
                 realm,
                 service,
                 scopes,
-                credential.Username,
-                credential.Password,
+                credential,
                 cancellationToken
             ).ConfigureAwait(false);
         }
-
-        return await FetchOauth2TokenAsync(
-            realm,
-            service,
-            scopes,
-            credential,
-            cancellationToken
-        ).ConfigureAwait(false);
+        catch (ResponseException e) when (e.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            throw new TokenEndpointUnauthorizedException(e);
+        }
     }
 
     /// <summary>
@@ -797,9 +812,12 @@ public class Client : IClient
     /// <summary>
     /// Runs the standard 401 challenge resolution: parse the <c>WWW-Authenticate</c> challenge and,
     /// for a recognized scheme, fetch/replay credentials. Returns a resolved response on success, or a
-    /// <see cref="StandardAuthResult"/> describing why the challenge was structurally unusable. Throws
-    /// only for genuine credential/token-endpoint failures (never for an unusable challenge), so a
-    /// caller can distinguish "the registry withheld a usable challenge" from "authentication failed".
+    /// <see cref="StandardAuthResult"/> describing why the challenge was structurally unusable. A 401
+    /// from following the challenge's token endpoint is reported as
+    /// <see cref="ChallengeFailureKind.TokenEndpointUnauthorized"/> (carrying the original exception for
+    /// verbatim rethrow), not thrown, so recovery can act on it. It still throws for other genuine
+    /// credential/token-endpoint failures, so a caller can distinguish "the registry withheld a usable
+    /// challenge" from "authentication failed".
     /// </summary>
     /// <remarks>
     /// Disposal: for a recognized scheme (Basic or Bearer) this method disposes
@@ -920,14 +938,31 @@ public class Client : IClient
                     }
 
                     // Try to fetch bearer token based on the challenge header
-                    var bearerAuthToken = await FetchBearerAuthAsync(
-                        host,
-                        realm,
-                        service,
-                        mergedScopes.TokenRequestScopes,
-                        forceRefresh: true,
-                        cancellationToken
-                    ).ConfigureAwait(false);
+                    string bearerAuthToken;
+                    try
+                    {
+                        bearerAuthToken = await FetchBearerAuthAsync(
+                            host,
+                            realm,
+                            service,
+                            mergedScopes.TokenRequestScopes,
+                            forceRefresh: true,
+                            cancellationToken
+                        ).ConfigureAwait(false);
+                    }
+                    catch (TokenEndpointUnauthorizedException e)
+                    {
+                        // We followed the challenge to its token endpoint and it returned 401. Report it
+                        // as an unusable challenge (rather than throwing) so an optional recovery handler
+                        // can act — e.g. a registry that 401s a token request derived from a stale-token
+                        // challenge, yet yields a usable challenge to a credential-free cold probe. If no
+                        // recovery is configured or it declines, the original exception is rethrown as-is.
+                        return StandardAuthResult.Unusable(
+                            ChallengeFailureKind.TokenEndpointUnauthorized,
+                            realm,
+                            realmUri,
+                            ExceptionDispatchInfo.Capture(e.ResponseException));
+                    }
                     if (!mergedScopes.HasOpaqueScopes)
                     {
                         Cache.SetCache(
@@ -1233,6 +1268,13 @@ public class Client : IClient
                 unauthorizedResponse.Dispose();
                 throw new AuthenticationException(
                     $"Authentication realm '{resolution.RealmUri}' is not allowed for registry '{host}'.");
+            case ChallengeFailureKind.TokenEndpointUnauthorized:
+                // We followed the challenge to its token endpoint and it returned 401. With no recovery
+                // (or a recovery that declined), preserve the original behavior: rethrow the exact
+                // token-endpoint exception, with its original stack, that the standard flow always threw.
+                unauthorizedResponse.Dispose();
+                resolution.TokenEndpointException!.Throw();
+                throw resolution.TokenEndpointException.SourceException; // unreachable; Throw() always throws
             default:
                 // NoUsableScheme: no recognized challenge scheme; return the original 401 to the caller.
                 return unauthorizedResponse;
@@ -1245,12 +1287,18 @@ public class Client : IClient
     /// </summary>
     private sealed class StandardAuthResult
     {
-        private StandardAuthResult(HttpResponseMessage? response, ChallengeFailureKind failureKind, string? realm, Uri? realmUri)
+        private StandardAuthResult(
+            HttpResponseMessage? response,
+            ChallengeFailureKind failureKind,
+            string? realm,
+            Uri? realmUri,
+            ExceptionDispatchInfo? tokenEndpointException)
         {
             Response = response;
             FailureKind = failureKind;
             Realm = realm;
             RealmUri = realmUri;
+            TokenEndpointException = tokenEndpointException;
         }
 
         /// <summary>The resolved response, or <c>null</c> when the challenge was unusable.</summary>
@@ -1265,11 +1313,22 @@ public class Client : IClient
         /// <summary>The parsed realm URI, when relevant to the failure.</summary>
         public Uri? RealmUri { get; }
 
-        public static StandardAuthResult Resolved(HttpResponseMessage response)
-            => new(response, ChallengeFailureKind.None, null, null);
+        /// <summary>
+        /// The captured token-endpoint exception for a
+        /// <see cref="ChallengeFailureKind.TokenEndpointUnauthorized"/> failure, rethrown verbatim when
+        /// recovery does not apply; <c>null</c> for all other outcomes.
+        /// </summary>
+        public ExceptionDispatchInfo? TokenEndpointException { get; }
 
-        public static StandardAuthResult Unusable(ChallengeFailureKind failureKind, string? realm = null, Uri? realmUri = null)
-            => new(null, failureKind, realm, realmUri);
+        public static StandardAuthResult Resolved(HttpResponseMessage response)
+            => new(response, ChallengeFailureKind.None, null, null, null);
+
+        public static StandardAuthResult Unusable(
+            ChallengeFailureKind failureKind,
+            string? realm = null,
+            Uri? realmUri = null,
+            ExceptionDispatchInfo? tokenEndpointException = null)
+            => new(null, failureKind, realm, realmUri, tokenEndpointException);
     }
 
     /// <summary>
@@ -1294,6 +1353,34 @@ public class Client : IClient
 
         /// <summary>A Bearer challenge whose <c>realm</c> was rejected by the realm validator.</summary>
         DeniedRealm,
+
+        /// <summary>
+        /// The challenge was structurally usable and its realm was followed, but the token endpoint
+        /// rejected the token request with a 401 (e.g. a non-conformant registry that cannot mint a
+        /// token for a challenge it derived from a stale cached token). Distinct from the failure kinds
+        /// above, which never contacted the token endpoint.
+        /// </summary>
+        TokenEndpointUnauthorized,
+    }
+
+    /// <summary>
+    /// Internal marker raised when following a 401's challenge to its token endpoint itself returns a
+    /// 401. It carries the original <see cref="Exceptions.ResponseException"/> so the standard resolver
+    /// can convert it into a <see cref="ChallengeFailureKind.TokenEndpointUnauthorized"/> result
+    /// (offering it to an optional recovery handler) while still rethrowing the exact original error
+    /// when recovery does not apply. Scoped to the realm round-trip only — an out-of-band
+    /// AccessTokenProvider 401 is excluded.
+    /// </summary>
+    private sealed class TokenEndpointUnauthorizedException : Exception
+    {
+        public TokenEndpointUnauthorizedException(ResponseException responseException)
+            : base(responseException.Message, responseException)
+        {
+            ResponseException = responseException;
+        }
+
+        /// <summary>The original token-endpoint 401 exception, rethrown verbatim when recovery declines.</summary>
+        public ResponseException ResponseException { get; }
     }
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -780,6 +780,11 @@ public class Client : IClient
                 recovered = await InvokeChallengeRecoveryAsync(
                     failedStatusCode: failedStatusCode,
                     wwwAuthenticateChallenges: failedChallenges!,
+                    unauthorizedResponseToBuffer:
+                        resolution.FailureKind == ChallengeFailureKind.NoUsableScheme
+                            && originalRequest.Method != HttpMethod.Head
+                            ? response1
+                            : null,
                     originalRequest: originalRequest,
                     host: host,
                     partitionId: partitionId,
@@ -903,6 +908,7 @@ public class Client : IClient
                                 scheme: schemeFromChallenge,
                                 attemptedKey: attemptedKey,
                                 newKey: mergedScopes.CacheKey,
+                                hasOpaqueScopes: mergedScopes.HasOpaqueScopes,
                                 token: cachedToken,
                                 partitionId: partitionId);
                             return StandardAuthResult.Resolved(response2);
@@ -983,6 +989,7 @@ public class Client : IClient
                         scheme: schemeFromChallenge,
                         attemptedKey: attemptedKey,
                         newKey: mergedScopes.CacheKey,
+                        hasOpaqueScopes: mergedScopes.HasOpaqueScopes,
                         token: bearerAuthToken,
                         partitionId: partitionId);
                     return StandardAuthResult.Resolved(bearerResponse);
@@ -1124,6 +1131,7 @@ public class Client : IClient
     private async Task<HttpResponseMessage?> InvokeChallengeRecoveryAsync(
         HttpStatusCode failedStatusCode,
         IReadOnlyList<string> wwwAuthenticateChallenges,
+        HttpResponseMessage? unauthorizedResponseToBuffer,
         HttpRequestMessage originalRequest,
         string host,
         string? partitionId,
@@ -1137,9 +1145,12 @@ public class Client : IClient
             wwwAuthenticateChallenges: wwwAuthenticateChallenges,
             host: host,
             attachedCachedToken: attachedCachedToken,
-            canReplay: CanReplayWithoutAuthorization(originalRequest),
+            canReplay: CanReplayWithoutAuthorization(
+                originalRequest,
+                unauthorizedResponseToBuffer),
             probe: ct => ProbeWithoutAuthorizationAsync(
                 originalRequest: originalRequest,
+                unauthorizedResponseToBuffer: unauthorizedResponseToBuffer,
                 allowAutoRedirect: allowAutoRedirect,
                 cancellationToken: ct));
 
@@ -1148,6 +1159,11 @@ public class Client : IClient
         {
             return null;
         }
+
+        // Custom recoveries may synthesize a response rather than sending an HTTP request. Preserve
+        // an explicitly supplied RequestMessage, but provide the original request when it is absent so
+        // downstream response parsing has the method/URI context it expects.
+        recovered.RequestMessage ??= originalRequest;
 
         if (recovered.StatusCode == HttpStatusCode.Unauthorized)
         {
@@ -1199,24 +1215,51 @@ public class Client : IClient
 
     /// <summary>
     /// Re-sends <paramref name="originalRequest"/> with no <c>Authorization</c> header to elicit a
-    /// fresh challenge from a registry that withheld a usable one for a cached token.
+    /// fresh challenge from a registry that withheld a usable one for a cached token. When the
+    /// original no-challenge 401 is still alive, buffers its bounded content first so the response
+    /// releases its connection before the same-host probe.
     /// </summary>
     private async Task<HttpResponseMessage> ProbeWithoutAuthorizationAsync(
         HttpRequestMessage originalRequest,
+        HttpResponseMessage? unauthorizedResponseToBuffer,
         bool allowAutoRedirect,
         CancellationToken cancellationToken)
     {
+        if (unauthorizedResponseToBuffer != null)
+        {
+            await unauthorizedResponseToBuffer.Content
+                .LoadIntoBufferAsync(MaxBufferSize)
+                .ConfigureAwait(false);
+        }
+
         var probe = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
         probe.Headers.Authorization = null;
         return await SendRequestAsync(probe, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Whether <paramref name="request"/> can be safely re-sent without authorization — restricted to
-    /// idempotent GET/HEAD so a probe never replays a mutating request.
+    /// Whether <paramref name="request"/> can be safely re-sent without authorization: the request is
+    /// an idempotent GET/HEAD, and any still-live 401 content can be bounded-buffered to release its
+    /// connection before the same-host probe.
     /// </summary>
-    private static bool CanReplayWithoutAuthorization(HttpRequestMessage request)
-        => request.Method == HttpMethod.Get || request.Method == HttpMethod.Head;
+    private static bool CanReplayWithoutAuthorization(
+        HttpRequestMessage request,
+        HttpResponseMessage? unauthorizedResponseToBuffer)
+    {
+        if (request.Method != HttpMethod.Get && request.Method != HttpMethod.Head)
+        {
+            return false;
+        }
+
+        if (unauthorizedResponseToBuffer == null)
+        {
+            return true;
+        }
+
+        var contentLength = unauthorizedResponseToBuffer.Content.Headers.ContentLength;
+        return contentLength.HasValue
+            && contentLength.Value <= MaxBufferSize;
+    }
 
     /// <summary>Whether <paramref name="statusCode"/> is a 2xx success or a 3xx redirect (200–399).</summary>
     private static bool IsSuccessOrRedirect(HttpStatusCode statusCode)
@@ -1225,7 +1268,7 @@ public class Client : IClient
     /// <summary>
     /// Recovery only: once a token has demonstrably worked (a 2xx/3xx final response), replace the stale
     /// token cached under the originally attempted scope key so future requests under that key succeed
-    /// directly instead of re-entering recovery. No-op unless the key actually changed.
+    /// directly instead of re-entering recovery. No-op for opaque scopes or unless the key changed.
     /// </summary>
     private void RefreshAttemptedScopeKeyIfNeeded(
         bool refresh,
@@ -1234,11 +1277,13 @@ public class Client : IClient
         Challenge.Scheme scheme,
         string attemptedKey,
         string newKey,
+        bool hasOpaqueScopes,
         string token,
         string? partitionId)
     {
         if (refresh
             && IsSuccessOrRedirect(resolvedStatus)
+            && !hasOpaqueScopes
             && !string.Equals(newKey, attemptedKey, StringComparison.Ordinal))
         {
             Cache.SetCache(host, scheme, attemptedKey, token, partitionId);

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -718,6 +718,14 @@ public class Client : IClient
             return response1;
         }
 
+        // Snapshot the 401's details for a possible recovery handler now, while the response is still
+        // alive: the standard flow below disposes the 401 up front for recognized schemes. Only pay the
+        // (tiny) snapshot cost when a recovery handler is actually configured.
+        var failedStatusCode = response1.StatusCode;
+        var failedChallenges = ChallengeRecovery != null
+            ? Array.AsReadOnly(response1.Headers.WwwAuthenticate.Select(header => header.ToString()).ToArray())
+            : null;
+
         // Resolve the 401 through the standard challenge flow. This never throws for a structurally
         // unusable challenge (it reports the reason instead); it DOES throw for credential/token
         // failures, so those propagate and are never eligible for recovery.
@@ -755,8 +763,9 @@ public class Client : IClient
             try
             {
                 recovered = await InvokeChallengeRecoveryAsync(
+                    failedStatusCode: failedStatusCode,
+                    wwwAuthenticateChallenges: failedChallenges!,
                     originalRequest: originalRequest,
-                    unauthorizedResponse: response1,
                     host: host,
                     partitionId: partitionId,
                     attemptedKey: attemptedKey,
@@ -793,15 +802,17 @@ public class Client : IClient
     /// caller can distinguish "the registry withheld a usable challenge" from "authentication failed".
     /// </summary>
     /// <remarks>
-    /// Disposal: on a <em>resolved</em> return this method disposes <paramref name="unauthorizedResponse"/>
-    /// before the credential/token round-trip (matching the client's long-standing eager-dispose
-    /// behavior); on an <em>unusable</em> return it leaves the response undisposed for the caller to
-    /// reuse (recovery) or return/dispose.
+    /// Disposal: for a recognized scheme (Basic or Bearer) this method disposes
+    /// <paramref name="unauthorizedResponse"/> up front, before the credential/token round-trip (matching
+    /// the client's long-standing eager-dispose behavior) — whether the outcome is resolved or a
+    /// structurally-unusable Bearer challenge. Only the <see cref="ChallengeFailureKind.NoUsableScheme"/>
+    /// outcome leaves the response undisposed, so the caller can return it or hand it to the fallback.
     /// </remarks>
     /// <param name="refreshAttemptedScopeKey">
-    /// When <c>true</c> (the recovery re-derive), the resolving token is also cached under
-    /// <paramref name="attemptedKey"/> so a stale token that provoked recovery is replaced and future
-    /// requests under that scope key don't re-enter recovery.
+    /// When <c>true</c> (the recovery re-derive, gated on a stale token having been attached), a token
+    /// obtained from a successful (2xx/3xx) response is also cached under <paramref name="attemptedKey"/>
+    /// so the stale token that provoked recovery is replaced and future requests under that scope key
+    /// don't re-enter recovery.
     /// </param>
     private async Task<StandardAuthResult> ResolveStandardChallengeAsync(
         HttpRequestMessage originalRequest,
@@ -946,8 +957,9 @@ public class Client : IClient
     /// recovered 401 cannot re-enter recovery — bounded to one pass.
     /// </summary>
     private async Task<HttpResponseMessage?> InvokeChallengeRecoveryAsync(
+        HttpStatusCode failedStatusCode,
+        IReadOnlyList<string> wwwAuthenticateChallenges,
         HttpRequestMessage originalRequest,
-        HttpResponseMessage unauthorizedResponse,
         string host,
         string? partitionId,
         string attemptedKey,
@@ -956,8 +968,8 @@ public class Client : IClient
         CancellationToken cancellationToken)
     {
         var context = new FailedChallenge(
-            statusCode: unauthorizedResponse.StatusCode,
-            wwwAuthenticateChallenges: unauthorizedResponse.Headers.WwwAuthenticate.Select(h => h.ToString()).ToArray(),
+            statusCode: failedStatusCode,
+            wwwAuthenticateChallenges: wwwAuthenticateChallenges,
             host: host,
             attachedCachedToken: attachedCachedToken,
             canReplay: CanReplayWithoutAuthorization(originalRequest),
@@ -987,7 +999,7 @@ public class Client : IClient
                     attemptedKey: attemptedKey,
                     allowAutoRedirect: allowAutoRedirect,
                     cancellationToken: cancellationToken,
-                    refreshAttemptedScopeKey: true)
+                    refreshAttemptedScopeKey: attachedCachedToken)
                     .ConfigureAwait(false);
             }
             catch

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -734,7 +734,7 @@ public class Client : IClient
 
         if (resolution.Response != null)
         {
-            response1.Dispose();
+            // ResolveStandardChallengeAsync disposed the original 401 before the token round-trip.
             return resolution.Response;
         }
 
@@ -774,6 +774,17 @@ public class Client : IClient
     /// only for genuine credential/token-endpoint failures (never for an unusable challenge), so a
     /// caller can distinguish "the registry withheld a usable challenge" from "authentication failed".
     /// </summary>
+    /// <remarks>
+    /// Disposal: on a <em>resolved</em> return this method disposes <paramref name="unauthorizedResponse"/>
+    /// before the credential/token round-trip (matching the client's long-standing eager-dispose
+    /// behavior); on an <em>unusable</em> return it leaves the response undisposed for the caller to
+    /// reuse (recovery) or return/dispose.
+    /// </remarks>
+    /// <param name="refreshAttemptedScopeKey">
+    /// When <c>true</c> (the recovery re-derive), the resolving token is also cached under
+    /// <paramref name="attemptedKey"/> so a stale token that provoked recovery is replaced and future
+    /// requests under that scope key don't re-enter recovery.
+    /// </param>
     private async Task<StandardAuthResult> ResolveStandardChallengeAsync(
         HttpRequestMessage originalRequest,
         HttpResponseMessage unauthorizedResponse,
@@ -781,7 +792,8 @@ public class Client : IClient
         string? partitionId,
         string attemptedKey,
         bool allowAutoRedirect,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool refreshAttemptedScopeKey = false)
     {
         var (schemeFromChallenge, parameters) =
             Challenge.ParseChallenge(unauthorizedResponse.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
@@ -791,6 +803,8 @@ public class Client : IClient
         {
             case Challenge.Scheme.Basic:
                 {
+                    // Usable challenge: release the original 401 before the credential round-trip.
+                    unauthorizedResponse.Dispose();
                     var basicAuthToken = await FetchBasicAuthAsync(host, cancellationToken).ConfigureAwait(false);
                     Cache.SetCache(host, schemeFromChallenge, string.Empty, basicAuthToken, partitionId);
 
@@ -831,6 +845,11 @@ public class Client : IClient
 
                         if (response2.StatusCode != HttpStatusCode.Unauthorized)
                         {
+                            if (refreshAttemptedScopeKey && !string.Equals(newKey, attemptedKey, StringComparison.Ordinal))
+                            {
+                                Cache.SetCache(host, schemeFromChallenge, attemptedKey, cachedToken, partitionId);
+                            }
+                            unauthorizedResponse.Dispose();
                             return StandardAuthResult.Resolved(response2);
                         }
                         response2.Dispose();
@@ -860,6 +879,9 @@ public class Client : IClient
                         service = string.Empty;
                     }
 
+                    // Usable challenge: release the original 401 before the token round-trip.
+                    unauthorizedResponse.Dispose();
+
                     // Try to fetch bearer token based on the challenge header
                     var bearerAuthToken = await FetchBearerAuthAsync(
                         host,
@@ -870,6 +892,13 @@ public class Client : IClient
                         cancellationToken
                     ).ConfigureAwait(false);
                     Cache.SetCache(host, schemeFromChallenge, newKey, bearerAuthToken, partitionId);
+                    if (refreshAttemptedScopeKey && !string.Equals(newKey, attemptedKey, StringComparison.Ordinal))
+                    {
+                        // Recovery: the token cached under the originally attempted scope key was stale
+                        // (it provoked this 401). Overwrite it so future requests under that key succeed
+                        // directly instead of re-entering recovery.
+                        Cache.SetCache(host, schemeFromChallenge, attemptedKey, bearerAuthToken, partitionId);
+                    }
 
                     var requestAttempt3 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
                     requestAttempt3.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerAuthToken);
@@ -883,10 +912,11 @@ public class Client : IClient
 
     /// <summary>
     /// Invokes the configured <see cref="ChallengeRecovery"/> handler for an unusable 401 and continues
-    /// from whatever it returns: a non-401 response is treated as success (e.g. anonymous access); a
-    /// fresh 401 is re-run through <see cref="ResolveStandardChallengeAsync"/> exactly once (using this
-    /// client's own collaborators). Returns the response to continue from, or <c>null</c> to give up.
-    /// The cold probe carries no token, so a recovered 401 cannot re-enter recovery — bounded to one pass.
+    /// from whatever it returns: a fresh 401 is re-run through <see cref="ResolveStandardChallengeAsync"/>
+    /// exactly once (using this client's own collaborators); a success (2xx) is returned as-is (e.g.
+    /// anonymous access); any other status is discarded so it does not mask the original 401. Returns the
+    /// response to continue from, or <c>null</c> to give up. The cold probe carries no token, so a
+    /// recovered 401 cannot re-enter recovery — bounded to one pass.
     /// </summary>
     private async Task<HttpResponseMessage?> InvokeChallengeRecoveryAsync(
         HttpRequestMessage originalRequest,
@@ -899,7 +929,8 @@ public class Client : IClient
         CancellationToken cancellationToken)
     {
         var context = new FailedChallenge(
-            unauthorizedResponse,
+            unauthorizedResponse.StatusCode,
+            unauthorizedResponse.Headers,
             host,
             attachedCachedToken,
             canReplay: CanReplayWithoutAuthorization(originalRequest),
@@ -911,30 +942,45 @@ public class Client : IClient
             return null;
         }
 
-        if (recovered.StatusCode != HttpStatusCode.Unauthorized)
+        if (recovered.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            // The recovery produced a fresh challenge. Re-derive auth from it once, with our own
+            // collaborators, and refresh the stale scope key so we don't re-enter recovery next time.
+            StandardAuthResult retry;
+            try
+            {
+                retry = await ResolveStandardChallengeAsync(
+                    originalRequest, recovered, host, partitionId, attemptedKey, allowAutoRedirect,
+                    cancellationToken, refreshAttemptedScopeKey: true)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                recovered.Dispose();
+                throw;
+            }
+
+            if (retry.Response == null)
+            {
+                // Still unusable after a cold re-derive — give up; the caller falls back to the 401.
+                recovered.Dispose();
+                return null;
+            }
+
+            // Resolved: ResolveStandardChallengeAsync already disposed the cold-probe 401.
+            return retry.Response;
+        }
+
+        if (recovered.IsSuccessStatusCode)
         {
             // The registry served the request without (usable) authorization, e.g. anonymous access.
             return recovered;
         }
 
-        // The recovery produced a fresh challenge. Re-derive auth from it once, with our collaborators.
-        StandardAuthResult retry;
-        try
-        {
-            retry = await ResolveStandardChallengeAsync(
-                originalRequest, recovered, host, partitionId, attemptedKey, allowAutoRedirect, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch
-        {
-            recovered.Dispose();
-            throw;
-        }
-
-        // Either a resolved response (return it) or still unusable (null → caller falls back). Either
-        // way the cold-probe 401 is superseded and can be released.
+        // A non-401, non-success cold response (e.g. 403/404/5xx) is not a recovery; returning it would
+        // mask the original 401, which is the more meaningful signal for an auth problem. Give up.
         recovered.Dispose();
-        return retry.Response;
+        return null;
     }
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -273,14 +273,14 @@ public class Client : IClient
     private IRealmValidator _realmValidator = new DefaultRealmValidator();
 
     /// <summary>
-    /// An optional recovery handler consulted when standard resolution of a 401 fails to produce a
-    /// usable challenge (e.g. a non-conformant registry that omits the challenge on a token-carrying
+    /// An optional recovery implementation consulted when standard resolution of a 401 fails to produce
+    /// a usable challenge (e.g. a non-conformant registry that omits the challenge on a token-carrying
     /// 401, or one whose challenge is followed to its token endpoint only to be rejected there with a
     /// 401). Defaults to <c>null</c> — no recovery, i.e. the
     /// standard give-up behavior. Set to <see cref="ChallengeRecoveries.ColdProbe"/> (or a custom
-    /// handler) to opt in.
+    /// <see cref="IChallengeRecovery"/>) to opt in.
     /// </summary>
-    public ChallengeRecoveryHandler? ChallengeRecovery { get; init; }
+    public IChallengeRecovery? ChallengeRecovery { get; init; }
 
     /// <summary>
     /// ScopeManager is an instance to manage scopes.
@@ -1143,7 +1143,7 @@ public class Client : IClient
                 allowAutoRedirect: allowAutoRedirect,
                 cancellationToken: ct));
 
-        var recovered = await ChallengeRecovery!(context, cancellationToken).ConfigureAwait(false);
+        var recovered = await ChallengeRecovery!.RecoverAsync(context, cancellationToken).ConfigureAwait(false);
         if (recovered == null)
         {
             return null;

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -271,6 +271,15 @@ public class Client : IClient
     private IRealmValidator _realmValidator = new DefaultRealmValidator();
 
     /// <summary>
+    /// An optional recovery handler consulted when standard resolution of a 401 fails to produce a
+    /// usable challenge (e.g. a non-conformant registry that omits the challenge on a token-carrying
+    /// 401, or points its realm at a different host). Defaults to <c>null</c> — no recovery, i.e. the
+    /// standard give-up behavior. Set to <see cref="ChallengeRecoveries.ColdProbe"/> (or a custom
+    /// handler) to opt in.
+    /// </summary>
+    public ChallengeRecoveryHandler? ChallengeRecovery { get; init; }
+
+    /// <summary>
     /// ScopeManager is an instance to manage scopes.
     /// </summary>
     public ScopeManager ScopeManager { get; set; } = new();
@@ -670,6 +679,7 @@ public class Client : IClient
                     throw new ArgumentException("originalRequest.RequestUri or originalRequest.RequestUri.Authority property is null.", nameof(originalRequest));
         var requestAttempt1 = await originalRequest.CloneAsync(rewindContent: false, cancellationToken).ConfigureAwait(false);
         var attemptedKey = string.Empty;
+        var attachedCachedToken = false;
 
         // attempt to send request with cached auth token
         if (Cache.TryGetScheme(host, out var schemeFromCache, partitionId))
@@ -681,6 +691,7 @@ public class Client : IClient
                         if (Cache.TryGetToken(host, schemeFromCache, string.Empty, out var basicToken, partitionId))
                         {
                             requestAttempt1.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicToken);
+                            attachedCachedToken = true;
                         }
 
                         break;
@@ -692,6 +703,7 @@ public class Client : IClient
                         if (Cache.TryGetToken(host, schemeFromCache, attemptedKey, out var bearerToken, partitionId))
                         {
                             requestAttempt1.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+                            attachedCachedToken = true;
                         }
                         break;
                     }
@@ -704,29 +716,95 @@ public class Client : IClient
             return response1;
         }
 
+        // Resolve the 401 through the standard challenge flow. This never throws for a structurally
+        // unusable challenge (it reports the reason instead); it DOES throw for credential/token
+        // failures, so those propagate and are never eligible for recovery.
+        StandardAuthResult resolution;
+        try
+        {
+            resolution = await ResolveStandardChallengeAsync(
+                originalRequest, response1, host, partitionId, attemptedKey, allowAutoRedirect, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            response1.Dispose();
+            throw;
+        }
+
+        if (resolution.Response != null)
+        {
+            response1.Dispose();
+            return resolution.Response;
+        }
+
+        // Standard resolution dead-ended on a challenge it could not use. Consult the optional recovery
+        // handler; it decides whether the failure is recoverable (e.g. a stale-token rejection) and, if
+        // so, returns a response to continue from. Conformant registries never reach here.
+        if (ChallengeRecovery != null)
+        {
+            HttpResponseMessage? recovered;
+            try
+            {
+                recovered = await InvokeChallengeRecoveryAsync(
+                    originalRequest, response1, host, partitionId, attemptedKey, attachedCachedToken, allowAutoRedirect, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                response1.Dispose();
+                throw;
+            }
+
+            if (recovered != null)
+            {
+                response1.Dispose();
+                return recovered;
+            }
+        }
+
+        // No recovery configured, or recovery gave up: preserve the original behavior for this 401.
+        return HandleUnusableChallenge(response1, resolution, host);
+    }
+
+    /// <summary>
+    /// Runs the standard 401 challenge resolution: parse the <c>WWW-Authenticate</c> challenge and,
+    /// for a recognized scheme, fetch/replay credentials. Returns a resolved response on success, or a
+    /// <see cref="StandardAuthResult"/> describing why the challenge was structurally unusable. Throws
+    /// only for genuine credential/token-endpoint failures (never for an unusable challenge), so a
+    /// caller can distinguish "the registry withheld a usable challenge" from "authentication failed".
+    /// </summary>
+    private async Task<StandardAuthResult> ResolveStandardChallengeAsync(
+        HttpRequestMessage originalRequest,
+        HttpResponseMessage unauthorizedResponse,
+        string host,
+        string? partitionId,
+        string attemptedKey,
+        bool allowAutoRedirect,
+        CancellationToken cancellationToken)
+    {
         var (schemeFromChallenge, parameters) =
-            Challenge.ParseChallenge(response1.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
+            Challenge.ParseChallenge(unauthorizedResponse.Headers.WwwAuthenticate.FirstOrDefault()?.ToString());
 
         // Attempt again with credentials for recognized schemes
         switch (schemeFromChallenge)
         {
             case Challenge.Scheme.Basic:
                 {
-                    response1.Dispose();
                     var basicAuthToken = await FetchBasicAuthAsync(host, cancellationToken).ConfigureAwait(false);
                     Cache.SetCache(host, schemeFromChallenge, string.Empty, basicAuthToken, partitionId);
 
                     // Attempt again with basic token
                     var requestAttempt2 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
                     requestAttempt2.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicAuthToken);
-                    return await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    var basicResponse = await SendRequestAsync(requestAttempt2, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    return StandardAuthResult.Resolved(basicResponse);
                 }
             case Challenge.Scheme.Bearer:
                 {
-                    response1.Dispose();
                     if (parameters == null)
                     {
-                        throw new AuthenticationException("Missing parameters in the Www-Authenticate challenge.");
+                        return StandardAuthResult.Unusable(ChallengeFailureKind.MissingParameters);
                     }
 
                     var existingScopes = ScopeManager.GetScopesForHost(host);
@@ -753,33 +831,27 @@ public class Client : IClient
 
                         if (response2.StatusCode != HttpStatusCode.Unauthorized)
                         {
-                            return response2;
+                            return StandardAuthResult.Resolved(response2);
                         }
                         response2.Dispose();
                     }
 
                     if (!parameters.TryGetValue("realm", out var realm))
                     {
-                        // 'realm' is required as it specifies the token endpoint URL for Bearer authentication.
-                        throw new KeyNotFoundException("Missing 'realm' parameter in WWW-Authenticate Bearer challenge.");
+                        // 'realm' is required as it specifies the token endpoint URL for Bearer auth.
+                        return StandardAuthResult.Unusable(ChallengeFailureKind.MissingRealm);
                     }
 
                     // Validate realm URL before sending credentials.
-                    if (!Uri.TryCreate(
-                            realm, UriKind.Absolute,
-                            out var realmUri))
+                    if (!Uri.TryCreate(realm, UriKind.Absolute, out var realmUri))
                     {
-                        throw new AuthenticationException(
-                            $"Invalid realm URL: '{realm}'");
+                        return StandardAuthResult.Unusable(ChallengeFailureKind.InvalidRealm, realm);
                     }
 
                     var registryUri = originalRequest.RequestUri!;
-                    if (!await RealmValidator.IsRealmAllowedAsync(
-                            registryUri, realmUri, cancellationToken)
-                        .ConfigureAwait(false))
+                    if (!await RealmValidator.IsRealmAllowedAsync(registryUri, realmUri, cancellationToken).ConfigureAwait(false))
                     {
-                        throw new AuthenticationException(
-                            $"Authentication realm '{realmUri}' is not allowed for registry '{registryUri.Authority}'.");
+                        return StandardAuthResult.Unusable(ChallengeFailureKind.DeniedRealm, realm, realmUri);
                     }
 
                     if (!parameters.TryGetValue("service", out var service))
@@ -801,11 +873,175 @@ public class Client : IClient
 
                     var requestAttempt3 = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
                     requestAttempt3.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerAuthToken);
-                    return await SendRequestAsync(requestAttempt3, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    var bearerResponse = await SendRequestAsync(requestAttempt3, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+                    return StandardAuthResult.Resolved(bearerResponse);
                 }
             default:
-                return response1;
+                return StandardAuthResult.Unusable(ChallengeFailureKind.NoUsableScheme);
         }
+    }
+
+    /// <summary>
+    /// Invokes the configured <see cref="ChallengeRecovery"/> handler for an unusable 401 and continues
+    /// from whatever it returns: a non-401 response is treated as success (e.g. anonymous access); a
+    /// fresh 401 is re-run through <see cref="ResolveStandardChallengeAsync"/> exactly once (using this
+    /// client's own collaborators). Returns the response to continue from, or <c>null</c> to give up.
+    /// The cold probe carries no token, so a recovered 401 cannot re-enter recovery — bounded to one pass.
+    /// </summary>
+    private async Task<HttpResponseMessage?> InvokeChallengeRecoveryAsync(
+        HttpRequestMessage originalRequest,
+        HttpResponseMessage unauthorizedResponse,
+        string host,
+        string? partitionId,
+        string attemptedKey,
+        bool attachedCachedToken,
+        bool allowAutoRedirect,
+        CancellationToken cancellationToken)
+    {
+        var context = new FailedChallenge(
+            unauthorizedResponse,
+            host,
+            attachedCachedToken,
+            canReplay: CanReplayWithoutAuthorization(originalRequest),
+            probe: ct => ProbeWithoutAuthorizationAsync(originalRequest, allowAutoRedirect, ct));
+
+        var recovered = await ChallengeRecovery!(context, cancellationToken).ConfigureAwait(false);
+        if (recovered == null)
+        {
+            return null;
+        }
+
+        if (recovered.StatusCode != HttpStatusCode.Unauthorized)
+        {
+            // The registry served the request without (usable) authorization, e.g. anonymous access.
+            return recovered;
+        }
+
+        // The recovery produced a fresh challenge. Re-derive auth from it once, with our collaborators.
+        StandardAuthResult retry;
+        try
+        {
+            retry = await ResolveStandardChallengeAsync(
+                originalRequest, recovered, host, partitionId, attemptedKey, allowAutoRedirect, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            recovered.Dispose();
+            throw;
+        }
+
+        // Either a resolved response (return it) or still unusable (null → caller falls back). Either
+        // way the cold-probe 401 is superseded and can be released.
+        recovered.Dispose();
+        return retry.Response;
+    }
+
+    /// <summary>
+    /// Re-sends <paramref name="originalRequest"/> with no <c>Authorization</c> header to elicit a
+    /// fresh challenge from a registry that withheld a usable one for a cached token.
+    /// </summary>
+    private async Task<HttpResponseMessage> ProbeWithoutAuthorizationAsync(
+        HttpRequestMessage originalRequest,
+        bool allowAutoRedirect,
+        CancellationToken cancellationToken)
+    {
+        var probe = await originalRequest.CloneAsync(rewindContent: true, cancellationToken).ConfigureAwait(false);
+        probe.Headers.Authorization = null;
+        return await SendRequestAsync(probe, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="request"/> can be safely re-sent without authorization — restricted to
+    /// idempotent GET/HEAD so a probe never replays a mutating request.
+    /// </summary>
+    private static bool CanReplayWithoutAuthorization(HttpRequestMessage request)
+        => request.Method == HttpMethod.Get || request.Method == HttpMethod.Head;
+
+    /// <summary>
+    /// Reproduces the client's default behavior for a structurally unusable challenge when no recovery
+    /// applies: an unrecognized scheme yields the original 401; a malformed Bearer challenge throws the
+    /// same exception the standard flow has always thrown.
+    /// </summary>
+    private static HttpResponseMessage HandleUnusableChallenge(
+        HttpResponseMessage unauthorizedResponse, StandardAuthResult resolution, string host)
+    {
+        switch (resolution.FailureKind)
+        {
+            case ChallengeFailureKind.MissingParameters:
+                unauthorizedResponse.Dispose();
+                throw new AuthenticationException("Missing parameters in the Www-Authenticate challenge.");
+            case ChallengeFailureKind.MissingRealm:
+                unauthorizedResponse.Dispose();
+                throw new KeyNotFoundException("Missing 'realm' parameter in WWW-Authenticate Bearer challenge.");
+            case ChallengeFailureKind.InvalidRealm:
+                unauthorizedResponse.Dispose();
+                throw new AuthenticationException($"Invalid realm URL: '{resolution.Realm}'");
+            case ChallengeFailureKind.DeniedRealm:
+                unauthorizedResponse.Dispose();
+                throw new AuthenticationException(
+                    $"Authentication realm '{resolution.RealmUri}' is not allowed for registry '{host}'.");
+            default:
+                // NoUsableScheme: no recognized challenge scheme; return the original 401 to the caller.
+                return unauthorizedResponse;
+        }
+    }
+
+    /// <summary>
+    /// The outcome of <see cref="ResolveStandardChallengeAsync"/>: either a resolved response, or the
+    /// reason the challenge could not be used.
+    /// </summary>
+    private readonly struct StandardAuthResult
+    {
+        private StandardAuthResult(HttpResponseMessage? response, ChallengeFailureKind failureKind, string? realm, Uri? realmUri)
+        {
+            Response = response;
+            FailureKind = failureKind;
+            Realm = realm;
+            RealmUri = realmUri;
+        }
+
+        /// <summary>The resolved response, or <c>null</c> when the challenge was unusable.</summary>
+        public HttpResponseMessage? Response { get; }
+
+        /// <summary>Why the challenge was unusable; <see cref="ChallengeFailureKind.None"/> when resolved.</summary>
+        public ChallengeFailureKind FailureKind { get; }
+
+        /// <summary>The raw realm value, when relevant to the failure.</summary>
+        public string? Realm { get; }
+
+        /// <summary>The parsed realm URI, when relevant to the failure.</summary>
+        public Uri? RealmUri { get; }
+
+        public static StandardAuthResult Resolved(HttpResponseMessage response)
+            => new(response, ChallengeFailureKind.None, null, null);
+
+        public static StandardAuthResult Unusable(ChallengeFailureKind failureKind, string? realm = null, Uri? realmUri = null)
+            => new(null, failureKind, realm, realmUri);
+    }
+
+    /// <summary>
+    /// The reason the standard flow could not use a 401's challenge.
+    /// </summary>
+    private enum ChallengeFailureKind
+    {
+        /// <summary>The challenge was resolved; not a failure.</summary>
+        None,
+
+        /// <summary>No recognized authentication scheme in the challenge (e.g. no challenge at all).</summary>
+        NoUsableScheme,
+
+        /// <summary>A Bearer challenge with no parameters.</summary>
+        MissingParameters,
+
+        /// <summary>A Bearer challenge missing the required <c>realm</c> parameter.</summary>
+        MissingRealm,
+
+        /// <summary>A Bearer challenge whose <c>realm</c> is not an absolute URI.</summary>
+        InvalidRealm,
+
+        /// <summary>A Bearer challenge whose <c>realm</c> was rejected by the realm validator.</summary>
+        DeniedRealm,
     }
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Client.cs
@@ -725,7 +725,13 @@ public class Client : IClient
         try
         {
             resolution = await ResolveStandardChallengeAsync(
-                originalRequest, response1, host, partitionId, attemptedKey, allowAutoRedirect, cancellationToken)
+                originalRequest: originalRequest,
+                unauthorizedResponse: response1,
+                host: host,
+                partitionId: partitionId,
+                attemptedKey: attemptedKey,
+                allowAutoRedirect: allowAutoRedirect,
+                cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
         catch
@@ -749,7 +755,14 @@ public class Client : IClient
             try
             {
                 recovered = await InvokeChallengeRecoveryAsync(
-                    originalRequest, response1, host, partitionId, attemptedKey, attachedCachedToken, allowAutoRedirect, cancellationToken)
+                    originalRequest: originalRequest,
+                    unauthorizedResponse: response1,
+                    host: host,
+                    partitionId: partitionId,
+                    attemptedKey: attemptedKey,
+                    attachedCachedToken: attachedCachedToken,
+                    allowAutoRedirect: allowAutoRedirect,
+                    cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
             catch
@@ -766,7 +779,10 @@ public class Client : IClient
         }
 
         // No recovery configured, or recovery gave up: preserve the original behavior for this 401.
-        return HandleUnusableChallenge(response1, resolution, host);
+        return HandleUnusableChallenge(
+            unauthorizedResponse: response1,
+            resolution: resolution,
+            host: host);
     }
 
     /// <summary>
@@ -853,7 +869,14 @@ public class Client : IClient
                         if (response2.StatusCode != HttpStatusCode.Unauthorized)
                         {
                             RefreshAttemptedScopeKeyIfNeeded(
-                                refreshAttemptedScopeKey, response2.StatusCode, host, schemeFromChallenge, attemptedKey, newKey, cachedToken, partitionId);
+                                refresh: refreshAttemptedScopeKey,
+                                resolvedStatus: response2.StatusCode,
+                                host: host,
+                                scheme: schemeFromChallenge,
+                                attemptedKey: attemptedKey,
+                                newKey: newKey,
+                                token: cachedToken,
+                                partitionId: partitionId);
                             return StandardAuthResult.Resolved(response2);
                         }
                         response2.Dispose();
@@ -898,7 +921,14 @@ public class Client : IClient
                     requestAttempt3.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerAuthToken);
                     var bearerResponse = await SendRequestAsync(requestAttempt3, allowAutoRedirect, cancellationToken).ConfigureAwait(false);
                     RefreshAttemptedScopeKeyIfNeeded(
-                        refreshAttemptedScopeKey, bearerResponse.StatusCode, host, schemeFromChallenge, attemptedKey, newKey, bearerAuthToken, partitionId);
+                        refresh: refreshAttemptedScopeKey,
+                        resolvedStatus: bearerResponse.StatusCode,
+                        host: host,
+                        scheme: schemeFromChallenge,
+                        attemptedKey: attemptedKey,
+                        newKey: newKey,
+                        token: bearerAuthToken,
+                        partitionId: partitionId);
                     return StandardAuthResult.Resolved(bearerResponse);
                 }
             default:
@@ -926,12 +956,15 @@ public class Client : IClient
         CancellationToken cancellationToken)
     {
         var context = new FailedChallenge(
-            unauthorizedResponse.StatusCode,
-            unauthorizedResponse.Headers.WwwAuthenticate.Select(h => h.ToString()).ToArray(),
-            host,
-            attachedCachedToken,
+            statusCode: unauthorizedResponse.StatusCode,
+            wwwAuthenticateChallenges: unauthorizedResponse.Headers.WwwAuthenticate.Select(h => h.ToString()).ToArray(),
+            host: host,
+            attachedCachedToken: attachedCachedToken,
             canReplay: CanReplayWithoutAuthorization(originalRequest),
-            probe: ct => ProbeWithoutAuthorizationAsync(originalRequest, allowAutoRedirect, ct));
+            probe: ct => ProbeWithoutAuthorizationAsync(
+                originalRequest: originalRequest,
+                allowAutoRedirect: allowAutoRedirect,
+                cancellationToken: ct));
 
         var recovered = await ChallengeRecovery!(context, cancellationToken).ConfigureAwait(false);
         if (recovered == null)
@@ -947,8 +980,14 @@ public class Client : IClient
             try
             {
                 retry = await ResolveStandardChallengeAsync(
-                    originalRequest, recovered, host, partitionId, attemptedKey, allowAutoRedirect,
-                    cancellationToken, refreshAttemptedScopeKey: true)
+                    originalRequest: originalRequest,
+                    unauthorizedResponse: recovered,
+                    host: host,
+                    partitionId: partitionId,
+                    attemptedKey: attemptedKey,
+                    allowAutoRedirect: allowAutoRedirect,
+                    cancellationToken: cancellationToken,
+                    refreshAttemptedScopeKey: true)
                     .ConfigureAwait(false);
             }
             catch

--- a/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
@@ -21,10 +21,10 @@ using System.Threading.Tasks;
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
 /// <summary>
-/// The context passed to a <see cref="ChallengeRecoveryHandler"/>: a read-only view of an HTTP 401
+/// The context passed to an <see cref="IChallengeRecovery"/>: a read-only view of an HTTP 401
 /// whose challenge the standard flow could not use, plus a credential-free probe primitive to
 /// re-derive a usable one. This is plain data; it holds no client reference and does not expose the
-/// underlying (engine-owned) response object, so a handler can neither dispose nor mutate it.
+/// underlying (engine-owned) response object, so a recovery cannot dispose or mutate it.
 /// </summary>
 public sealed class FailedChallenge
 {

--- a/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
@@ -1,0 +1,80 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrasProject.Oras.Registry.Remote.Auth;
+
+/// <summary>
+/// The context passed to a <see cref="ChallengeRecoveryHandler"/>: an HTTP 401 whose challenge the
+/// standard flow could not use, plus a credential-free probe primitive to re-derive a usable one.
+/// This is plain data; it holds no client reference.
+/// </summary>
+public sealed class FailedChallenge
+{
+    private readonly Func<CancellationToken, Task<HttpResponseMessage>> _probe;
+
+    internal FailedChallenge(
+        HttpResponseMessage unauthorizedResponse,
+        string host,
+        bool attachedCachedToken,
+        bool canReplay,
+        Func<CancellationToken, Task<HttpResponseMessage>> probe)
+    {
+        UnauthorizedResponse = unauthorizedResponse;
+        Host = host;
+        AttachedCachedToken = attachedCachedToken;
+        CanReplay = canReplay;
+        _probe = probe;
+    }
+
+    /// <summary>The 401 response, including whatever (unusable) <c>WWW-Authenticate</c> it carried.</summary>
+    public HttpResponseMessage UnauthorizedResponse { get; }
+
+    /// <summary>The registry authority (host, with port when non-default) that issued the challenge.</summary>
+    public string Host { get; }
+
+    /// <summary>
+    /// <c>true</c> when the failed attempt carried a cached token — i.e. this 401 is likely a
+    /// stale-token rejection rather than a first-time challenge.
+    /// </summary>
+    public bool AttachedCachedToken { get; }
+
+    /// <summary>
+    /// <c>true</c> when the original request can be safely re-sent without authorization
+    /// (an idempotent GET/HEAD). <see cref="ProbeWithoutAuthorizationAsync"/> requires it.
+    /// </summary>
+    public bool CanReplay { get; }
+
+    /// <summary>
+    /// Re-sends the original request with no <c>Authorization</c> header to elicit a fresh challenge.
+    /// The returned response is owned by the caller and must be disposed (or returned to the client).
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The response to the credential-free request.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <see cref="CanReplay"/> is <c>false</c>.</exception>
+    public Task<HttpResponseMessage> ProbeWithoutAuthorizationAsync(CancellationToken cancellationToken = default)
+    {
+        if (!CanReplay)
+        {
+            throw new InvalidOperationException(
+                "The original request cannot be safely replayed without authorization " +
+                "because it is not an idempotent GET or HEAD request.");
+        }
+
+        return _probe(cancellationToken);
+    }
+}

--- a/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
@@ -12,37 +12,48 @@
 // limitations under the License.
 
 using System;
+using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
 /// <summary>
-/// The context passed to a <see cref="ChallengeRecoveryHandler"/>: an HTTP 401 whose challenge the
-/// standard flow could not use, plus a credential-free probe primitive to re-derive a usable one.
-/// This is plain data; it holds no client reference.
+/// The context passed to a <see cref="ChallengeRecoveryHandler"/>: a read-only view of an HTTP 401
+/// whose challenge the standard flow could not use, plus a credential-free probe primitive to
+/// re-derive a usable one. This is plain data; it holds no client reference and does not expose the
+/// underlying (engine-owned) response object, so a handler can neither dispose nor mutate it.
 /// </summary>
 public sealed class FailedChallenge
 {
     private readonly Func<CancellationToken, Task<HttpResponseMessage>> _probe;
 
     internal FailedChallenge(
-        HttpResponseMessage unauthorizedResponse,
+        HttpStatusCode statusCode,
+        HttpResponseHeaders responseHeaders,
         string host,
         bool attachedCachedToken,
         bool canReplay,
         Func<CancellationToken, Task<HttpResponseMessage>> probe)
     {
-        UnauthorizedResponse = unauthorizedResponse;
+        StatusCode = statusCode;
+        ResponseHeaders = responseHeaders;
         Host = host;
         AttachedCachedToken = attachedCachedToken;
         CanReplay = canReplay;
         _probe = probe;
     }
 
-    /// <summary>The 401 response, including whatever (unusable) <c>WWW-Authenticate</c> it carried.</summary>
-    public HttpResponseMessage UnauthorizedResponse { get; }
+    /// <summary>The status code of the rejected response (an <see cref="HttpStatusCode.Unauthorized"/>).</summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The response headers of the rejected 401, including whatever (unusable) <c>WWW-Authenticate</c>
+    /// it carried. Provided for inspection only.
+    /// </summary>
+    public HttpResponseHeaders ResponseHeaders { get; }
 
     /// <summary>The registry authority (host, with port when non-default) that issued the challenge.</summary>
     public string Host { get; }

--- a/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
@@ -59,8 +59,9 @@ public sealed class FailedChallenge
     public string Host { get; }
 
     /// <summary>
-    /// <c>true</c> when the failed attempt carried a cached token — i.e. this 401 is likely a
-    /// stale-token rejection rather than a first-time challenge.
+    /// <c>true</c> when the failed attempt carried a cached <em>bearer</em> token — i.e. this 401 is
+    /// likely a stale-token rejection rather than a first-time challenge. Cached Basic credentials are
+    /// not flagged, since a credential-free re-derive cannot remedy them.
     /// </summary>
     public bool AttachedCachedToken { get; }
 

--- a/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
@@ -67,7 +67,8 @@ public sealed class FailedChallenge
 
     /// <summary>
     /// <c>true</c> when the original request can be safely re-sent without authorization
-    /// (an idempotent GET/HEAD). <see cref="ProbeWithoutAuthorizationAsync"/> requires it.
+    /// (an idempotent GET/HEAD whose failed response can release its connection before the probe).
+    /// <see cref="ProbeWithoutAuthorizationAsync"/> requires it.
     /// </summary>
     public bool CanReplay { get; }
 

--- a/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
@@ -50,8 +50,8 @@ public sealed class FailedChallenge
     public HttpStatusCode StatusCode { get; }
 
     /// <summary>
-    /// An immutable snapshot of the rejected 401's <c>WWW-Authenticate</c> challenge value(s) — empty
-    /// when the registry sent none. Provided for inspection; mutating it cannot affect the engine.
+    /// A read-only snapshot of the rejected 401's <c>WWW-Authenticate</c> challenge value(s) — empty
+    /// when the registry sent none. Provided for inspection.
     /// </summary>
     public IReadOnlyList<string> WwwAuthenticateChallenges { get; }
 

--- a/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/FailedChallenge.cs
@@ -12,9 +12,9 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -32,14 +32,14 @@ public sealed class FailedChallenge
 
     internal FailedChallenge(
         HttpStatusCode statusCode,
-        HttpResponseHeaders responseHeaders,
+        IReadOnlyList<string> wwwAuthenticateChallenges,
         string host,
         bool attachedCachedToken,
         bool canReplay,
         Func<CancellationToken, Task<HttpResponseMessage>> probe)
     {
         StatusCode = statusCode;
-        ResponseHeaders = responseHeaders;
+        WwwAuthenticateChallenges = wwwAuthenticateChallenges;
         Host = host;
         AttachedCachedToken = attachedCachedToken;
         CanReplay = canReplay;
@@ -50,10 +50,10 @@ public sealed class FailedChallenge
     public HttpStatusCode StatusCode { get; }
 
     /// <summary>
-    /// The response headers of the rejected 401, including whatever (unusable) <c>WWW-Authenticate</c>
-    /// it carried. Provided for inspection only.
+    /// An immutable snapshot of the rejected 401's <c>WWW-Authenticate</c> challenge value(s) — empty
+    /// when the registry sent none. Provided for inspection; mutating it cannot affect the engine.
     /// </summary>
-    public HttpResponseHeaders ResponseHeaders { get; }
+    public IReadOnlyList<string> WwwAuthenticateChallenges { get; }
 
     /// <summary>The registry authority (host, with port when non-default) that issued the challenge.</summary>
     public string Host { get; }

--- a/src/OrasProject.Oras/Registry/Remote/Auth/IChallengeRecovery.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/IChallengeRecovery.cs
@@ -56,7 +56,10 @@ public interface IChallengeRecovery
     /// </summary>
     /// <param name="context">The failed 401 exchange, plus a credential-free probe primitive.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A replacement response to continue from, or <c>null</c> to give up.</returns>
+    /// <returns>
+    /// A replacement response to continue from, or <c>null</c> to give up. If the returned response
+    /// has no <see cref="HttpResponseMessage.RequestMessage"/>, the client assigns the original request.
+    /// </returns>
     Task<HttpResponseMessage?> RecoverAsync(
         FailedChallenge context,
         CancellationToken cancellationToken = default);

--- a/src/OrasProject.Oras/Registry/Remote/Auth/IChallengeRecovery.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/IChallengeRecovery.cs
@@ -48,9 +48,16 @@ namespace OrasProject.Oras.Registry.Remote.Auth;
 /// </para>
 /// <para>See <see cref="ChallengeRecoveries.ColdProbe"/> for the built-in cold-probe recovery.</para>
 /// </remarks>
-/// <param name="context">The failed 401 exchange, plus a credential-free probe primitive.</param>
-/// <param name="cancellationToken">A token to cancel the operation.</param>
-/// <returns>A replacement response to continue from, or <c>null</c> to give up.</returns>
-public delegate Task<HttpResponseMessage?> ChallengeRecoveryHandler(
-    FailedChallenge context,
-    CancellationToken cancellationToken);
+public interface IChallengeRecovery
+{
+    /// <summary>
+    /// Attempts to recover from the failed 401 challenge described by <paramref name="context"/>,
+    /// returning a replacement response for the client to continue from, or <c>null</c> to give up.
+    /// </summary>
+    /// <param name="context">The failed 401 exchange, plus a credential-free probe primitive.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A replacement response to continue from, or <c>null</c> to give up.</returns>
+    Task<HttpResponseMessage?> RecoverAsync(
+        FailedChallenge context,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -51,13 +51,16 @@ public class ChallengeRecoveryTest
             RequestMessage = req
         };
 
-    private static HttpResponseMessage Unauthorized(HttpRequestMessage req, string? realm)
+    private static HttpResponseMessage Unauthorized(
+        HttpRequestMessage req,
+        string? realm,
+        string scope = _scope)
     {
         var response = new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req };
         if (realm != null)
         {
             response.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(
-                "Bearer", $"realm=\"{realm}\",service=\"registry\",scope=\"{_scope}\""));
+                "Bearer", $"realm=\"{realm}\",service=\"registry\",scope=\"{scope}\""));
         }
         return response;
     }
@@ -581,6 +584,36 @@ public class ChallengeRecoveryTest
     }
 
     [Fact]
+    public async Task SendAsync_ChallengeRecovery_SynthesizedResponse_PopulatesRequestMessage()
+    {
+        // Arrange: a custom recovery may synthesize a terminal response without sending a request.
+        // Normalize its RequestMessage so downstream parsing has the original method/URI context.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+            => Unauthorized(req, realm: null);
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = new DelegateChallengeRecovery(
+                (context, ct) => Task.FromResult<HttpResponseMessage?>(
+                    new HttpResponseMessage(HttpStatusCode.OK)))
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        using var response = await client.SendAsync(
+            request,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Same(request, response.RequestMessage);
+    }
+
+    [Fact]
     public async Task SendAsync_ChallengeRecovery_NoCachedToken_ColdProbeDeclines()
     {
         // Arrange: an unusable 401 with NO cached token attached (first-request style). ColdProbe must
@@ -690,6 +723,176 @@ public class ChallengeRecoveryTest
         Assert.Equal(2, recoveryCalls);
     }
 
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_OpaqueScope_DoesNotRefreshAttemptedKey()
+    {
+        // Arrange: the caller's structured scope drives the attempted cache key. A stale token under
+        // that key provokes recovery, whose cold-probe challenge adds an opaque scope. Tokens fetched
+        // for opaque scopes are deliberately non-cacheable, including under the attempted key.
+        var host = NewHost();
+        var coldRealm = $"https://{host}/token";
+        const string opaqueScope = "opaque-scope";
+        var tokenRequestCount = 0;
+        var currentToken = string.Empty;
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req))
+            {
+                currentToken = $"opaque_scope_token_{++tokenRequestCount}";
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent($"{{\"access_token\":\"{currentToken}\"}}"),
+                    RequestMessage = req
+                };
+            }
+
+            var token = req.Headers.Authorization?.Parameter;
+            if (!string.IsNullOrEmpty(currentToken) && token == currentToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, realm: null);
+            return Unauthorized(req, coldRealm, opaqueScope);
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        Assert.True(Scope.TryParse(_scope, out var structuredScope));
+        client.ScopeManager.SetScopeForRegistry(host, structuredScope, null);
+        client.Cache.SetCache(host, Challenge.Scheme.Bearer, _scope, _staleToken);
+
+        // Act: both calls must recover independently; the first opaque-scope token must not become
+        // sticky under the structured attempted key.
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+        var response1 = await client.SendAsync(request1, cancellationToken: CancellationToken.None);
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+        var response2 = await client.SendAsync(request2, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+        Assert.Equal(2, tokenRequestCount);
+        VerifyColdProbe(mockHandler, Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_NoChallenge_Buffers401BeforeColdProbe()
+    {
+        // Arrange: ResponseHeadersRead leaves an unread 401 body holding its HTTP/1.1 connection.
+        // Recovery must buffer the bounded body before issuing a same-host cold probe.
+        var host = NewHost();
+        var coldRealm = $"https://{host}/token";
+        var unauthorizedContent = new TrackingContent();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken)
+            {
+                var response = Unauthorized(req, realm: null);
+                response.Content = unauthorizedContent;
+                return response;
+            }
+
+            Assert.True(unauthorizedContent.WasBuffered);
+            return Unauthorized(req, coldRealm);
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(unauthorizedContent.WasBuffered);
+        VerifyColdProbe(mockHandler, Times.Once());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_NoChallengeWithUnboundedBody_ColdProbeDeclines()
+    {
+        // Arrange: an unknown-length body cannot be bounded-buffered without risking unbounded memory.
+        // Mark the exchange non-replayable so ColdProbe declines instead of holding the connection and
+        // deadlocking a bounded same-host connection pool.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (req.Headers.Authorization?.Parameter == _staleToken)
+            {
+                var response = Unauthorized(req, realm: null);
+                response.Content = new UnknownLengthContent();
+                return response;
+            }
+
+            return Ok(req); // an unsafe cold probe would turn the result into 200
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: preserve the original 401 and issue no credential-free probe.
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        VerifyColdProbe(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_HeadWithLargeDeclaredLength_ColdProbeRecovers()
+    {
+        // Arrange: HEAD responses can advertise the GET representation's large Content-Length but
+        // cannot carry a response body. Do not treat that metadata as an unbufferable 401 body.
+        var host = NewHost();
+        var coldRealm = $"https://{host}/token";
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken)
+            {
+                var response = Unauthorized(req, realm: null);
+                response.Content = new LargeDeclaredLengthContent();
+                return response;
+            }
+
+            return Unauthorized(req, coldRealm);
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Head, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: recovery proceeds without trying to buffer the nonexistent HEAD response body.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        VerifyColdProbe(mockHandler, Times.Once());
+    }
+
     /// <summary>
     /// Test adapter that turns a lambda into an <see cref="IChallengeRecovery"/>, so tests can express
     /// ad-hoc recovery strategies inline.
@@ -705,5 +908,58 @@ public class ChallengeRecoveryTest
         public Task<HttpResponseMessage?> RecoverAsync(
             FailedChallenge context, CancellationToken cancellationToken = default)
             => _recover(context, cancellationToken);
+    }
+
+    private sealed class TrackingContent : HttpContent
+    {
+        private readonly byte[] _content = [1, 2, 3];
+
+        public TrackingContent()
+        {
+            Headers.ContentLength = _content.Length;
+        }
+
+        public bool WasBuffered { get; private set; }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            WasBuffered = true;
+            return stream.WriteAsync(_content, 0, _content.Length);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _content.Length;
+            return true;
+        }
+    }
+
+    private sealed class UnknownLengthContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => Task.CompletedTask;
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+
+    private sealed class LargeDeclaredLengthContent : HttpContent
+    {
+        public LargeDeclaredLengthContent()
+        {
+            Headers.ContentLength = Client.MaxBufferSize + 1;
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => throw new InvalidOperationException("HEAD response content must not be buffered.");
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = Client.MaxBufferSize + 1;
+            return true;
+        }
     }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -360,4 +360,168 @@ public class ChallengeRecoveryTest
         VerifyColdProbe(mockHandler, Times.Once());
         VerifyTokenFetch(mockHandler, Times.Never());
     }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_AfterRecovery_SecondRequestSkipsColdProbe()
+    {
+        // Arrange: dhi.io-style stale-token-no-challenge. After the first request recovers, the fresh
+        // token must replace the stale one under the originally attempted scope key, so a second request
+        // succeeds directly without re-attaching the stale token or re-probing.
+        var host = NewHost();
+        var coldRealm = $"https://{host}/token";
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, realm: null);
+            return Unauthorized(req, coldRealm);
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+
+        // Act: first request recovers; second request reuses the refreshed cache.
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+        var response1 = await client.SendAsync(request1, cancellationToken: CancellationToken.None);
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+        var response2 = await client.SendAsync(request2, cancellationToken: CancellationToken.None);
+
+        // Assert: both succeed; the stale token was sent only once (first attempt) and the cold probe
+        // fired only once — the second request used the now-cached fresh token directly.
+        Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+        VerifyStaleTokenSent(mockHandler); // Times.Once across both requests
+        VerifyColdProbe(mockHandler, Times.Once());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_NonReplayableRequest_DoesNotColdProbe()
+    {
+        // Arrange: a POST (non-idempotent) with a stale token hits a no-challenge 401. ColdProbe must
+        // decline (CanReplay=false) rather than replay a mutating request without authorization.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _staleToken) return Unauthorized(req, realm: null);
+            return Ok(req); // an errant cold probe would look successful — so a 401 result proves none ran
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"https://{host}{_requestPath}")
+        {
+            Content = new StringContent("{}")
+        };
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: the 401 is returned unchanged; ColdProbe declined without replaying.
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        VerifyColdProbe(mockHandler, Times.Never());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_HandlerThrows_Propagates()
+    {
+        // Arrange: a recovery handler that throws must surface the exception (engine disposes the 401).
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            return Unauthorized(req, realm: null);
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = (context, ct) => throw new InvalidOperationException("recovery boom")
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.SendAsync(request, cancellationToken: CancellationToken.None));
+        Assert.Equal("recovery boom", ex.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_NoCachedToken_ColdProbeDeclines()
+    {
+        // Arrange: an unusable 401 with NO cached token attached (first-request style). ColdProbe must
+        // decline (AttachedCachedToken=false) rather than issue a redundant credential-free replay.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            return Unauthorized(req, realm: null); // every request → no challenge
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        // No stale token seeded → attempt 1 carries no Authorization.
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: original 401 returned; the registry saw exactly one credential-free request (the
+        // initial attempt) — ColdProbe added no second one because AttachedCachedToken was false.
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_NonSuccessColdProbe_ReturnsOriginal401()
+    {
+        // Arrange: stale-token no-challenge 401; the cold probe yields a non-401, non-success response
+        // (404). That is not a recovery — the original 401 must be surfaced, not the 404.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _staleToken) return Unauthorized(req, realm: null);
+            return new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = req }; // cold → 404
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: the original 401 (not the cold 404) is returned; the probe fired once; no token fetch.
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -568,7 +568,8 @@ public class ChallengeRecoveryTest
         var mockHandler = CustomHandler(Handler);
         var client = new Client(new HttpClient(mockHandler.Object))
         {
-            ChallengeRecovery = (context, ct) => throw new InvalidOperationException("recovery boom")
+            ChallengeRecovery = new DelegateChallengeRecovery(
+                (context, ct) => throw new InvalidOperationException("recovery boom"))
         };
         SeedStaleToken(client, host);
         using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
@@ -665,15 +666,15 @@ public class ChallengeRecoveryTest
         var mockHandler = CustomHandler(Handler);
         var client = new Client(new HttpClient(mockHandler.Object))
         {
-            // A custom handler that synthesizes a usable challenge regardless of the gating signals.
-            ChallengeRecovery = (context, ct) =>
+            // A custom recovery that synthesizes a usable challenge regardless of the gating signals.
+            ChallengeRecovery = new DelegateChallengeRecovery((context, ct) =>
             {
                 recoveryCalls++;
                 var challenge = new HttpResponseMessage(HttpStatusCode.Unauthorized);
                 challenge.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(
                     "Bearer", $"realm=\"{coldRealm}\",service=\"registry\",scope=\"{_scope}\""));
                 return Task.FromResult<HttpResponseMessage?>(challenge);
-            }
+            })
         };
         // No stale token seeded → attachedCachedToken is false and the attempted key is empty.
 
@@ -687,5 +688,22 @@ public class ChallengeRecoveryTest
         Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
         Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
         Assert.Equal(2, recoveryCalls);
+    }
+
+    /// <summary>
+    /// Test adapter that turns a lambda into an <see cref="IChallengeRecovery"/>, so tests can express
+    /// ad-hoc recovery strategies inline.
+    /// </summary>
+    private sealed class DelegateChallengeRecovery : IChallengeRecovery
+    {
+        private readonly Func<FailedChallenge, CancellationToken, Task<HttpResponseMessage?>> _recover;
+
+        public DelegateChallengeRecovery(
+            Func<FailedChallenge, CancellationToken, Task<HttpResponseMessage?>> recover)
+            => _recover = recover;
+
+        public Task<HttpResponseMessage?> RecoverAsync(
+            FailedChallenge context, CancellationToken cancellationToken = default)
+            => _recover(context, cancellationToken);
     }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -556,4 +556,78 @@ public class ChallengeRecoveryTest
         VerifyColdProbe(mockHandler, Times.Never());
         VerifyTokenFetch(mockHandler, Times.Never());
     }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_AnonymousColdProbeRedirect_ReturnsRedirect()
+    {
+        // Arrange: a stale token provokes a no-challenge 401, but the resource is served anonymously via
+        // a redirect (e.g. a blob-location 307). The redirect must be returned to the caller — callers
+        // like GetBlobLocationAsync (allowAutoRedirect:false) treat 3xx as the successful outcome.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _staleToken) return Unauthorized(req, realm: null);
+            var redirect = new HttpResponseMessage(HttpStatusCode.TemporaryRedirect) { RequestMessage = req };
+            redirect.Headers.Location = new Uri($"https://cdn.example.com{_requestPath}");
+            return redirect; // cold probe (no auth) → 307 with a location
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: the 307 (not the original 401) is returned; the probe fired once; no token fetch.
+        Assert.Equal(HttpStatusCode.TemporaryRedirect, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_RecoveredTokenForbidden_DoesNotBecomeSticky()
+    {
+        // Arrange: recovery re-derives a token that the registry then rejects with 403 (not a success).
+        // The stale scope key must NOT be refreshed with that token, so a second request re-enters
+        // recovery rather than silently attaching a non-working token.
+        var host = NewHost();
+        var coldRealm = $"https://{host}/token";
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return new HttpResponseMessage(HttpStatusCode.Forbidden) { RequestMessage = req };
+            if (token == _staleToken) return Unauthorized(req, realm: null);
+            return Unauthorized(req, coldRealm); // cold probe → usable challenge
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+
+        // Act: two requests.
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+        var response1 = await client.SendAsync(request1, cancellationToken: CancellationToken.None);
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+        var response2 = await client.SendAsync(request2, cancellationToken: CancellationToken.None);
+
+        // Assert: both get 403, and recovery ran on BOTH (cold probe twice) — the 403 token was never
+        // made sticky under the stale scope key.
+        Assert.Equal(HttpStatusCode.Forbidden, response1.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, response2.StatusCode);
+        VerifyColdProbe(mockHandler, Times.Exactly(2));
+    }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -34,8 +34,8 @@ public class ChallengeRecoveryTest
 {
     private const string _staleToken = "stale_bearer_token";
     private const string _freshToken = "fresh_access_token";
-    private const string _requestPath = "/v2/redis/manifests/8.6.4";
-    private const string _scope = "repository:redis:pull";
+    private const string _requestPath = "/v2/app/manifests/v1";
+    private const string _scope = "repository:app:pull";
 
     // The default Client cache is a process-wide shared MemoryCache. Use a unique host per test so
     // cache entries never collide across tests running in parallel.
@@ -107,7 +107,7 @@ public class ChallengeRecoveryTest
     [Fact]
     public async Task SendAsync_ChallengeRecovery_NoChallengeOnStaleToken_ColdProbeRecovers()
     {
-        // Arrange: dhi.io-style — a stale cached token provokes a 401 with NO WWW-Authenticate
+        // Arrange: a stale cached token provokes a 401 with NO WWW-Authenticate
         // challenge, but a credential-free request to the same URL yields a usable Bearer challenge.
         var host = NewHost();
         var coldRealm = $"https://{host}/token";
@@ -142,7 +142,7 @@ public class ChallengeRecoveryTest
     [Fact]
     public async Task SendAsync_NoChallengeOnStaleToken_WithoutRecovery_ReturnsOriginal401()
     {
-        // Arrange: identical to the dhi case, but recovery is NOT configured (default).
+        // Arrange: identical to the no-challenge case, but recovery is NOT configured (default).
         var host = NewHost();
 
         HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
@@ -172,10 +172,10 @@ public class ChallengeRecoveryTest
     [Fact]
     public async Task SendAsync_ChallengeRecovery_DeniedRealmOnStaleToken_ColdProbeRecovers()
     {
-        // Arrange: nvcr.io-style — a stale cached token provokes a 401 whose realm points at a foreign
+        // Arrange: a stale cached token provokes a 401 whose realm points at a foreign
         // host (rejected by the realm validator), but a cold request yields a same-host (allowed) realm.
         var host = NewHost();
-        var foreignRealm = "https://authn.nvidia.com/token";
+        var foreignRealm = "https://foreign-auth.example.com/token";
         var coldRealm = $"https://{host}/token";
 
         HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
@@ -208,9 +208,9 @@ public class ChallengeRecoveryTest
     [Fact]
     public async Task SendAsync_DeniedRealmOnStaleToken_WithoutRecovery_Throws()
     {
-        // Arrange: identical to the nvcr case, but recovery is NOT configured (default).
+        // Arrange: identical to the foreign-realm case, but recovery is NOT configured (default).
         var host = NewHost();
-        var foreignRealm = "https://authn.nvidia.com/token";
+        var foreignRealm = "https://foreign-auth.example.com/token";
 
         HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
         {

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -26,9 +26,9 @@ namespace OrasProject.Oras.Tests.Registry.Remote.Auth;
 /// <summary>
 /// Tests for the opt-in <see cref="Client.ChallengeRecovery"/> seam and the built-in
 /// <see cref="ChallengeRecoveries.ColdProbe"/> handler. These cover non-conformant upstreams that
-/// mishandle a stale cached token (a registry that omits the challenge, or points its realm at a
-/// different host), while proving the seam is inert for conformant registries and never masks a
-/// genuine credential failure.
+/// mishandle a stale cached token (a registry that omits the challenge, points its realm at a
+/// different host, or 401s the token request when the challenge is followed), while proving the seam is
+/// inert for conformant registries and never masks a genuine credential failure.
 /// </summary>
 public class ChallengeRecoveryTest
 {
@@ -276,18 +276,68 @@ public class ChallengeRecoveryTest
     }
 
     [Fact]
-    public async Task SendAsync_ChallengeRecovery_UsableChallengeButBadCredentials_DoesNotFireRecovery()
+    public async Task SendAsync_ChallengeRecovery_TokenEndpoint401OnStaleToken_ColdProbeRecovers()
     {
-        // Arrange: the stale token yields a perfectly usable challenge (allowed realm), but the token
-        // endpoint rejects the credentials. Recovery must NOT fire and must NOT mask the failure.
+        // Arrange: nvcr-style. A stale cached token yields a challenge whose realm is a foreign host the
+        // caller has explicitly trusted; following it to that token endpoint returns 401 (the registry
+        // cannot mint a token for the stale-token-derived challenge). A credential-free cold probe yields
+        // a usable same-host challenge whose token endpoint works.
+        var host = NewHost();
+        var foreignAuthHost = "authn.foreign.example.com";
+        var foreignRealm = $"https://{foreignAuthHost}/token"; // trusted, but 401s the token request
+        var coldRealm = $"https://{host}/token";               // same-host, mints a token
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req))
+            {
+                return req.RequestUri!.Host == foreignAuthHost
+                    ? new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req }
+                    : TokenResponse(req);
+            }
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, foreignRealm); // stale → foreign token endpoint
+            return Unauthorized(req, coldRealm);                              // cold probe → same-host endpoint
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe,
+            RealmValidator = new DefaultRealmValidator
+            {
+                TrustedRealmHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { foreignAuthHost }
+            }
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: recovered to 200 via a single cold probe + a token from the working same-host endpoint.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyFreshTokenSent(mockHandler);
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_TokenEndpoint401_ColdProbeAlsoFails_GivesUpAndRethrows()
+    {
+        // Arrange: a stale token yields a usable (allowed) challenge, but following it to the token
+        // endpoint returns 401. Recovery is offered this failure and cold-probes once; here the cold
+        // probe's challenge dead-ends at the same 401 token endpoint, so recovery gives up and rethrows
+        // the original token-endpoint exception — attempted exactly once, but never masked.
         var host = NewHost();
 
         HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
         {
-            if (IsTokenEndpoint(req)) return new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req };
+            if (IsTokenEndpoint(req)) return Unauthorized(req, realm: null);
             var token = req.Headers.Authorization?.Parameter;
             if (token == _freshToken) return Ok(req);
-            return Unauthorized(req, $"https://{host}/token"); // usable challenge for stale token
+            return Unauthorized(req, $"https://{host}/token"); // usable challenge for both stale attempt and cold probe
         }
 
         var mockHandler = CustomHandler(Handler);
@@ -298,7 +348,64 @@ public class ChallengeRecoveryTest
         SeedStaleToken(client, host);
         using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
 
-        // Act + Assert: the genuine token-endpoint failure surfaces; recovery never cold-probes.
+        // Act + Assert: the original token-endpoint 401 surfaces; recovery cold-probed exactly once (bounded).
+        await Assert.ThrowsAsync<ResponseException>(
+            () => client.SendAsync(request, cancellationToken: CancellationToken.None));
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_TokenEndpoint401_NoCachedToken_DoesNotProbe()
+    {
+        // Arrange: a genuine first-time failure — no cached token, so attempt 1 is credential-free. The
+        // challenge is usable but the token endpoint returns 401 (e.g. bad credentials). ColdProbe
+        // self-gates on AttachedCachedToken, which is false here, so recovery declines WITHOUT any cold
+        // probe or re-derivation and the failure surfaces unchanged.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return Unauthorized(req, realm: null);
+            return Unauthorized(req, $"https://{host}/token"); // usable challenge on the credential-free request
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        // No SeedStaleToken: attempt 1 carries no Authorization, so AttachedCachedToken is false.
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act + Assert: throws the token-endpoint failure; the endpoint was contacted exactly once (the
+        // initial follow) — recovery did not cold-probe and re-derive, which would fetch a second time.
+        await Assert.ThrowsAsync<ResponseException>(
+            () => client.SendAsync(request, cancellationToken: CancellationToken.None));
+        VerifyTokenFetch(mockHandler, Times.Once());
+    }
+
+    [Fact]
+    public async Task SendAsync_TokenEndpoint401OnStaleToken_WithoutRecovery_Throws()
+    {
+        // Arrange: identical stale-token + token-endpoint-401 scenario, but recovery is NOT configured
+        // (default). Behavior must be preserved: the token-endpoint exception is thrown, no cold probe.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return Unauthorized(req, realm: null);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            return Unauthorized(req, $"https://{host}/token"); // usable challenge for the stale token
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object)); // ChallengeRecovery == null
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act + Assert: the token-endpoint failure surfaces exactly as before — recovery never masks it.
         await Assert.ThrowsAsync<ResponseException>(
             () => client.SendAsync(request, cancellationToken: CancellationToken.None));
         VerifyStaleTokenSent(mockHandler);

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -233,19 +233,28 @@ public class ChallengeRecoveryTest
         VerifyColdProbe(mockHandler, Times.Never());
     }
 
-    [Fact]
-    public async Task SendAsync_ChallengeRecovery_AnonymousColdProbe_ReturnsResponseWithoutTokenFetch()
+    [Theory]
+    [InlineData(HttpStatusCode.OK, HttpStatusCode.OK)]                               // anonymous success → returned
+    [InlineData(HttpStatusCode.Found, HttpStatusCode.Found)]                         // 302 redirect → returned
+    [InlineData(HttpStatusCode.TemporaryRedirect, HttpStatusCode.TemporaryRedirect)] // 307 (blob location) → returned
+    [InlineData(HttpStatusCode.Forbidden, HttpStatusCode.Unauthorized)]              // 403 → give up (original 401)
+    [InlineData(HttpStatusCode.NotFound, HttpStatusCode.Unauthorized)]               // 404 → give up (original 401)
+    [InlineData(HttpStatusCode.InternalServerError, HttpStatusCode.Unauthorized)]    // 5xx → give up (original 401)
+    public async Task SendAsync_ChallengeRecovery_ColdProbeStatus_DeterminesOutcome(
+        HttpStatusCode coldProbeStatus, HttpStatusCode expectedStatus)
     {
-        // Arrange: a stale token provokes a no-challenge 401, but the resource is actually served
-        // anonymously — the cold probe returns 200 directly, so no token is fetched.
+        // Arrange: a stale token provokes a no-challenge 401; the credential-free cold probe comes back
+        // with `coldProbeStatus`. A 2xx success or 3xx redirect is a genuine recovery and is returned
+        // as-is (e.g. an anonymous 200, or a blob-location 307 for an allowAutoRedirect:false caller);
+        // any other status is discarded so the original 401 is surfaced rather than masked. The probe
+        // never yields a fresh challenge, so no token is fetched.
         var host = NewHost();
 
         HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
         {
             if (IsTokenEndpoint(req)) return TokenResponse(req);
-            var token = req.Headers.Authorization?.Parameter;
-            if (token == _staleToken) return Unauthorized(req, realm: null);
-            return Ok(req); // cold probe (no auth) → anonymous 200
+            if (req.Headers.Authorization?.Parameter == _staleToken) return Unauthorized(req, realm: null);
+            return new HttpResponseMessage(coldProbeStatus) { RequestMessage = req }; // cold probe (no auth)
         }
 
         var mockHandler = CustomHandler(Handler);
@@ -259,8 +268,8 @@ public class ChallengeRecoveryTest
         // Act
         var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
 
-        // Assert: the anonymous 200 is returned, and no token endpoint was contacted.
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        // Assert
+        Assert.Equal(expectedStatus, response.StatusCode);
         VerifyStaleTokenSent(mockHandler);
         VerifyColdProbe(mockHandler, Times.Once());
         VerifyTokenFetch(mockHandler, Times.Never());
@@ -361,12 +370,15 @@ public class ChallengeRecoveryTest
         VerifyTokenFetch(mockHandler, Times.Never());
     }
 
-    [Fact]
-    public async Task SendAsync_ChallengeRecovery_AfterRecovery_SecondRequestSkipsColdProbe()
+    [Theory]
+    [InlineData(HttpStatusCode.OK, 1)]        // token worked → sticky; the 2nd request skips recovery
+    [InlineData(HttpStatusCode.Forbidden, 2)] // token rejected (403) → not sticky; 2nd request re-probes
+    public async Task SendAsync_ChallengeRecovery_StickyOnlyAfterWorkingToken(
+        HttpStatusCode recoveredTokenStatus, int expectedColdProbes)
     {
-        // Arrange: dhi.io-style stale-token-no-challenge. After the first request recovers, the fresh
-        // token must replace the stale one under the originally attempted scope key, so a second request
-        // succeeds directly without re-attaching the stale token or re-probing.
+        // Arrange: a stale token provokes a no-challenge 401; recovery derives a fresh token that the
+        // registry answers with `recoveredTokenStatus`. The stale scope key is replaced only when that
+        // token actually worked (2xx/3xx), so a follow-up request re-enters recovery iff it didn't.
         var host = NewHost();
         var coldRealm = $"https://{host}/token";
 
@@ -374,9 +386,9 @@ public class ChallengeRecoveryTest
         {
             if (IsTokenEndpoint(req)) return TokenResponse(req);
             var token = req.Headers.Authorization?.Parameter;
-            if (token == _freshToken) return Ok(req);
+            if (token == _freshToken) return new HttpResponseMessage(recoveredTokenStatus) { RequestMessage = req };
             if (token == _staleToken) return Unauthorized(req, realm: null);
-            return Unauthorized(req, coldRealm);
+            return Unauthorized(req, coldRealm); // cold probe → usable challenge
         }
 
         var mockHandler = CustomHandler(Handler);
@@ -386,18 +398,17 @@ public class ChallengeRecoveryTest
         };
         SeedStaleToken(client, host);
 
-        // Act: first request recovers; second request reuses the refreshed cache.
+        // Act: two identical requests.
         using var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
         var response1 = await client.SendAsync(request1, cancellationToken: CancellationToken.None);
         using var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
         var response2 = await client.SendAsync(request2, cancellationToken: CancellationToken.None);
 
-        // Assert: both succeed; the stale token was sent only once (first attempt) and the cold probe
-        // fired only once — the second request used the now-cached fresh token directly.
-        Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
-        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
-        VerifyStaleTokenSent(mockHandler); // Times.Once across both requests
-        VerifyColdProbe(mockHandler, Times.Once());
+        // Assert: both requests resolve to the same status; recovery cold-probed once (sticky) or on
+        // both requests (not sticky), per whether the recovered token worked.
+        Assert.Equal(recoveredTokenStatus, response1.StatusCode);
+        Assert.Equal(recoveredTokenStatus, response2.StatusCode);
+        VerifyColdProbe(mockHandler, Times.Exactly(expectedColdProbes));
     }
 
     [Fact]
@@ -493,39 +504,6 @@ public class ChallengeRecoveryTest
     }
 
     [Fact]
-    public async Task SendAsync_ChallengeRecovery_NonSuccessColdProbe_ReturnsOriginal401()
-    {
-        // Arrange: stale-token no-challenge 401; the cold probe yields a non-401, non-success response
-        // (404). That is not a recovery — the original 401 must be surfaced, not the 404.
-        var host = NewHost();
-
-        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
-        {
-            if (IsTokenEndpoint(req)) return TokenResponse(req);
-            var token = req.Headers.Authorization?.Parameter;
-            if (token == _staleToken) return Unauthorized(req, realm: null);
-            return new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = req }; // cold → 404
-        }
-
-        var mockHandler = CustomHandler(Handler);
-        var client = new Client(new HttpClient(mockHandler.Object))
-        {
-            ChallengeRecovery = ChallengeRecoveries.ColdProbe
-        };
-        SeedStaleToken(client, host);
-        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
-
-        // Act
-        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
-
-        // Assert: the original 401 (not the cold 404) is returned; the probe fired once; no token fetch.
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        VerifyStaleTokenSent(mockHandler);
-        VerifyColdProbe(mockHandler, Times.Once());
-        VerifyTokenFetch(mockHandler, Times.Never());
-    }
-
-    [Fact]
     public async Task SendAsync_ChallengeRecovery_StaleBasicCredentials_DoesNotRecover()
     {
         // Arrange: a cached Basic credential provokes a no-challenge 401. Recovery must NOT fire — a
@@ -555,80 +533,6 @@ public class ChallengeRecoveryTest
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         VerifyColdProbe(mockHandler, Times.Never());
         VerifyTokenFetch(mockHandler, Times.Never());
-    }
-
-    [Fact]
-    public async Task SendAsync_ChallengeRecovery_AnonymousColdProbeRedirect_ReturnsRedirect()
-    {
-        // Arrange: a stale token provokes a no-challenge 401, but the resource is served anonymously via
-        // a redirect (e.g. a blob-location 307). The redirect must be returned to the caller — callers
-        // like GetBlobLocationAsync (allowAutoRedirect:false) treat 3xx as the successful outcome.
-        var host = NewHost();
-
-        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
-        {
-            if (IsTokenEndpoint(req)) return TokenResponse(req);
-            var token = req.Headers.Authorization?.Parameter;
-            if (token == _staleToken) return Unauthorized(req, realm: null);
-            var redirect = new HttpResponseMessage(HttpStatusCode.TemporaryRedirect) { RequestMessage = req };
-            redirect.Headers.Location = new Uri($"https://cdn.example.com{_requestPath}");
-            return redirect; // cold probe (no auth) → 307 with a location
-        }
-
-        var mockHandler = CustomHandler(Handler);
-        var client = new Client(new HttpClient(mockHandler.Object))
-        {
-            ChallengeRecovery = ChallengeRecoveries.ColdProbe
-        };
-        SeedStaleToken(client, host);
-        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
-
-        // Act
-        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
-
-        // Assert: the 307 (not the original 401) is returned; the probe fired once; no token fetch.
-        Assert.Equal(HttpStatusCode.TemporaryRedirect, response.StatusCode);
-        VerifyStaleTokenSent(mockHandler);
-        VerifyColdProbe(mockHandler, Times.Once());
-        VerifyTokenFetch(mockHandler, Times.Never());
-    }
-
-    [Fact]
-    public async Task SendAsync_ChallengeRecovery_RecoveredTokenForbidden_DoesNotBecomeSticky()
-    {
-        // Arrange: recovery re-derives a token that the registry then rejects with 403 (not a success).
-        // The stale scope key must NOT be refreshed with that token, so a second request re-enters
-        // recovery rather than silently attaching a non-working token.
-        var host = NewHost();
-        var coldRealm = $"https://{host}/token";
-
-        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
-        {
-            if (IsTokenEndpoint(req)) return TokenResponse(req);
-            var token = req.Headers.Authorization?.Parameter;
-            if (token == _freshToken) return new HttpResponseMessage(HttpStatusCode.Forbidden) { RequestMessage = req };
-            if (token == _staleToken) return Unauthorized(req, realm: null);
-            return Unauthorized(req, coldRealm); // cold probe → usable challenge
-        }
-
-        var mockHandler = CustomHandler(Handler);
-        var client = new Client(new HttpClient(mockHandler.Object))
-        {
-            ChallengeRecovery = ChallengeRecoveries.ColdProbe
-        };
-        SeedStaleToken(client, host);
-
-        // Act: two requests.
-        using var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
-        var response1 = await client.SendAsync(request1, cancellationToken: CancellationToken.None);
-        using var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
-        var response2 = await client.SendAsync(request2, cancellationToken: CancellationToken.None);
-
-        // Assert: both get 403, and recovery ran on BOTH (cold probe twice) — the 403 token was never
-        // made sticky under the stale scope key.
-        Assert.Equal(HttpStatusCode.Forbidden, response1.StatusCode);
-        Assert.Equal(HttpStatusCode.Forbidden, response2.StatusCode);
-        VerifyColdProbe(mockHandler, Times.Exactly(2));
     }
 
     [Fact]

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -630,4 +630,51 @@ public class ChallengeRecoveryTest
         Assert.Equal(HttpStatusCode.Forbidden, response2.StatusCode);
         VerifyColdProbe(mockHandler, Times.Exactly(2));
     }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_CustomHandlerFirstContact_DoesNotPoisonEmptyScopeKey()
+    {
+        // Arrange: a custom handler recovers a first-contact 401 (no cached token was attached, so the
+        // attempted scope key is empty). The freshly derived token must NOT be cached under that empty
+        // key, or later no-scope requests would silently attach a scoped token. So each such request
+        // re-enters recovery instead. (The built-in ColdProbe never hits this — it self-gates on
+        // AttachedCachedToken — but a custom handler can, so the engine must not refresh the key.)
+        var host = NewHost();
+        var coldRealm = $"https://{host}/token";
+        var recoveryCalls = 0;
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            return Unauthorized(req, realm: null); // first (no-auth) attempt → no-challenge 401
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            // A custom handler that synthesizes a usable challenge regardless of the gating signals.
+            ChallengeRecovery = (context, ct) =>
+            {
+                recoveryCalls++;
+                var challenge = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+                challenge.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(
+                    "Bearer", $"realm=\"{coldRealm}\",service=\"registry\",scope=\"{_scope}\""));
+                return Task.FromResult<HttpResponseMessage?>(challenge);
+            }
+        };
+        // No stale token seeded → attachedCachedToken is false and the attempted key is empty.
+
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+        var response1 = await client.SendAsync(request1, cancellationToken: CancellationToken.None);
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+        var response2 = await client.SendAsync(request2, cancellationToken: CancellationToken.None);
+
+        // Assert: both succeed, but recovery ran on BOTH requests — the empty scope key was never
+        // poisoned with the scoped token (which would have let the second request skip recovery).
+        Assert.Equal(HttpStatusCode.OK, response1.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response2.StatusCode);
+        Assert.Equal(2, recoveryCalls);
+    }
 }

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -1,0 +1,363 @@
+// Copyright The ORAS Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Authentication;
+using Moq;
+using Moq.Protected;
+using OrasProject.Oras.Registry.Remote.Auth;
+using OrasProject.Oras.Registry.Remote.Exceptions;
+using static OrasProject.Oras.Tests.Remote.Util.Util;
+using Xunit;
+
+namespace OrasProject.Oras.Tests.Registry.Remote.Auth;
+
+/// <summary>
+/// Tests for the opt-in <see cref="Client.ChallengeRecovery"/> seam and the built-in
+/// <see cref="ChallengeRecoveries.ColdProbe"/> handler. These cover non-conformant upstreams that
+/// mishandle a stale cached token (a registry that omits the challenge, or points its realm at a
+/// different host), while proving the seam is inert for conformant registries and never masks a
+/// genuine credential failure.
+/// </summary>
+public class ChallengeRecoveryTest
+{
+    private const string _staleToken = "stale_bearer_token";
+    private const string _freshToken = "fresh_access_token";
+    private const string _requestPath = "/v2/redis/manifests/8.6.4";
+    private const string _scope = "repository:redis:pull";
+
+    // The default Client cache is a process-wide shared MemoryCache. Use a unique host per test so
+    // cache entries never collide across tests running in parallel.
+    private static string NewHost() => $"reg-{Guid.NewGuid():N}.example.com";
+
+    private static HttpResponseMessage Ok(HttpRequestMessage req)
+        => new(HttpStatusCode.OK) { RequestMessage = req };
+
+    private static HttpResponseMessage TokenResponse(HttpRequestMessage req)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent($"{{\"access_token\":\"{_freshToken}\"}}"),
+            RequestMessage = req
+        };
+
+    private static HttpResponseMessage Unauthorized(HttpRequestMessage req, string? realm)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req };
+        if (realm != null)
+        {
+            response.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue(
+                "Bearer", $"realm=\"{realm}\",service=\"registry\",scope=\"{_scope}\""));
+        }
+        return response;
+    }
+
+    private static bool IsTokenEndpoint(HttpRequestMessage req)
+        => req.RequestUri!.AbsolutePath.EndsWith("/token");
+
+    private static bool IsRegistryProbe(HttpRequestMessage req)
+        => req.RequestUri!.AbsolutePath == _requestPath && req.Headers.Authorization == null;
+
+    // Seeds a stale cached bearer token so attempt 1 attaches it (mirrors a real stale-token pull).
+    private static void SeedStaleToken(Client client, string host)
+        => client.Cache.SetCache(host, Challenge.Scheme.Bearer, string.Empty, _staleToken);
+
+    // Verifies attempt 1 actually carried the stale token — otherwise the request would degrade to a
+    // credential-free probe and quietly exercise the wrong code path.
+    private static void VerifyStaleTokenSent(Mock<System.Net.Http.DelegatingHandler> mockHandler)
+        => mockHandler.Protected().Verify(
+            "SendAsync", Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == _requestPath &&
+                req.Headers.Authorization != null &&
+                req.Headers.Authorization.Parameter == _staleToken),
+            ItExpr.IsAny<CancellationToken>());
+
+    private static void VerifyFreshTokenSent(Mock<System.Net.Http.DelegatingHandler> mockHandler)
+        => mockHandler.Protected().Verify(
+            "SendAsync", Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == _requestPath &&
+                req.Headers.Authorization != null &&
+                req.Headers.Authorization.Parameter == _freshToken),
+            ItExpr.IsAny<CancellationToken>());
+
+    private static void VerifyColdProbe(Mock<System.Net.Http.DelegatingHandler> mockHandler, Times times)
+        => mockHandler.Protected().Verify(
+            "SendAsync", times,
+            ItExpr.Is<HttpRequestMessage>(req => IsRegistryProbe(req)),
+            ItExpr.IsAny<CancellationToken>());
+
+    private static void VerifyTokenFetch(Mock<System.Net.Http.DelegatingHandler> mockHandler, Times times)
+        => mockHandler.Protected().Verify(
+            "SendAsync", times,
+            ItExpr.Is<HttpRequestMessage>(req => IsTokenEndpoint(req)),
+            ItExpr.IsAny<CancellationToken>());
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_NoChallengeOnStaleToken_ColdProbeRecovers()
+    {
+        // Arrange: dhi.io-style — a stale cached token provokes a 401 with NO WWW-Authenticate
+        // challenge, but a credential-free request to the same URL yields a usable Bearer challenge.
+        var host = NewHost();
+        var coldRealm = $"https://{host}/token";
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, realm: null); // stale token → no challenge
+            return Unauthorized(req, coldRealm);                             // cold probe → usable challenge
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: recovered to 200 via a cold probe + a freshly fetched token.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyFreshTokenSent(mockHandler);
+    }
+
+    [Fact]
+    public async Task SendAsync_NoChallengeOnStaleToken_WithoutRecovery_ReturnsOriginal401()
+    {
+        // Arrange: identical to the dhi case, but recovery is NOT configured (default).
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, realm: null);
+            return Unauthorized(req, $"https://{host}/token");
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object)); // ChallengeRecovery == null
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: the original 401 is returned unchanged — no cold probe, no token fetch.
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Never());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_DeniedRealmOnStaleToken_ColdProbeRecovers()
+    {
+        // Arrange: nvcr.io-style — a stale cached token provokes a 401 whose realm points at a foreign
+        // host (rejected by the realm validator), but a cold request yields a same-host (allowed) realm.
+        var host = NewHost();
+        var foreignRealm = "https://authn.nvidia.com/token";
+        var coldRealm = $"https://{host}/token";
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req) && req.RequestUri!.Host == host) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, foreignRealm); // stale → foreign realm
+            return Unauthorized(req, coldRealm);                              // cold → same-host realm
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: recovered to 200 via the cold, same-host realm.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyFreshTokenSent(mockHandler);
+    }
+
+    [Fact]
+    public async Task SendAsync_DeniedRealmOnStaleToken_WithoutRecovery_Throws()
+    {
+        // Arrange: identical to the nvcr case, but recovery is NOT configured (default).
+        var host = NewHost();
+        var foreignRealm = "https://authn.nvidia.com/token";
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req) && req.RequestUri!.Host == host) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            if (token == _staleToken) return Unauthorized(req, foreignRealm);
+            return Unauthorized(req, $"https://{host}/token");
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object)); // ChallengeRecovery == null
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act + Assert: the foreign realm is rejected exactly as before — no cold probe masks it.
+        var ex = await Assert.ThrowsAsync<AuthenticationException>(
+            () => client.SendAsync(request, cancellationToken: CancellationToken.None));
+        Assert.Contains("not allowed", ex.Message);
+        VerifyColdProbe(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_AnonymousColdProbe_ReturnsResponseWithoutTokenFetch()
+    {
+        // Arrange: a stale token provokes a no-challenge 401, but the resource is actually served
+        // anonymously — the cold probe returns 200 directly, so no token is fetched.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _staleToken) return Unauthorized(req, realm: null);
+            return Ok(req); // cold probe (no auth) → anonymous 200
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: the anonymous 200 is returned, and no token endpoint was contacted.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_UsableChallengeButBadCredentials_DoesNotFireRecovery()
+    {
+        // Arrange: the stale token yields a perfectly usable challenge (allowed realm), but the token
+        // endpoint rejects the credentials. Recovery must NOT fire and must NOT mask the failure.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = req };
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            return Unauthorized(req, $"https://{host}/token"); // usable challenge for stale token
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act + Assert: the genuine token-endpoint failure surfaces; recovery never cold-probes.
+        await Assert.ThrowsAsync<ResponseException>(
+            () => client.SendAsync(request, cancellationToken: CancellationToken.None));
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Never());
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_ConformantRegistry_RecoveryNeverFires()
+    {
+        // Arrange: a conformant registry (no cached token) with recovery configured. The first
+        // (credential-free) request already yields a usable challenge, so recovery is never reached
+        // and adds no extra request.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            var token = req.Headers.Authorization?.Parameter;
+            if (token == _freshToken) return Ok(req);
+            return Unauthorized(req, $"https://{host}/token"); // normal challenge on the first request
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: 200, and the registry saw exactly one credential-free request (the initial one) —
+        // recovery did not add a second cold probe.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyFreshTokenSent(mockHandler);
+    }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_ColdProbeAlsoUnusable_GivesUpAfterSingleProbe()
+    {
+        // Arrange: pathological upstream — both the stale-token attempt AND the cold probe return a
+        // no-challenge 401. Recovery must probe exactly once, then give up and return the original 401
+        // (no infinite loop).
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            return Unauthorized(req, realm: null); // every registry request → no challenge
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        SeedStaleToken(client, host);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: original 401 returned; exactly one cold probe (bounded); no token fetch.
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        VerifyStaleTokenSent(mockHandler);
+        VerifyColdProbe(mockHandler, Times.Once());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
+}

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/ChallengeRecoveryTest.cs
@@ -524,4 +524,36 @@ public class ChallengeRecoveryTest
         VerifyColdProbe(mockHandler, Times.Once());
         VerifyTokenFetch(mockHandler, Times.Never());
     }
+
+    [Fact]
+    public async Task SendAsync_ChallengeRecovery_StaleBasicCredentials_DoesNotRecover()
+    {
+        // Arrange: a cached Basic credential provokes a no-challenge 401. Recovery must NOT fire — a
+        // credential-free cold probe cannot remedy Basic auth (the same credentials would just be
+        // re-sent), so the seam is scoped to stale Bearer tokens.
+        var host = NewHost();
+
+        HttpResponseMessage Handler(HttpRequestMessage req, CancellationToken ct)
+        {
+            if (IsTokenEndpoint(req)) return TokenResponse(req);
+            if (req.Headers.Authorization?.Scheme == "Basic") return Unauthorized(req, realm: null);
+            return Ok(req); // an errant cold probe (no auth) would look successful
+        }
+
+        var mockHandler = CustomHandler(Handler);
+        var client = new Client(new HttpClient(mockHandler.Object))
+        {
+            ChallengeRecovery = ChallengeRecoveries.ColdProbe
+        };
+        client.Cache.SetCache(host, Challenge.Scheme.Basic, string.Empty, "cached_basic_creds");
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"https://{host}{_requestPath}");
+
+        // Act
+        var response = await client.SendAsync(request, cancellationToken: CancellationToken.None);
+
+        // Assert: the 401 is returned unchanged; no cold probe (a 200 would have meant one ran).
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        VerifyColdProbe(mockHandler, Times.Never());
+        VerifyTokenFetch(mockHandler, Times.Never());
+    }
 }


### PR DESCRIPTION
## Summary

Adds a narrow, **opt-in** `ChallengeRecovery` seam to the auth `Client` so it can recover from a 401 that the standard flow can't get past — the failure mode a stale cached bearer token provokes on some non-conformant upstreams:

- **dhi.io** → `401` with **no** challenge at all.
- **nvcr.io** → `401` whose challenge realm points at a **different host** (`authn.nvidia.com`). Rejected by realm validation by default — or, if the caller trusts that host, **following it to that token endpoint returns another `401`**.

For each, a credential-free request to the *same URL* yields a perfectly usable challenge. Today the engine has no way to act on that: it returns the 401 (no scheme), throws (denied realm), or throws (the token endpoint rejects the request).

> Design decision record and the full menu of alternatives we evaluated: oras-project/oras-dotnet#405. This replaces the earlier `IRegistryAuthenticator` prototype (fork #29, closed) and the `IAuthChallengeHandler` prototype (oras-project/oras-dotnet#406, closed).
>
> 📊 Interactive walkthrough of the approach and why we landed on it: https://htmlpreview.github.io/?https://gist.githubusercontent.com/akashsinghal/44e213166b973018312bc7c03b4654ca/raw/challenge-recovery-explainer.html

## API surface (all additive)

- `Client.ChallengeRecovery { get; init; }` — nullable `IChallengeRecovery`. **Default `null` = today's exact behavior.**
- `IChallengeRecovery` — interface with `Task<HttpResponseMessage?> RecoverAsync(FailedChallenge, CancellationToken)` (matches the SDK's other auth seams — `IRealmValidator`, `ICredentialProvider`, …). A custom recovery implements this interface.
- `FailedChallenge` — plain data (`StatusCode`, a read-only `WwwAuthenticateChallenges` snapshot, `Host`, `AttachedCachedToken`, `CanReplay`) + `ProbeWithoutAuthorizationAsync(...)`, a credential-free replay primitive. Holds no `Client` reference and never exposes the raw response.
- `ChallengeRecoveries.ColdProbe` — built-in, host-agnostic strategy: when the failed attempt carried a cached token and the request is replayable, re-derive the challenge from a credential-free request.

Opt in with one line:

```csharp
var client = new Client(httpClient) { ChallengeRecovery = ChallengeRecoveries.ColdProbe };
```

## How it works

`SendCoreAsync` is refactored to separate two concerns that were previously tangled in one switch:

1. **`ResolveStandardChallengeAsync`** runs the normal parse-challenge → fetch/replay-credentials flow and returns a discriminated `StandardAuthResult`. It **never throws for an unusable challenge** (it reports a `ChallengeFailureKind` instead). A **401 from following the challenge's realm** (the token endpoint) is likewise reported as `TokenEndpointUnauthorized` — carrying the original exception via `ExceptionDispatchInfo` — so recovery can act on it. Genuine credential failures and **non-401** token-endpoint errors still throw.
2. **`HandleUnusableChallenge`** maps each `ChallengeFailureKind` back to the **exact** exception/return the engine has always produced — including rethrowing the captured token-endpoint exception verbatim — so with no recovery configured, behavior is unchanged.

Recovery sits between them and only runs when standard resolution dead-ends:

- Genuine credential failures and non-401 token-endpoint errors throw **before** recovery is consulted. Only a **401 from the realm round-trip** is offered to recovery (an out-of-band `AccessTokenProvider` 401 is not), and `ColdProbe` self-gates on `AttachedCachedToken` — so a real first-time failure is declined without probing and its exact exception is rethrown. Recovery can never mask a real auth error.
- The recovered response is re-run through the standard flow **once** (bounded — the cold probe carries no token, so it can't re-arm recovery): a recovered challenge is fetched/cached normally; an anonymous `200` is returned as-is.
- Gating signals (`AttachedCachedToken`, `CanReplay`) are passed honestly to the handler; `ColdProbe` enforces the stale-token + idempotency policy itself.

**No extra round-trip for conformant registries:** they resolve on the standard path and never reach recovery — only a tiny in-memory 401 snapshot when a handler is configured.

## Why opt-in (not default-on)

There's no performance reason — the gate excludes conformant registries entirely. It's off by default because cold-probing around a withheld/foreign challenge is *tolerance of a registry deviating from the docker/distribution de-facto auth flow* (the OCI specs don't mandate auth semantics). That's the consumer's call to make, so it's opt-in. ACR sets `ChallengeRecoveries.ColdProbe`.

## Testing

- **612/612** pass.
- `ChallengeRecoveryTest` covers: dhi no-challenge recover, nvcr foreign-realm recover, **token-endpoint 401** recover (foreign realm trusted, the cold probe yields a working same-host challenge), a token-endpoint 401 whose cold probe *also* fails (probe once, give up, rethrow the exact exception), a genuine first-time failure with **no cached token** (declined, never probed), an out-of-band `AccessTokenProvider` 401 staying a throw, the **default-off** behaviors (return 401 / throw unchanged), anonymous cold success, **credential failure not masked**, conformant-registry inert, single-probe boundedness, opaque-scope tokens remaining non-cacheable during recovery, bounded 401 buffering before a same-host cold probe, safe decline for unknown-length 401 bodies, large-length HEAD recovery, and synthesized response `RequestMessage` normalization. Each stale-token test asserts attempt 1 actually carried the stale token, so the recovery path is genuinely exercised.

## Behavior preservation

When `ChallengeRecovery == null`, every path — including the exact exception types and messages (`AuthenticationException`, `KeyNotFoundException`, realm-denied/invalid messages), the verbatim rethrow of a token-endpoint 401 (via `ExceptionDispatchInfo`), and response disposal semantics — is identical to `main`.

Refs oras-project/oras-dotnet#405


