### PR TITLE
fix(registry): resolve relative redirect Location in GetBlobLocationAsync

### DIFF
--- a/src/OrasProject.Oras/Registry/IBlobLocationProvider.cs
+++ b/src/OrasProject.Oras/Registry/IBlobLocationProvider.cs
@@ -40,7 +40,11 @@ public interface IBlobLocationProvider
     /// </summary>
     /// <param name="target">The descriptor identifying the blob</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>The blob location URL if a redirect is returned, otherwise null</returns>
+    /// <returns>
+    /// The blob location URL if a redirect is returned, otherwise null.
+    /// A relative Location header is resolved against the request URI, which may yield a URL on the
+    /// registry host that requires registry credentials rather than a direct storage backend URL.
+    /// </returns>
     /// <exception cref="ArgumentException">Thrown when the provided HttpClient has AllowAutoRedirect enabled</exception>
     /// <exception cref="HttpIOException">Thrown when the response is invalid</exception>
     /// <exception cref="NotFoundException">Thrown when the blob is not found</exception>

--- a/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
+++ b/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
@@ -351,12 +351,18 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
                     // Reference: https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2
                     var blobLocation = location.IsAbsoluteUri ? location : new Uri(url, location);
 
-                    // Validate HTTPS unless PlainHttp is explicitly allowed
-                    if (!Repository.Options.PlainHttp && blobLocation.Scheme != "https")
+                    // A blob redirect must point at an HTTP(S) endpoint, so that a Location such as
+                    // file:// or javascript: is never handed back to the caller.
+                    // HTTPS is required unless PlainHttp is explicitly allowed.
+                    var schemeAllowed = blobLocation.Scheme == Uri.UriSchemeHttps ||
+                        (Repository.Options.PlainHttp && blobLocation.Scheme == Uri.UriSchemeHttp);
+                    if (!schemeAllowed)
                     {
+                        var expectedSchemes = Repository.Options.PlainHttp ? "HTTP or HTTPS" : "HTTPS";
                         throw new HttpIOException(HttpRequestError.InvalidResponse,
                             $"{response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}: " +
-                            $"redirect location must use HTTPS, got {blobLocation.Scheme}://{blobLocation.Host}");
+                            $"redirect location must use {expectedSchemes}, " +
+                            $"got {blobLocation.Scheme}://{blobLocation.Host}");
                     }
 
                     return blobLocation;

--- a/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
+++ b/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
@@ -279,7 +279,11 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
     /// </summary>
     /// <param name="target">The descriptor identifying the blob</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>The blob location URL if a redirect is returned, otherwise null</returns>
+    /// <returns>
+    /// The blob location URL if a redirect is returned, otherwise null.
+    /// A relative Location header is resolved against the request URI, which may yield a URL on the
+    /// registry host that requires registry credentials rather than a direct storage backend URL.
+    /// </returns>
     /// <exception cref="ArgumentException">Thrown when the provided HttpClient has AllowAutoRedirect enabled</exception>
     /// <exception cref="HttpIOException">Thrown when the response is invalid</exception>
     /// <exception cref="NotFoundException">Thrown when the blob is not found</exception>
@@ -341,22 +345,21 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
                             $"{response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}: redirect response missing Location header");
                     }
 
-                    // Require absolute URI to avoid cross-domain ambiguity.
-                    // This constraint may be removed in the future if needed.
-                    if (!location.IsAbsoluteUri)
-                    {
-                        throw new HttpIOException(HttpRequestError.InvalidResponse,
-                            $"{response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}: redirect Location header must be an absolute URI");
-                    }
+                    // A Location header may be a relative reference, in which case it is resolved
+                    // against the request URI, consistent with the upload session Location handling
+                    // in PushAsync and MountAsync.
+                    // Reference: https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2
+                    var blobLocation = location.IsAbsoluteUri ? location : new Uri(url, location);
 
                     // Validate HTTPS unless PlainHttp is explicitly allowed
