### PR TITLE
docs: add XML documentation comments and enable doc generation

### DIFF
--- a/src/OrasProject.Oras/Content/Exceptions/InvalidDescriptorSizeException.cs
+++ b/src/OrasProject.Oras/Content/Exceptions/InvalidDescriptorSizeException.cs
@@ -20,15 +20,28 @@ namespace OrasProject.Oras.Content.Exceptions;
 /// </summary>
 public class InvalidDescriptorSizeException : ArgumentException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidDescriptorSizeException"/> class.
+    /// </summary>
     public InvalidDescriptorSizeException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidDescriptorSizeException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public InvalidDescriptorSizeException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidDescriptorSizeException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public InvalidDescriptorSizeException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Content/Exceptions/InvalidDigestException.cs
+++ b/src/OrasProject.Oras/Content/Exceptions/InvalidDigestException.cs
@@ -20,15 +20,28 @@ namespace OrasProject.Oras.Content.Exceptions;
 /// </summary>
 public class InvalidDigestException : FormatException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidDigestException"/> class.
+    /// </summary>
     public InvalidDigestException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidDigestException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public InvalidDigestException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidDigestException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public InvalidDigestException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Content/Exceptions/MismatchedDigestException.cs
+++ b/src/OrasProject.Oras/Content/Exceptions/MismatchedDigestException.cs
@@ -21,15 +21,28 @@ namespace OrasProject.Oras.Content.Exceptions;
 /// </summary>
 public class MismatchedDigestException : IOException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MismatchedDigestException"/> class.
+    /// </summary>
     public MismatchedDigestException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MismatchedDigestException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public MismatchedDigestException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MismatchedDigestException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public MismatchedDigestException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Content/Exceptions/MismatchedSizeException.cs
+++ b/src/OrasProject.Oras/Content/Exceptions/MismatchedSizeException.cs
@@ -16,17 +16,33 @@ using System.IO;
 
 namespace OrasProject.Oras.Content.Exceptions;
 
+/// <summary>
+/// MismatchedSizeException is thrown when a size does not match the content.
+/// </summary>
 public class MismatchedSizeException : IOException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MismatchedSizeException"/> class.
+    /// </summary>
     public MismatchedSizeException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MismatchedSizeException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public MismatchedSizeException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MismatchedSizeException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public MismatchedSizeException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Content/FetchableExtensions.cs
+++ b/src/OrasProject.Oras/Content/FetchableExtensions.cs
@@ -22,6 +22,9 @@ using Index = OrasProject.Oras.Oci.Index;
 namespace OrasProject.Oras.Content;
 
 
