### PR TITLE
fix: remove unnecessary async from TrustedHosts_IsReadOnly test

### DIFF
--- a/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/Auth/DefaultRealmValidatorTest.cs
@@ -419,7 +419,7 @@ public class DefaultRealmValidatorTest
     }
 
     [Fact]
-    public async Task TrustedHosts_IsReadOnly()
+    public void TrustedHosts_IsReadOnly()
     {
         var validator = new DefaultRealmValidator();
         // IReadOnlySet does not expose Add/Remove — compile-time


### PR DESCRIPTION
The TrustedHosts_IsReadOnly test method has no await operators, causing CS1998 (async method lacks await) which is treated as an error with warnings-as-errors enabled.

This is a one-line fix: change public async Task to public void.