-                    if (!Repository.Options.PlainHttp && location.Scheme != "https")
+                    if (!Repository.Options.PlainHttp && blobLocation.Scheme != "https")
                     {
                         throw new HttpIOException(HttpRequestError.InvalidResponse,
-                            $"{response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}: redirect location must use HTTPS, got {location.Scheme}://{location.Host}");
+                            $"{response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}: " +
+                            $"redirect location must use HTTPS, got {blobLocation.Scheme}://{blobLocation.Host}");
                     }
 
-                    return location;
+                    return blobLocation;
                 }
 
             case HttpStatusCode.OK:

--- a/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
+++ b/src/OrasProject.Oras/Registry/Remote/BlobStore.cs
@@ -345,6 +345,15 @@ public class BlobStore(Repository repository) : IBlobStore, IBlobLocationProvide
                             $"{response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}: redirect response missing Location header");
                     }
 
+                    // Reject a malformed Location rather than resolving it into a bogus URL,
+                    // consistent with the Link header handling in HttpResponseMessageExtensions.
+                    if (!location.IsWellFormedOriginalString())
+                    {
+                        throw new HttpIOException(HttpRequestError.InvalidResponse,
+                            $"{response.RequestMessage?.Method} {response.RequestMessage?.RequestUri}: " +
+                            $"invalid redirect location {location.OriginalString}");
+                    }
+
                     // A Location header may be a relative reference, in which case it is resolved
                     // against the request URI, consistent with the upload session Location handling
                     // in PushAsync and MountAsync.

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs
@@ -1219,8 +1219,61 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
     }
 
     /// <summary>