+/// <summary>
+/// FetchableExtensions provides extension helpers for fetching successors of a node.
+/// </summary>
 public static class FetchableExtensions
 {
     /// <summary>

--- a/src/OrasProject.Oras/Content/MemoryGraph.cs
+++ b/src/OrasProject.Oras/Content/MemoryGraph.cs
@@ -26,9 +26,9 @@ internal class MemoryGraph : IPredecessorFindable
     /// <summary>
     /// Returns the nodes directly pointing to the current node.
     /// </summary>
-    /// <param name="node"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <param name="node">The node whose predecessors are requested.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The descriptors of the nodes directly pointing to <paramref name="node"/>.</returns>
     public Task<IEnumerable<Descriptor>> GetPredecessorsAsync(Descriptor node, CancellationToken cancellationToken = default)
     {
         var key = node.BasicDescriptor;

--- a/src/OrasProject.Oras/Content/MemoryGraph.cs
+++ b/src/OrasProject.Oras/Content/MemoryGraph.cs
@@ -27,6 +27,7 @@ internal class MemoryGraph : IPredecessorFindable
     /// Returns the nodes directly pointing to the current node.
     /// </summary>
     /// <param name="node"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns></returns>
     public Task<IEnumerable<Descriptor>> GetPredecessorsAsync(Descriptor node, CancellationToken cancellationToken = default)
     {

--- a/src/OrasProject.Oras/Content/MemoryStore.cs
+++ b/src/OrasProject.Oras/Content/MemoryStore.cs
@@ -20,6 +20,9 @@ using System.Threading.Tasks;
 
 namespace OrasProject.Oras.Content;
 
+/// <summary>
+/// MemoryStore is an in-memory implementation of a content-addressable target store.
+/// </summary>
 public class MemoryStore : ITarget, IReadOnlyGraphStorage
 {
     private readonly MemoryStorage _storage = new();

--- a/src/OrasProject.Oras/Content/ReadOnlyGraphStorageExtensions.cs
+++ b/src/OrasProject.Oras/Content/ReadOnlyGraphStorageExtensions.cs
@@ -21,6 +21,9 @@ using OrasProject.Oras.Oci;
 
 namespace OrasProject.Oras.Content;
 
+/// <summary>
+/// ReadOnlyGraphStorageExtensions provides extension helpers for read-only graph storage.
+/// </summary>
 public static class ReadOnlyGraphStorageExtensions
 {
     /// <summary>

--- a/src/OrasProject.Oras/Content/ReadOnlyStorageExtensions.cs
+++ b/src/OrasProject.Oras/Content/ReadOnlyStorageExtensions.cs
@@ -20,6 +20,9 @@ using System.Threading.Tasks;
 
 namespace OrasProject.Oras.Content;
 
+/// <summary>
+/// ReadOnlyStorageExtensions provides extension helpers for read-only storage.
+/// </summary>
 public static class ReadOnlyStorageExtensions
 {
     /// <summary>

--- a/src/OrasProject.Oras/Content/StreamExtensions.cs
+++ b/src/OrasProject.Oras/Content/StreamExtensions.cs
@@ -35,8 +35,8 @@ public static class StreamExtensions
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <returns>The content read from the stream.</returns>
     /// <exception cref="InvalidDescriptorSizeException">Thrown when the descriptor size is negative.</exception>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    /// <exception cref="MismatchedDigestException"></exception>
+    /// <exception cref="MismatchedSizeException">Thrown when the content length does not match the descriptor size.</exception>
+    /// <exception cref="MismatchedDigestException">Thrown when the content digest does not match the descriptor digest.</exception>
     public static async Task<byte[]> ReadAllAsync(this Stream stream, Descriptor descriptor, CancellationToken cancellationToken = default)
     {
         if (descriptor.Size < 0)

--- a/src/OrasProject.Oras/Content/StreamExtensions.cs
+++ b/src/OrasProject.Oras/Content/StreamExtensions.cs
@@ -30,11 +30,11 @@ public static class StreamExtensions
     /// <summary>
     /// Reads and verifies the content from a stream
     /// </summary>
-    /// <param name="stream"></param>
-    /// <param name="descriptor"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    /// <exception cref="InvalidDescriptorSizeException"></exception>
+    /// <param name="stream">The stream to read the content from.</param>
+    /// <param name="descriptor">The descriptor describing the expected size and digest of the content.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The content read from the stream.</returns>
+    /// <exception cref="InvalidDescriptorSizeException">Thrown when the descriptor size is negative.</exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     /// <exception cref="MismatchedDigestException"></exception>
     public static async Task<byte[]> ReadAllAsync(this Stream stream, Descriptor descriptor, CancellationToken cancellationToken = default)
@@ -73,10 +73,10 @@ public static class StreamExtensions
     /// Reads the content from a stream up to a specified byte limit.
     /// Throws SizeLimitExceededException if the content exceeds the limit.
     /// </summary>
-    /// <param name="stream"></param>
-    /// <param name="maxBytes"></param>
-    /// <param name="cancellationToken"></param>
-    /// <exception cref="SizeLimitExceededException"></exception>
+    /// <param name="stream">The stream to read the content from.</param>
+    /// <param name="maxBytes">The maximum number of bytes to read.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <exception cref="SizeLimitExceededException">Thrown when the content exceeds <paramref name="maxBytes"/>.</exception>
     internal static async Task<byte[]> ReadStreamWithLimitAsync(
         this Stream stream,
         long maxBytes,

--- a/src/OrasProject.Oras/Content/StreamExtensions.cs
+++ b/src/OrasProject.Oras/Content/StreamExtensions.cs
@@ -21,6 +21,9 @@ using System.Threading;
 using System.Threading.Tasks;
 namespace OrasProject.Oras.Content;
 
+/// <summary>
+/// StreamExtensions provides extension helpers for reading and verifying stream content.
+/// </summary>
 public static class StreamExtensions
 {
     private const int _defaultBufferSize = 8192; // 8 KB, standard for stream I/O
@@ -29,6 +32,7 @@ public static class StreamExtensions
     /// </summary>
     /// <param name="stream"></param>
     /// <param name="descriptor"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns></returns>
     /// <exception cref="InvalidDescriptorSizeException"></exception>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
@@ -71,6 +75,7 @@ public static class StreamExtensions
     /// </summary>
     /// <param name="stream"></param>
     /// <param name="maxBytes"></param>
+    /// <param name="cancellationToken"></param>
     /// <exception cref="SizeLimitExceededException"></exception>
     internal static async Task<byte[]> ReadStreamWithLimitAsync(
         this Stream stream,

--- a/src/OrasProject.Oras/Docker/MediaType.cs
+++ b/src/OrasProject.Oras/Docker/MediaType.cs
@@ -18,8 +18,23 @@ namespace OrasProject.Oras.Docker;
 /// </summary>
 public static class MediaType
 {
+    /// <summary>
+    /// Config is the media type of a Docker container image configuration.
+    /// </summary>
     public const string Config = "application/vnd.docker.container.image.v1+json";
+
+    /// <summary>
+    /// ManifestList is the media type of a Docker manifest list (multi-platform image).
+    /// </summary>
     public const string ManifestList = "application/vnd.docker.distribution.manifest.list.v2+json";
+
+    /// <summary>
+    /// Manifest is the media type of a Docker image manifest.
+    /// </summary>
     public const string Manifest = "application/vnd.docker.distribution.manifest.v2+json";
+
+    /// <summary>
+    /// ForeignLayer is the media type of a Docker foreign (non-distributable) layer.
+    /// </summary>
     public const string ForeignLayer = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip";
 }

--- a/src/OrasProject.Oras/Exceptions/AlreadyExistsException.cs
+++ b/src/OrasProject.Oras/Exceptions/AlreadyExistsException.cs
@@ -21,15 +21,28 @@ namespace OrasProject.Oras.Exceptions;
 /// </summary>
 public class AlreadyExistsException : IOException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AlreadyExistsException"/> class.
+    /// </summary>
     public AlreadyExistsException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AlreadyExistsException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public AlreadyExistsException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AlreadyExistsException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public AlreadyExistsException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Exceptions/InvalidDateTimeFormatException.cs
+++ b/src/OrasProject.Oras/Exceptions/InvalidDateTimeFormatException.cs
@@ -20,15 +20,28 @@ namespace OrasProject.Oras.Exceptions;
 /// </summary>
 public class InvalidDateTimeFormatException : FormatException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidDateTimeFormatException"/> class.
+    /// </summary>
     public InvalidDateTimeFormatException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidDateTimeFormatException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public InvalidDateTimeFormatException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidDateTimeFormatException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public InvalidDateTimeFormatException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Exceptions/InvalidMediaTypeException.cs
+++ b/src/OrasProject.Oras/Exceptions/InvalidMediaTypeException.cs
@@ -20,15 +20,28 @@ namespace OrasProject.Oras.Exceptions;
 /// </summary>
 public class InvalidMediaTypeException : FormatException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidMediaTypeException"/> class.
+    /// </summary>
     public InvalidMediaTypeException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidMediaTypeException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public InvalidMediaTypeException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidMediaTypeException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public InvalidMediaTypeException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Exceptions/MissingArtifactTypeException.cs
+++ b/src/OrasProject.Oras/Exceptions/MissingArtifactTypeException.cs
@@ -20,15 +20,28 @@ namespace OrasProject.Oras.Exceptions;
 /// </summary>
 public class MissingArtifactTypeException : FormatException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingArtifactTypeException"/> class.
+    /// </summary>
     public MissingArtifactTypeException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingArtifactTypeException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public MissingArtifactTypeException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingArtifactTypeException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public MissingArtifactTypeException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Exceptions/NotFoundException.cs
+++ b/src/OrasProject.Oras/Exceptions/NotFoundException.cs
@@ -21,15 +21,28 @@ namespace OrasProject.Oras.Exceptions;
 /// </summary>
 public class NotFoundException : IOException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotFoundException"/> class.
+    /// </summary>
     public NotFoundException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotFoundException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public NotFoundException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotFoundException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public NotFoundException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Exceptions/SizeLimitExceededException.cs
+++ b/src/OrasProject.Oras/Exceptions/SizeLimitExceededException.cs
@@ -15,17 +15,33 @@ using System;
 
 namespace OrasProject.Oras.Exceptions;
 
+/// <summary>
+/// SizeLimitExceededException is thrown when content exceeds an allowed size limit.
+/// </summary>
 public class SizeLimitExceededException : Exception
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SizeLimitExceededException"/> class.
+    /// </summary>
     public SizeLimitExceededException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SizeLimitExceededException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public SizeLimitExceededException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SizeLimitExceededException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public SizeLimitExceededException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Oci/Descriptor.cs
+++ b/src/OrasProject.Oras/Oci/Descriptor.cs
@@ -23,35 +23,66 @@ namespace OrasProject.Oras.Oci;
 /// </summary>
 public class Descriptor
 {
+    /// <summary>
+    /// MediaType is the media type of the object this descriptor refers to.
+    /// </summary>
     [JsonPropertyName("mediaType")]
     public required string MediaType { get; set; }
 
+    /// <summary>
+    /// Digest is the digest of the targeted content.
+    /// </summary>
     [JsonPropertyName("digest")]
     public required string Digest { get; set; }
 
+    /// <summary>
+    /// Size specifies the size in bytes of the blob.
+    /// </summary>
     [JsonPropertyName("size")]
     public long Size { get; set; }
 
+    /// <summary>
+    /// Urls specifies a list of URLs from which this object may be downloaded.
+    /// </summary>
     [JsonPropertyName("urls")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public IList<string>? Urls { get; set; }
 
+    /// <summary>
+    /// Annotations contains arbitrary metadata relating to the targeted content.
+    /// </summary>
     [JsonPropertyName("annotations")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public IDictionary<string, string>? Annotations { get; set; }
 
+    /// <summary>
+    /// Data is an embedding of the targeted content, encoded as a byte array.
+    /// </summary>
     [JsonPropertyName("data")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public byte[]? Data { get; set; }
 
+    /// <summary>
+    /// Platform describes the platform which the image in the manifest runs on.
+    /// </summary>
     [JsonPropertyName("platform")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public Platform? Platform { get; set; }
 
+    /// <summary>
+    /// ArtifactType is the type of an artifact when the descriptor points to an artifact.
+    /// </summary>
     [JsonPropertyName("artifactType")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? ArtifactType { get; set; }
 
+    /// <summary>
+    /// Creates a <see cref="Descriptor"/> for the given content and media type,
+    /// computing the digest and size from the supplied data.
+    /// </summary>
+    /// <param name="data">The content to describe.</param>
+    /// <param name="mediaType">The media type of the content.</param>
+    /// <returns>A descriptor identifying the content.</returns>
     public static Descriptor Create(Span<byte> data, string mediaType)
     {
         byte[] byteData = data.ToArray();
@@ -63,6 +94,9 @@ public class Descriptor
         };
     }
 
+    /// <summary>
+    /// Gets a descriptor for the empty JSON object (<c>{}</c>).
+    /// </summary>
     public static Descriptor Empty => new()
     {
         MediaType = Oci.MediaType.EmptyJson,

--- a/src/OrasProject.Oras/Oci/Index.cs
+++ b/src/OrasProject.Oras/Oci/Index.cs
@@ -24,30 +24,50 @@ namespace OrasProject.Oras.Oci;
 /// </summary>
 public class Index : Versioned
 {
-    // MediaType specifies the type of this document data structure e.g. `application/vnd.oci.image.index.v1+json`
+    /// <summary>
+    /// MediaType specifies the type of this document data structure.
+    /// </summary>
     [JsonPropertyName("mediaType")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? MediaType { get; set; }
 
+    /// <summary>
+    /// ArtifactType is the type of an artifact when the index is used for an artifact.
+    /// </summary>
     [JsonPropertyName("artifactType")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? ArtifactType { get; set; }
 
-    // Manifests references platform specific manifests.
+    /// <summary>
+    /// Manifests references platform-specific manifests.
+    /// </summary>
     [JsonPropertyName("manifests")]
     public required IList<Descriptor> Manifests { get; set; }
 
+    /// <summary>
+    /// Subject is an optional link to another manifest that this index refers to.
+    /// </summary>
     [JsonPropertyName("subject")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public Descriptor? Subject { get; set; }
 
-    // Annotations contains arbitrary metadata for the image index.
+    /// <summary>
+    /// Annotations contains arbitrary metadata for the image index.
+    /// </summary>
     [JsonPropertyName("annotations")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public IDictionary<string, string>? Annotations { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Index"/> class.
+    /// </summary>
     public Index() { }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Index"/> class for the given manifests,
+    /// with the OCI image index media type and schema version 2.
+    /// </summary>
+    /// <param name="manifests">The platform-specific manifests referenced by the index.</param>
     [SetsRequiredMembers]
     public Index(IList<Descriptor> manifests)
     {

--- a/src/OrasProject.Oras/Oci/Manifest.cs
+++ b/src/OrasProject.Oras/Oci/Manifest.cs
@@ -23,24 +23,42 @@ namespace OrasProject.Oras.Oci;
 /// </summary>
 public class Manifest : Versioned, IJsonOnDeserialized
 {
+    /// <summary>
+    /// MediaType specifies the type of this document data structure.
+    /// </summary>
     [JsonPropertyName("mediaType")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? MediaType { get; set; }
 
+    /// <summary>
+    /// ArtifactType is the type of an artifact when the manifest is used for an artifact.
+    /// </summary>
     [JsonPropertyName("artifactType")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? ArtifactType { get; set; }
 
+    /// <summary>
+    /// Config references a configuration object for a container, by digest.
+    /// </summary>
     [JsonPropertyName("config")]
     public required Descriptor Config { get; set; }
 
+    /// <summary>
+    /// Layers is an indexed list of layers referenced by the manifest.
+    /// </summary>
     [JsonPropertyName("layers")]
     public required IList<Descriptor> Layers { get; set; }
 
+    /// <summary>
+    /// Subject is an optional link to another manifest that this manifest refers to.
+    /// </summary>
     [JsonPropertyName("subject")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public Descriptor? Subject { get; set; }
 
+    /// <summary>
+    /// Annotations contains arbitrary metadata for the image manifest.
+    /// </summary>
     [JsonPropertyName("annotations")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public IDictionary<string, string>? Annotations { get; set; }

--- a/src/OrasProject.Oras/Oci/Platform.cs
+++ b/src/OrasProject.Oras/Oci/Platform.cs
@@ -23,20 +23,35 @@ namespace OrasProject.Oras.Oci;
 /// </summary>
 public class Platform
 {
+    /// <summary>
+    /// Architecture is the CPU architecture the image runs on, e.g. <c>amd64</c>.
+    /// </summary>
     [JsonPropertyName("architecture")]
     public required string Architecture { get; set; }
 
+    /// <summary>
+    /// Os is the operating system the image runs on, e.g. <c>linux</c>.
+    /// </summary>
     [JsonPropertyName("os")]
     public required string Os { get; set; }
 
+    /// <summary>
+    /// OsVersion is an optional version of the operating system.
+    /// </summary>
     [JsonPropertyName("os.version")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? OsVersion { get; set; }
 
+    /// <summary>
+    /// OsFeatures is an optional list of required operating system features.
+    /// </summary>
     [JsonPropertyName("os.features")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public IList<string>? OsFeatures { get; set; }
 
+    /// <summary>
+    /// Variant is an optional variant of the CPU architecture, e.g. <c>v7</c>.
+    /// </summary>
     [JsonPropertyName("variant")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public string? Variant { get; set; }

--- a/src/OrasProject.Oras/Oci/Versioned.cs
+++ b/src/OrasProject.Oras/Oci/Versioned.cs
@@ -21,6 +21,9 @@ namespace OrasProject.Oras.Oci;
 /// </summary>
 public class Versioned
 {
+    /// <summary>
+    /// SchemaVersion is the schema version of the document.
+    /// </summary>
     [JsonPropertyName("schemaVersion")]
     public int SchemaVersion { get; set; }
 }

--- a/src/OrasProject.Oras/OrasProject.Oras.csproj
+++ b/src/OrasProject.Oras/OrasProject.Oras.csproj
@@ -30,6 +30,7 @@ limitations under the License.
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<OutputType>Library</OutputType>
 		<Nullable>enable</Nullable>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/src/OrasProject.Oras/PackManifestOptions.cs
+++ b/src/OrasProject.Oras/PackManifestOptions.cs
@@ -17,8 +17,14 @@ using System.Collections.Generic;
 
 namespace OrasProject.Oras;
 
+/// <summary>
+/// PackManifestOptions contains optional parameters for packing a manifest.
+/// </summary>
 public struct PackManifestOptions
 {
+    /// <summary>
+    /// Gets an empty set of options.
+    /// </summary>
     public static PackManifestOptions None { get; }
 
     /// <summary>

--- a/src/OrasProject.Oras/Packer.cs
+++ b/src/OrasProject.Oras/Packer.cs
@@ -26,6 +26,9 @@ using System.Threading.Tasks;
 
 namespace OrasProject.Oras;
 
+/// <summary>
+/// Packer provides helpers to pack content into OCI image manifests.
+/// </summary>
 public static partial class Packer
 {
     /// <summary>
@@ -43,8 +46,14 @@ public static partial class Packer
     /// </summary>
     private const string _errMissingArtifactType = "missing artifact type";
 
+    /// <summary>
+    /// MediaTypeUnknownConfig is the default config media type used when none is specified.
+    /// </summary>
     public const string MediaTypeUnknownConfig = "application/vnd.unknown.config.v1+json";
 
+    /// <summary>
+    /// MediaTypeUnknownArtifact is the default artifact type used when none is specified.
+    /// </summary>
     public const string MediaTypeUnknownArtifact = "application/vnd.unknown.artifact.v1";
 
     /// <summary>
@@ -52,11 +61,16 @@ public static partial class Packer
     /// </summary>
     public enum ManifestVersion
     {
-        // Version1_0 represents the OCI Image Manifest defined in image-spec v1.0.2.
-        // Reference: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md
+        /// <summary>
+        /// Version1_0 represents the OCI Image Manifest defined in image-spec v1.0.2.
+        /// Reference: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md
+        /// </summary>
         Version1_0 = 1,
-        // Version1_1 represents the OCI Image Manifest defined in image-spec v1.1.1.
-        // Reference: https://github.com/opencontainers/image-spec/blob/v1.1.1/manifest.md
+
+        /// <summary>
+        /// Version1_1 represents the OCI Image Manifest defined in image-spec v1.1.1.
+        /// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.1/manifest.md
+        /// </summary>
         Version1_1 = 2
     }
 

--- a/src/OrasProject.Oras/ReadOnlyTargetExtensions.cs
+++ b/src/OrasProject.Oras/ReadOnlyTargetExtensions.cs
@@ -20,6 +20,9 @@ using OrasProject.Oras.Registry;
 
 namespace OrasProject.Oras;
 
+/// <summary>
+/// ReadOnlyTargetExtensions provides extension helpers for copying from read-only targets.
+/// </summary>
 public static class ReadOnlyTargetExtensions
 {
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Exceptions/InvalidReferenceException.cs
+++ b/src/OrasProject.Oras/Registry/Exceptions/InvalidReferenceException.cs
@@ -20,15 +20,28 @@ namespace OrasProject.Oras.Registry.Exceptions;
 /// </summary>
 public class InvalidReferenceException : FormatException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidReferenceException"/> class.
+    /// </summary>
     public InvalidReferenceException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidReferenceException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public InvalidReferenceException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidReferenceException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public InvalidReferenceException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Registry/IBlobLocationProvider.cs
+++ b/src/OrasProject.Oras/Registry/IBlobLocationProvider.cs
@@ -31,7 +31,7 @@ public interface IBlobLocationProvider
     /// <summary>
     /// GetBlobLocationAsync retrieves the location URL for a blob without downloading its content.
     /// Most OCI Distribution Spec v1.1.1 registries return a redirect with a blob location in the header
-    /// instead of returning the content directly on a /v2/<name>/blobs/<digest> request.
+    /// instead of returning the content directly on a /v2/{name}/blobs/{digest} request.
     /// This method captures that location URL.
     /// 
     /// Returns null if the registry returns the content directly (HTTP 200) instead of a redirect.

--- a/src/OrasProject.Oras/Registry/IRegistry.cs
+++ b/src/OrasProject.Oras/Registry/IRegistry.cs
@@ -17,6 +17,9 @@ using System.Threading.Tasks;
 
 namespace OrasProject.Oras.Registry;
 
+/// <summary>
+/// IRegistry represents a remote registry that provides access to its repositories.
+/// </summary>
 public interface IRegistry
 {
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Cache.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Cache.cs
@@ -18,6 +18,9 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
+/// <summary>
+/// Cache is the default in-memory implementation of <see cref="ICache"/>.
+/// </summary>
 public sealed class Cache : ICache
 {
     #region private members

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Challenge.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Challenge.cs
@@ -16,6 +16,9 @@ using System.Collections.Generic;
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
+/// <summary>
+/// Challenge provides helpers for parsing registry authentication challenges.
+/// </summary>
 public static class Challenge
 {
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Credential.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Credential.cs
@@ -20,4 +20,8 @@ namespace OrasProject.Oras.Registry.Remote.Auth;
 /// <param name="Password">The password for basic authentication.</param>
 /// <param name="RefreshToken">The refresh token (identity token) for OAuth2 authentication.</param>
 /// <param name="AccessToken">The access token (bearer token) for token-based authentication.</param>
-public record struct Credential(string? Username = null, string? Password = null, string? RefreshToken = null, string? AccessToken = null);
+public record struct Credential(
+    string? Username = null,
+    string? Password = null,
+    string? RefreshToken = null,
+    string? AccessToken = null);

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Credential.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Credential.cs
@@ -13,4 +13,11 @@
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
+/// <summary>
+/// Credential represents the credentials used to access a remote registry.
+/// </summary>
+/// <param name="Username">The username for basic authentication.</param>
+/// <param name="Password">The password for basic authentication.</param>
+/// <param name="RefreshToken">The refresh token (identity token) for OAuth2 authentication.</param>
+/// <param name="AccessToken">The access token (bearer token) for token-based authentication.</param>
 public record struct Credential(string? Username = null, string? Password = null, string? RefreshToken = null, string? AccessToken = null);

--- a/src/OrasProject.Oras/Registry/Remote/Auth/CredentialExtensions.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/CredentialExtensions.cs
@@ -13,6 +13,9 @@
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
+/// <summary>
+/// CredentialExtensions provides extension helpers for <see cref="Credential"/>.
+/// </summary>
 public static class CredentialExtensions
 {
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ICache.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ICache.cs
@@ -13,6 +13,9 @@
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
+/// <summary>
+/// ICache caches authentication schemes and tokens for registry hosts.
+/// </summary>
 public interface ICache
 {
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ICredentialProvider.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ICredentialProvider.cs
@@ -16,6 +16,9 @@ using System.Threading.Tasks;
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
+/// <summary>
+/// ICredentialProvider resolves credentials for a registry host.
+/// </summary>
 public interface ICredentialProvider
 {
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/Scope.cs
@@ -18,8 +18,11 @@ using System.Linq;
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
-// Scope is defined as: <ResourceType>:<ResourceName>:<Action>,<Action>,<Action>...
-// Ref: https://distribution.github.io/distribution/spec/auth/scope/
+/// <summary>
+/// Scope represents an authorization scope in the form
+/// <c>{ResourceType}:{ResourceName}:{Action},{Action},...</c>.
+/// Reference: https://distribution.github.io/distribution/spec/auth/scope/
+/// </summary>
 public class Scope : IComparable<Scope>
 {
     /// <summary>
@@ -61,10 +64,27 @@ public class Scope : IComparable<Scope>
 
     internal const string ActionDelete = "delete";
 
+    /// <summary>
+    /// Gets the resource type of the scope, e.g. <c>repository</c>.
+    /// </summary>
     public required string ResourceType { get; init; }
+
+    /// <summary>
+    /// Gets the resource name of the scope, e.g. the repository name.
+    /// </summary>
     public required string ResourceName { get; init; }
+
+    /// <summary>
+    /// Gets the set of actions granted by the scope, e.g. <c>pull</c> and <c>push</c>.
+    /// </summary>
     public required HashSet<string> Actions { get; init; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Scope"/> class.
+    /// </summary>
+    /// <param name="resourceType">The resource type of the scope.</param>
+    /// <param name="resourceName">The resource name of the scope.</param>
+    /// <param name="actions">The set of actions granted by the scope.</param>
     [SetsRequiredMembers]
     public Scope(string resourceType, string resourceName, HashSet<string> actions)
     {

--- a/src/OrasProject.Oras/Registry/Remote/Auth/ScopeManager.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Auth/ScopeManager.cs
@@ -18,6 +18,9 @@ using System.Linq;
 
 namespace OrasProject.Oras.Registry.Remote.Auth;
 
+/// <summary>
+/// ScopeManager tracks authorization scopes required for registry requests.
+/// </summary>
 public class ScopeManager
 {
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
+++ b/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
@@ -27,6 +27,9 @@ using OrasProject.Oras.Registry.Remote.Auth;
 
 namespace OrasProject.Oras.Registry.Remote;
 
+/// <summary>
+/// BlobStore provides access to the blobs of a remote repository.
+/// </summary>
 public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvider, IMounter
 {
     private Repository Repository { get; } = repository ?? throw new ArgumentNullException(nameof(repository));
@@ -267,7 +270,7 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
     /// <summary>
     /// GetBlobLocationAsync retrieves the location URL for a blob without downloading its content.
     /// Most OCI Distribution Spec v1.1.1 registries return a redirect with a blob location in the header
-    /// instead of returning the content directly on a /v2/<name>/blobs/<digest> request.
+    /// instead of returning the content directly on a /v2/{name}/blobs/{digest} request.
     /// This method makes an authenticated request without following redirects to capture the location URL.
     /// 
     /// Returns null if the registry returns the content directly (HTTP 200) instead of a redirect.

--- a/src/OrasProject.Oras/Registry/Remote/Error.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Error.cs
@@ -17,19 +17,37 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using OrasProject.Oras.Serialization;
 
+/// <summary>
+/// ErrorCode enumerates the error codes returned by a registry.
+/// </summary>
 public enum ErrorCode
 {
+    /// <summary>
+    /// NAME_UNKNOWN indicates the repository name is not known to the registry.
+    /// </summary>
     NAME_UNKNOWN
 }
 
+/// <summary>
+/// Error represents a single error entry returned by a registry response.
+/// </summary>
 public class Error
 {
+    /// <summary>
+    /// Code is the registry error code.
+    /// </summary>
     [JsonPropertyName("code")]
     public required string Code { get; set; }
 
+    /// <summary>
+    /// Message is a human-readable description of the error.
+    /// </summary>
     [JsonPropertyName("message")]
     public required string Message { get; set; }
 
+    /// <summary>
+    /// Detail contains optional structured details about the error.
+    /// </summary>
     [JsonPropertyName("detail")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public JsonElement? Detail { get; set; }

--- a/src/OrasProject.Oras/Registry/Remote/Exceptions/InvalidResponseException.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Exceptions/InvalidResponseException.cs
@@ -20,15 +20,28 @@ namespace OrasProject.Oras.Registry.Remote.Exceptions;
 /// </summary>
 public class InvalidResponseException : FormatException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidResponseException"/> class.
+    /// </summary>
     public InvalidResponseException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidResponseException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public InvalidResponseException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidResponseException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public InvalidResponseException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Registry/Remote/Exceptions/ReferrersStateAlreadySetException.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Exceptions/ReferrersStateAlreadySetException.cs
@@ -15,17 +15,33 @@ using System;
 
 namespace OrasProject.Oras.Registry.Remote.Exceptions;
 
+/// <summary>
+/// ReferrersStateAlreadySetException is thrown when the referrers state has already been set.
+/// </summary>
 public class ReferrersStateAlreadySetException : Exception
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReferrersStateAlreadySetException"/> class.
+    /// </summary>
     public ReferrersStateAlreadySetException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReferrersStateAlreadySetException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public ReferrersStateAlreadySetException(string? message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReferrersStateAlreadySetException"/> class with a specified error message
+    /// and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public ReferrersStateAlreadySetException(string? message, Exception? inner)
         : base(message, inner)
     {

--- a/src/OrasProject.Oras/Registry/Remote/Exceptions/ResponseException.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Exceptions/ResponseException.cs
@@ -59,16 +59,36 @@ public class ResponseException : HttpRequestException
     /// </remarks>
     public override string Message => _formattedMessage;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResponseException"/> class from an HTTP response.
+    /// </summary>
+    /// <param name="response">The HTTP response that caused the exception.</param>
+    /// <param name="responseBody">The response body, used to parse registry errors.</param>
     public ResponseException(HttpResponseMessage response, string? responseBody = null)
         : this(response, responseBody, null)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResponseException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="response">The HTTP response that caused the exception.</param>
+    /// <param name="responseBody">The response body, used to parse registry errors.</param>
+    /// <param name="message">The message that describes the error.</param>
     public ResponseException(HttpResponseMessage response, string? responseBody, string? message)
         : this(response, responseBody, response.StatusCode == HttpStatusCode.Unauthorized ? HttpRequestError.UserAuthenticationError : HttpRequestError.Unknown, message, null)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResponseException"/> class with a specified
+    /// HTTP request error, error message, and inner exception.
+    /// </summary>
+    /// <param name="response">The HTTP response that caused the exception.</param>
+    /// <param name="responseBody">The response body, used to parse registry errors.</param>
+    /// <param name="httpRequestError">The HTTP request error associated with the response.</param>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public ResponseException(HttpResponseMessage response, string? responseBody, HttpRequestError httpRequestError, string? message, Exception? inner)
         : base(httpRequestError, message, inner, response.StatusCode)
     {

--- a/src/OrasProject.Oras/Registry/Remote/HttpRequestMessageExtensions.cs
+++ b/src/OrasProject.Oras/Registry/Remote/HttpRequestMessageExtensions.cs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;

--- a/src/OrasProject.Oras/Registry/Remote/HttpResponseMessageExtensions.cs
+++ b/src/OrasProject.Oras/Registry/Remote/HttpResponseMessageExtensions.cs
@@ -54,7 +54,7 @@ internal static class HttpResponseMessageExtensions
 
     /// <summary>
     /// Returns the URL of the response's "Link" header, if present.
-    ///  The link header is of the form <link>; rel="next"
+    ///  The link header is of the form {link}; rel="next"
     /// </summary>
     /// <returns>next link or null if not present</returns>
     public static Uri? ParseLink(this HttpResponseMessage response)
@@ -178,6 +178,7 @@ internal static class HttpResponseMessageExtensions
     /// <param name="response"></param>
     /// <param name="reference"></param>
     /// <param name="maxBytes"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns></returns>
     /// <exception cref="Exception"></exception>
     public static async Task<Descriptor> GenerateDescriptorAsync(this HttpResponseMessage response, Reference reference, long maxBytes, CancellationToken cancellationToken = default)

--- a/src/OrasProject.Oras/Registry/Remote/HttpResponseMessageExtensions.cs
+++ b/src/OrasProject.Oras/Registry/Remote/HttpResponseMessageExtensions.cs
@@ -175,12 +175,15 @@ internal static class HttpResponseMessageExtensions
     /// <summary>
     /// Returns a descriptor generated from the response.
     /// </summary>
-    /// <param name="response"></param>
-    /// <param name="reference"></param>
-    /// <param name="maxBytes"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    /// <exception cref="Exception"></exception>
+    /// <param name="response">The HTTP response to generate the descriptor from.</param>
+    /// <param name="reference">The reference associated with the requested content.</param>
+    /// <param name="maxBytes">The maximum allowed content size, in bytes.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The descriptor describing the response content.</returns>
+    /// <exception cref="HttpIOException">
+    /// Thrown when the response has an invalid Content-Type header, a missing Content-Length,
+    /// or when the content digest cannot be validated.
+    /// </exception>
     public static async Task<Descriptor> GenerateDescriptorAsync(this HttpResponseMessage response, Reference reference, long maxBytes, CancellationToken cancellationToken = default)
     {
         // 1. Validate Content-Type

--- a/src/OrasProject.Oras/Registry/Remote/HttpResponseMessageExtensions.cs
+++ b/src/OrasProject.Oras/Registry/Remote/HttpResponseMessageExtensions.cs
@@ -54,7 +54,7 @@ internal static class HttpResponseMessageExtensions
 
     /// <summary>
     /// Returns the URL of the response's "Link" header, if present.
-    ///  The link header is of the form {link}; rel="next"
+    ///  The link header is of the form &lt;{link}&gt;; rel="next"
     /// </summary>
     /// <returns>next link or null if not present</returns>
     public static Uri? ParseLink(this HttpResponseMessage response)

--- a/src/OrasProject.Oras/Registry/Remote/ManifestStore.cs
+++ b/src/OrasProject.Oras/Registry/Remote/ManifestStore.cs
@@ -27,6 +27,9 @@ using Index = OrasProject.Oras.Oci.Index;
 
 namespace OrasProject.Oras.Registry.Remote;
 
+/// <summary>
+/// ManifestStore provides access to the manifests of a remote repository.
+/// </summary>
 public class ManifestStore(Repository repository) : IManifestStore
 {
     private Repository Repository { get; } = repository ?? throw new ArgumentNullException(nameof(repository));
@@ -392,6 +395,12 @@ public class ManifestStore(Repository repository) : IManifestStore
         response.VerifyContentDigest(expected.Digest);
     }
 
+    /// <summary>
+    /// Resolves the given reference to its descriptor.
+    /// </summary>
+    /// <param name="reference">The tag or digest to resolve.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The descriptor of the resolved manifest.</returns>
     public async Task<Descriptor> ResolveAsync(string reference, CancellationToken cancellationToken = default)
         => await ResolveAsync(reference, new ResolveOptions(), cancellationToken).ConfigureAwait(false);
 

--- a/src/OrasProject.Oras/Registry/Remote/Registry.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Registry.cs
@@ -26,20 +26,42 @@ using OrasProject.Oras.Serialization;
 
 namespace OrasProject.Oras.Registry.Remote;
 
+/// <summary>
+/// Registry provides access to a remote registry that implements the Docker Registry
+/// HTTP API V2 or the OCI Distribution Specification.
+/// </summary>
 public class Registry : IRegistry
 {
+    /// <summary>
+    /// Gets the options used to access repositories in this registry.
+    /// </summary>
     public RepositoryOptions RepositoryOptions => _opts;
 
     private RepositoryOptions _opts;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Registry"/> class for the given
+    /// registry host, using the default HTTP client.
+    /// </summary>
+    /// <param name="registry">The registry host, e.g. <c>registry.example.com</c>.</param>
     public Registry(string registry) : this(registry, new PlainClient()) { }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Registry"/> class for the given
+    /// registry host, using the specified HTTP client.
+    /// </summary>
+    /// <param name="registry">The registry host, e.g. <c>registry.example.com</c>.</param>
+    /// <param name="client">The client used to send HTTP requests.</param>
     public Registry(string registry, IClient client) => _opts = new()
     {
         Reference = new Reference(registry),
         Client = client,
     };
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Registry"/> class from the given options.
+    /// </summary>
+    /// <param name="options">The repository options used to access the registry.</param>
     public Registry(RepositoryOptions options) => _opts = options;
 
     /// <summary>

--- a/src/OrasProject.Oras/Registry/Remote/Repository.cs
+++ b/src/OrasProject.Oras/Registry/Remote/Repository.cs
@@ -60,6 +60,9 @@ public class Repository : IRepository
     public async Task<Uri?> GetBlobLocationAsync(Descriptor descriptor, CancellationToken cancellationToken = default)
         => await ((IBlobLocationProvider)Blobs).GetBlobLocationAsync(descriptor, cancellationToken).ConfigureAwait(false);
 
+    /// <summary>
+    /// Gets the options used to access the remote repository.
+    /// </summary>
     public RepositoryOptions Options => _opts;
 
     private int _referrersState = (int)Referrers.ReferrersState.Unknown;

--- a/src/OrasProject.Oras/Registry/Remote/UriFactory.cs
+++ b/src/OrasProject.Oras/Registry/Remote/UriFactory.cs
@@ -108,7 +108,7 @@ internal class UriFactory : UriBuilder
     /// Format: {scheme}://{registry}/v2/{repository}/referrers/{digest}
     /// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The URL for listing all referrers of the referenced content.</returns>
     public Uri BuildReferrersUrl()
     {
         return BuildReferrersUrl(string.Empty);
@@ -119,8 +119,8 @@ internal class UriFactory : UriBuilder
     /// Format: {scheme}://{registry}/v2/{repository}/referrers/{digest}?artifactType={artifactType}
     /// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
     /// </summary>
-    /// <param name="artifactType"></param>
-    /// <returns></returns>
+    /// <param name="artifactType">The artifact type used to filter the referrers; ignored when empty.</param>
+    /// <returns>The URL for listing referrers of the referenced content, optionally filtered by artifact type.</returns>
     public Uri BuildReferrersUrl(string artifactType)
     {
         var builder = NewRepositoryBaseBuilder();

--- a/src/OrasProject.Oras/Registry/Remote/UriFactory.cs
+++ b/src/OrasProject.Oras/Registry/Remote/UriFactory.cs
@@ -33,7 +33,7 @@ internal class UriFactory : UriBuilder
 
     /// <summary>
     /// Builds the URL for accessing the base API.
-    /// Format: <scheme>://<registry>/v2/
+    /// Format: {scheme}://{registry}/v2/
     /// Reference: https://docs.docker.com/registry/spec/api/#base
     /// </summary>
     public Uri BuildRegistryBase() => new UriBuilder(_base)
@@ -43,7 +43,7 @@ internal class UriFactory : UriBuilder
 
     /// <summary>
     /// Builds the URL for accessing the catalog API.
-    /// Format: <scheme>://<registry>/v2/_catalog
+    /// Format: {scheme}://{registry}/v2/_catalog
     /// Reference: https://docs.docker.com/registry/spec/api/#catalog
     /// </summary>
     public Uri BuildRegistryCatalog() => new UriBuilder(_base)
@@ -53,7 +53,7 @@ internal class UriFactory : UriBuilder
 
     /// <summary>
     /// Builds the URL for accessing the tag list API.
-    /// Format: <scheme>://<registry>/v2/<repository>/tags/list
+    /// Format: {scheme}://{registry}/v2/{repository}/tags/list
     /// Reference: https://docs.docker.com/registry/spec/api/#tags
     /// </summary>
     public Uri BuildRepositoryTagList()
@@ -65,7 +65,7 @@ internal class UriFactory : UriBuilder
 
     /// <summary>
     /// Builds the URL for accessing the manifest API.
-    /// Format: <scheme>://<registry>/v2/<repository>/manifests/<digest_or_tag>
+    /// Format: {scheme}://{registry}/v2/{repository}/manifests/{digest_or_tag}
     /// Reference: https://docs.docker.com/registry/spec/api/#manifest
     /// </summary>
     public Uri BuildRepositoryManifest()
@@ -81,7 +81,7 @@ internal class UriFactory : UriBuilder
 
     /// <summary>
     /// Builds the URL for accessing the blob API.
-    /// Format: <scheme>://<registry>/v2/<repository>/blobs/<digest>
+    /// Format: {scheme}://{registry}/v2/{repository}/blobs/{digest}
     /// Reference: https://docs.docker.com/registry/spec/api/#blob
     /// </summary>
     public Uri BuildRepositoryBlob()
@@ -93,7 +93,7 @@ internal class UriFactory : UriBuilder
 
     /// <summary>
     /// Builds the URL for accessing the blob upload API.
-    /// Format: <scheme>://<registry>/v2/<repository>/blobs/uploads/
+    /// Format: {scheme}://{registry}/v2/{repository}/blobs/uploads/
     /// Reference: https://docs.docker.com/registry/spec/api/#initiate-blob-upload
     /// </summary>
     public Uri BuildRepositoryBlobUpload()
@@ -105,7 +105,7 @@ internal class UriFactory : UriBuilder
 
     /// <summary>
     /// BuildReferrersUrl builds the URL for accessing referrers API
-    /// Format: <scheme>://<registry>/v2/<repository>/referrers/<digest>
+    /// Format: {scheme}://{registry}/v2/{repository}/referrers/{digest}
     /// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
     /// </summary>
     /// <returns></returns>
@@ -116,7 +116,7 @@ internal class UriFactory : UriBuilder
 
     /// <summary>
     /// BuildReferrersUrl builds the URL for accessing referrers API
-    /// Format: <scheme>://<registry>/v2/<repository>/referrers/<digest>?artifactType=<artifactType>
+    /// Format: {scheme}://{registry}/v2/{repository}/referrers/{digest}?artifactType={artifactType}
     /// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
     /// </summary>
     /// <param name="artifactType"></param>
@@ -137,7 +137,7 @@ internal class UriFactory : UriBuilder
 
     /// <summary>
     /// Generates a UriBuilder with the base endpoint of the remote repository.
-    /// Format: <scheme>://<registry>/v2/<repository>
+    /// Format: {scheme}://{registry}/v2/{repository}
     /// </summary>
     /// <returns>Repository-scoped base UriBuilder</returns>
     protected UriBuilder NewRepositoryBaseBuilder()


### PR DESCRIPTION
## What this PR does

Adds missing XML documentation comments across the public API surface and fixes malformed existing comments, so the library builds cleanly with documentation generation enabled.

## Changes

- **CS1570 (malformed XML):** switched angle-bracket URL-format placeholders (e.g. `<scheme>://<registry>`) to `{scheme}://{registry}` notation — readable and not parsed as XML — in `UriFactory`, `BlobStore`, `IBlobLocationProvider`, `HttpResponseMessageExtensions`.
- **CS1573:** added missing `<param name="cancellationToken">` tags (`MemoryGraph`, `StreamExtensions`, `HttpResponseMessageExtensions`).
- **CS1574:** added `using System;` so `InvalidOperationException`/`FormatException` crefs resolve in `HttpRequestMessageExtensions`.
- **CS1591:** documented public types and members — OCI models (`Descriptor`, `Manifest`, `Index`, `Platform`, `Versioned`), exceptions, registry/auth types (`Registry`, `Scope`, `Error`, `Credential`, etc.), extensions, and `Packer`/`PackManifestOptions`.
- Enabled `<GenerateDocumentationFile>` so the XML docs ship in the NuGet package and future missing/broken docs are caught by warnings-as-errors.

## Validation

- `dotnet build` (warnings-as-errors, the repo default): **0 warnings, 0 errors**.
- `dotnet test`: **593/593 passing**.

Documentation-only change; no public API or behavior changes.