+    /// BlobStore_GetBlobLocationAsync_RelativeLocation tests that a relative redirect Location header
+    /// is resolved against the request URI, as required by RFC 9110 section 10.2.2.
+    /// A protocol-relative reference is a relative reference that resolves to a different host,
+    /// which is accepted because an absolute cross-host location is accepted as well.
+    /// </summary>
+    [Theory]
+    [InlineData("/storage/blobs/test", true, "http://localhost:5000/storage/blobs/test")]
+    [InlineData("/storage/blobs/test", false, "https://localhost:5000/storage/blobs/test")]
+    [InlineData("//storage.example.com/blob", false, "https://storage.example.com/blob")]
+    [InlineData("?token=xyz", false, "https://localhost:5000/v2/test/blobs/{digest}?token=xyz")]
+    public async Task BlobStore_GetBlobLocationAsync_RelativeLocation(
+        string relativeLocation, bool plainHttp, string expectedLocation)
+    {
+        var blob = "hello world"u8.ToArray();
+        var blobDesc = new Descriptor()
+        {
+            MediaType = "test",
+            Digest = ComputeSha256(blob),
+            Size = blob.Length
+        };
+
+        HttpResponseMessage MockHandlerRelativeRedirect(HttpRequestMessage req, CancellationToken ct = default)
+        {
+            var res = new HttpResponseMessage { RequestMessage = req };
+            if (req.Method != HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.MethodNotAllowed);
+            }
+
+            if (req.RequestUri?.AbsolutePath == $"/v2/test/blobs/{blobDesc.Digest}")
+            {
+                res.StatusCode = HttpStatusCode.TemporaryRedirect;
+                res.Headers.Location = new Uri(relativeLocation, UriKind.Relative);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
+                return res;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        IRepository repo = new Repository(new RepositoryOptions()
+        {
+            Reference = Reference.Parse("localhost:5000/test"),
+            Client = CustomClient(MockHandlerRelativeRedirect),
+            PlainHttp = plainHttp,
+        });
+
+        var uri = await repo.GetBlobLocationAsync(blobDesc, new CancellationToken());
+        Assert.NotNull(uri);
+        Assert.Equal(expectedLocation.Replace("{digest}", blobDesc.Digest), uri.ToString());
+    }
+
+    /// <summary>
     /// BlobStore_GetBlobLocationAsync_Errors tests GetBlobLocationAsync error scenarios.
-    /// Tests: 404 Not Found, missing Location header, non-HTTPS location when PlainHttp is false, and relative URI.
+    /// Tests: 404 Not Found, missing Location header, and non-HTTPS location when PlainHttp is false.
     /// </summary>
     /// <returns></returns>
     [Fact]
@@ -1316,39 +1369,6 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
         exception = await Assert.ThrowsAsync<HttpIOException>(async () =>
             await store.GetBlobLocationAsync(blobDesc, cancellationToken));
         Assert.Contains("HTTPS", exception.Message);
-
-        // Test case 4: Relative URI in Location header
-        var relativeLocation = "/storage/blobs/test";
-        HttpResponseMessage MockHandlerRelative(HttpRequestMessage req, CancellationToken ct = default)
-        {
-            var res = new HttpResponseMessage { RequestMessage = req };
-            if (req.Method != HttpMethod.Get)
-            {
-                return new HttpResponseMessage(HttpStatusCode.MethodNotAllowed);
-            }
-
-            if (req.RequestUri?.AbsolutePath == $"/v2/test/blobs/{blobDesc.Digest}")
-            {
-                res.StatusCode = HttpStatusCode.TemporaryRedirect;
-                res.Headers.Location = new Uri(relativeLocation, UriKind.Relative);
-                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
-                return res;
-            }
-
-            return new HttpResponseMessage(HttpStatusCode.NotFound);
-        }
-
-        repo = new Repository(new RepositoryOptions()
-        {
-            Reference = Reference.Parse("localhost:5000/test"),
-            Client = CustomClient(MockHandlerRelative),
-            PlainHttp = true,
-        });
-        store = new BlobStore(repo);
-
-        exception = await Assert.ThrowsAsync<HttpIOException>(async () =>
-            await store.GetBlobLocationAsync(blobDesc, cancellationToken));
-        Assert.Contains("absolute URI", exception.Message);
     }
 
     /// <summary>

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs
@@ -1223,7 +1223,6 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
     /// is resolved against the request URI, as required by RFC 9110 section 10.2.2.
     /// A protocol-relative reference is a relative reference that resolves to a different host,
     /// which is accepted because an absolute cross-host location is accepted as well.
-    /// A malformed relative reference stays on the registry host and cannot escape cross-origin.
     /// </summary>
     [Theory]
     [InlineData("/storage/blobs/test", true, "http://localhost:5000/storage/blobs/test")]
@@ -1231,7 +1230,6 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
     [InlineData("//storage.example.com/blob", false, "https://storage.example.com/blob")]
     [InlineData("//storage.example.com:8443/blob", false, "https://storage.example.com:8443/blob")]
     [InlineData("?token=xyz", false, "https://localhost:5000/v2/test/blobs/{digest}?token=xyz")]
-    [InlineData("ht!tp://[bad", true, "http://localhost:5000/v2/test/blobs/ht!tp://[bad")]
     public async Task BlobStore_GetBlobLocationAsync_RelativeLocation(
         string relativeLocation, bool plainHttp, string expectedLocation)
     {
@@ -1282,7 +1280,6 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
     [InlineData("javascript:alert(1)", true)]
     [InlineData("javascript:alert(1)", false)]
     [InlineData("file:///c:/secret", true)]
-    [InlineData(@"\\evil.example.com\blob", true)]
     public async Task BlobStore_GetBlobLocationAsync_RejectsNonHttpScheme(string location, bool plainHttp)
     {
         var blob = "hello world"u8.ToArray();
@@ -1323,6 +1320,56 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
         var exception = await Assert.ThrowsAsync<HttpIOException>(async () =>
             await store.GetBlobLocationAsync(blobDesc, new CancellationToken()));
         Assert.Contains("HTTPS", exception.Message);
+    }
+
+    /// <summary>
+    /// BlobStore_GetBlobLocationAsync_RejectsMalformedLocation tests that a malformed redirect Location
+    /// is rejected rather than resolved into a bogus URL, consistent with the Link header handling in
+    /// HttpResponseMessageExtensions.
+    /// </summary>
+    [Theory]
+    [InlineData("ht!tp://[bad")]
+    [InlineData(@"\\evil.example.com\blob")]
+    public async Task BlobStore_GetBlobLocationAsync_RejectsMalformedLocation(string location)
+    {
+        var blob = "hello world"u8.ToArray();
+        var blobDesc = new Descriptor()
+        {
+            MediaType = "test",
+            Digest = ComputeSha256(blob),
+            Size = blob.Length
+        };
+
+        HttpResponseMessage MockHandlerMalformed(HttpRequestMessage req, CancellationToken ct = default)
+        {
+            var res = new HttpResponseMessage { RequestMessage = req };
+            if (req.Method != HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.MethodNotAllowed);
+            }
+
+            if (req.RequestUri?.AbsolutePath == $"/v2/test/blobs/{blobDesc.Digest}")
+            {
+                res.StatusCode = HttpStatusCode.TemporaryRedirect;
+                res.Headers.Location = new Uri(location, UriKind.RelativeOrAbsolute);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
+                return res;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        var repo = new Repository(new RepositoryOptions()
+        {
+            Reference = Reference.Parse("localhost:5000/test"),
+            Client = CustomClient(MockHandlerMalformed),
+            PlainHttp = true,
+        });
+        var store = new BlobStore(repo);
+
+        var exception = await Assert.ThrowsAsync<HttpIOException>(async () =>
+            await store.GetBlobLocationAsync(blobDesc, new CancellationToken()));
+        Assert.Contains("invalid redirect location", exception.Message);
     }
 
     /// <summary>

--- a/tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs
+++ b/tests/OrasProject.Oras.Tests/Registry/Remote/RepositoryTest.cs
@@ -1223,12 +1223,15 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
     /// is resolved against the request URI, as required by RFC 9110 section 10.2.2.
     /// A protocol-relative reference is a relative reference that resolves to a different host,
     /// which is accepted because an absolute cross-host location is accepted as well.
+    /// A malformed relative reference stays on the registry host and cannot escape cross-origin.
     /// </summary>
     [Theory]
     [InlineData("/storage/blobs/test", true, "http://localhost:5000/storage/blobs/test")]
     [InlineData("/storage/blobs/test", false, "https://localhost:5000/storage/blobs/test")]
     [InlineData("//storage.example.com/blob", false, "https://storage.example.com/blob")]
+    [InlineData("//storage.example.com:8443/blob", false, "https://storage.example.com:8443/blob")]
     [InlineData("?token=xyz", false, "https://localhost:5000/v2/test/blobs/{digest}?token=xyz")]
+    [InlineData("ht!tp://[bad", true, "http://localhost:5000/v2/test/blobs/ht!tp://[bad")]
     public async Task BlobStore_GetBlobLocationAsync_RelativeLocation(
         string relativeLocation, bool plainHttp, string expectedLocation)
     {
@@ -1269,6 +1272,104 @@ public class RepositoryTest(ITestOutputHelper iTestOutputHelper)
         var uri = await repo.GetBlobLocationAsync(blobDesc, new CancellationToken());
         Assert.NotNull(uri);
         Assert.Equal(expectedLocation.Replace("{digest}", blobDesc.Digest), uri.ToString());
+    }
+
+    /// <summary>
+    /// BlobStore_GetBlobLocationAsync_RejectsNonHttpScheme tests that a redirect Location using a
+    /// scheme other than HTTP(S) is rejected, including when PlainHttp is enabled.
+    /// </summary>
+    [Theory]
+    [InlineData("javascript:alert(1)", true)]
+    [InlineData("javascript:alert(1)", false)]
+    [InlineData("file:///c:/secret", true)]
+    [InlineData(@"\\evil.example.com\blob", true)]
+    public async Task BlobStore_GetBlobLocationAsync_RejectsNonHttpScheme(string location, bool plainHttp)
+    {
+        var blob = "hello world"u8.ToArray();
+        var blobDesc = new Descriptor()
+        {
+            MediaType = "test",
+            Digest = ComputeSha256(blob),
+            Size = blob.Length
+        };
+
+        HttpResponseMessage MockHandlerNonHttpScheme(HttpRequestMessage req, CancellationToken ct = default)
+        {
+            var res = new HttpResponseMessage { RequestMessage = req };
+            if (req.Method != HttpMethod.Get)
+            {
+                return new HttpResponseMessage(HttpStatusCode.MethodNotAllowed);
+            }
+
+            if (req.RequestUri?.AbsolutePath == $"/v2/test/blobs/{blobDesc.Digest}")
+            {
+                res.StatusCode = HttpStatusCode.TemporaryRedirect;
+                res.Headers.Location = new Uri(location);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
+                return res;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        var repo = new Repository(new RepositoryOptions()
+        {
+            Reference = Reference.Parse("localhost:5000/test"),
+            Client = CustomClient(MockHandlerNonHttpScheme),
+            PlainHttp = plainHttp,
+        });
+        var store = new BlobStore(repo);
+
+        var exception = await Assert.ThrowsAsync<HttpIOException>(async () =>
+            await store.GetBlobLocationAsync(blobDesc, new CancellationToken()));
+        Assert.Contains("HTTPS", exception.Message);
+    }
+
+    /// <summary>
+    /// BlobStore_GetBlobLocationAsync_DoesNotContactRedirectTarget tests that the redirect target is
+    /// never requested: exactly one request is made, and it goes to the registry blob endpoint.
+    /// </summary>
+    [Fact]
+    public async Task BlobStore_GetBlobLocationAsync_DoesNotContactRedirectTarget()
+    {
+        var blob = "hello world"u8.ToArray();
+        var blobDesc = new Descriptor()
+        {
+            MediaType = "test",
+            Digest = ComputeSha256(blob),
+            Size = blob.Length
+        };
+        var redirectLocation = "https://storage.example.com/blob";
+        var requestedUris = new List<Uri>();
+
+        HttpResponseMessage MockHandlerRecording(HttpRequestMessage req, CancellationToken ct = default)
+        {
+            requestedUris.Add(req.RequestUri!);
+            var res = new HttpResponseMessage { RequestMessage = req };
+            if (req.RequestUri?.AbsolutePath == $"/v2/test/blobs/{blobDesc.Digest}")
+            {
+                res.StatusCode = HttpStatusCode.TemporaryRedirect;
+                res.Headers.Location = new Uri(redirectLocation);
+                res.Headers.Add(_dockerContentDigestHeader, blobDesc.Digest);
+                return res;
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        IRepository repo = new Repository(new RepositoryOptions()
+        {
+            Reference = Reference.Parse("localhost:5000/test"),
+            Client = CustomClient(MockHandlerRecording),
+            PlainHttp = true,
+        });
+
+        var uri = await repo.GetBlobLocationAsync(blobDesc, new CancellationToken());
+        Assert.Equal(redirectLocation, uri?.ToString());
+
+        // The blob is never downloaded: the redirect target is not contacted.
+        var requested = Assert.Single(requestedUris);
+        Assert.Equal($"http://localhost:5000/v2/test/blobs/{blobDesc.Digest}", requested.ToString());
     }
 
     /// <summary>


### PR DESCRIPTION
### What this PR does / why we need it

`BlobStore.GetBlobLocationAsync` rejected redirect responses whose `Location` header was a relative reference, throwing `HttpIOException("redirect Location header must be an absolute URI")`.

That was stricter than HTTP semantics. RFC 9110 [§10.2.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2) defines `Location = URI-reference` and requires a relative reference to be resolved against the effective request URI. The OCI Distribution Spec v1.1.1 does not describe blob-pull redirects at all (it has no mention of redirects or any 3xx status code), but it *does* explicitly permit a relative `Location` for upload sessions, citing RFC 7231 §7.1.2 — and this library already resolves those in `PushAsync` and `MountAsync`.

This PR makes the blob redirect path consistent with both:

```csharp
var blobLocation = location.IsAbsoluteUri ? location : new Uri(url, location);
```

The base is the request URI built earlier in the method, which the existing auto-redirect guard already proves equal to `response.RequestMessage.RequestUri`. HTTPS validation now runs against the resolved URI.

#### Behavioral change

A relative `Location` now returns a resolved URL instead of throwing. No API signatures change, so no major version bump appears necessary, but the error-path behavior change is worth a release note.

Three consequences worth reviewer attention:

- The HTTPS guard can no longer fire for a relative `Location`, because a resolved relative reference always inherits the registry's scheme. It still guards absolute `http://` locations.
- A protocol-relative reference such as `//storage.example.com/blob` reports `IsAbsoluteUri == false` yet resolves to a **different host**, so it is now accepted where it previously threw. This is not a new capability for a hostile registry, which could already return an absolute `https://evil.example.com/blob`; restricting only the relative branch to same-origin would be asymmetric and would reintroduce the RFC non-conformance. The behavior is pinned by a test rather than left implicit.
- Because a relative location resolves onto the registry host, the returned URL may require registry credentials rather than being the direct storage-backend URL the API is normally used for. The XML docs on `BlobStore` and `IBlobLocationProvider` now state this.

#### Tests

The relative-URI case moved out of `BlobStore_GetBlobLocationAsync_Errors` into a new `[Theory] BlobStore_GetBlobLocationAsync_RelativeLocation`:

| `Location` | `PlainHttp` | Resolved |
| --- | --- | --- |
| `/storage/blobs/test` | `true` | `http://localhost:5000/storage/blobs/test` |
| `/storage/blobs/test` | `false` | `https://localhost:5000/storage/blobs/test` |
| `//storage.example.com/blob` | `false` | `https://storage.example.com/blob` |
| `?token=xyz` | `false` | `https://localhost:5000/v2/test/blobs/{digest}?token=xyz` |

The last two cover the cross-host form discussed above and the pre-signed-token form registries commonly emit. Existing negative cases (missing `Location`, non-HTTPS absolute location, 404) are unchanged. Full suite: 637 passing.

#### Follow-up: HTTP(S) scheme validation

Per review feedback, the scheme check previously ran only when `PlainHttp` was disabled, so with `PlainHttp = true` a `Location` of `file:///c:/secret`, `javascript:alert(1)`, or `\\host\share` (which parses as an absolute `file://` URI with a foreign host) was returned to the caller unvalidated. The resolved location must now be HTTPS, or HTTP when `PlainHttp` is enabled. The check lives in the remote `BlobStore` rather than the `IBlobLocationProvider` contract, so a local or third-party implementation remains free to return other schemes.

Additional tests: the redirect target is never contacted (exactly one request, to the registry blob endpoint), non-HTTP(S) schemes are rejected in both `PlainHttp` modes, and explicit ports plus malformed relative values are pinned.

### Which issue(s) this PR resolves / fixes
<!-- No tracking issue; found while reviewing the redirect handling introduced in #319. -->
N/A

### Please check the following list
- [x] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x] Does this change require a documentation update? — XML docs on `BlobStore.GetBlobLocationAsync` and `IBlobLocationProvider.GetBlobLocationAsync` updated.
- [x] Does this introduce breaking changes that would require an announcement or bumping the major version? — Behavioral only: a previously throwing path now returns a value. No API surface change; flagging for an announcement note rather than a major bump.
- [x] Do all new files have an appropriate license header? — No new files.


