### PR TITLE
feat: support .NET 10 via multi-targeting (net8.0;net10.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "dotnet-sdk" #global.json
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,20 +28,66 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['8.0.x']
+        target-framework: ['net8.0', 'net10.0']
       fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Set up dotnet ${{ matrix.dotnet-version }} environment
+      - name: Set up dotnet environment
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-      - name: Run unit tests
-        run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover ./tests/OrasProject.Oras.Tests
+          # The .NET 10 SDK builds every target framework; the .NET 8 runtime is
+          # required to actually execute the net8.0 test run.
+          dotnet-version: |
+            8.0.x
+            10.0.x
+      - name: Run unit tests (${{ matrix.target-framework }})
+        run: >
+          dotnet test ./tests/OrasProject.Oras.Tests
+          --framework ${{ matrix.target-framework }}
+          /p:CollectCoverage=true
+          /p:CoverletOutputFormat=opencover
+          /p:CoverletOutput=${{ github.workspace }}/coverage/${{ matrix.target-framework }}/
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: ./tests/OrasProject.Oras.Tests/coverage.opencover.xml
+          directory: ${{ github.workspace }}/coverage/${{ matrix.target-framework }}
+          flags: ${{ matrix.target-framework }}
+
+  # Guards the core promise of multi-targeting: the published package must stay
+  # restorable from a net8.0 project built with the .NET 8 SDK.
+  package-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up dotnet environment
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+      - name: Pack
+        run: >
+          dotnet pack ./src/OrasProject.Oras
+          --configuration Release
+          --output "$RUNNER_TEMP/nupkgs"
+          /p:PackageVersion=0.0.0-ci
+      - name: Assert the package ships both target frameworks
+        run: |
+          unzip -o -q "$RUNNER_TEMP/nupkgs/OrasProject.Oras.0.0.0-ci.nupkg" -d "$RUNNER_TEMP/extracted"
+          test -f "$RUNNER_TEMP/extracted/lib/net8.0/OrasProject.Oras.dll"
+          test -f "$RUNNER_TEMP/extracted/lib/net10.0/OrasProject.Oras.dll"
+      - name: Build a net8.0 consumer against the packed output using the .NET 8 SDK
+        run: |
+          CONSUMER="$RUNNER_TEMP/consumer"
+          mkdir -p "$CONSUMER"
+          cd "$CONSUMER"
+          printf '{ "sdk": { "version": "8.0.100", "rollForward": "latestFeature" } }\n' > global.json
+          dotnet new console -f net8.0 -o app
+          cd app
+          printf '<configuration><packageSources><clear /><add key="nuget.org" value="https://api.nuget.org/v3/index.json" /><add key="local" value="%s" /></packageSources></configuration>\n' "$RUNNER_TEMP/nupkgs" > NuGet.config
+          dotnet add package OrasProject.Oras --version 0.0.0-ci
+          dotnet build --configuration Release

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,17 +33,15 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    strategy:
-      matrix:
-        dotnet-version: ['8.0.x']
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-      - name: Set up dotnet ${{ matrix.dotnet-version }} environment
+      - name: Set up dotnet environment
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: |
+            8.0.x
+            10.0.x
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,12 +43,12 @@ jobs:
             8.0.x
             10.0.x
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v4.37.4
         with:
           languages: csharp
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@v4.37.4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v4.37.4
         with:
           category: "/language:csharp"

--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Install DocFX
         run: |

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Set up dotnet environment
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
       - name: Validate tag name
         uses: ./.github/actions/validate-tag
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,24 @@ Please start with the [ORAS contributing guide](https://oras.land/community/cont
 Below are specifics for the oras-dotnet project:
 
 ## Prerequisites
-- .NET 8 SDK or higher is required.
+- .NET 10 SDK is required **to build this repository**. The SDK version is pinned in
+  [`global.json`](global.json). An older SDK cannot build a newer target framework, so the
+  .NET 8 SDK alone is not sufficient.
+- The .NET 8 runtime is additionally required to **run** the `net8.0` test pass, because
+  .NET does not roll forward across major versions by default. Installing both the .NET 8
+  and .NET 10 SDKs is the simplest way to get a working local setup.
+- These are build-time requirements for contributors only. They do **not** raise the bar for
+  consumers of the published NuGet package — see [Target Frameworks](#target-frameworks).
+
+## Target Frameworks
+The library multi-targets `net8.0` and `net10.0`, so the published package remains fully
+consumable from .NET 8 applications. Building a `net10.0` target requires the .NET 10 SDK,
+which is why the SDK prerequisite is higher than the lowest supported target framework.
+
+When adding support for a newer .NET release, **add** a target framework rather than
+replacing one — replacing it makes the published NuGet package unresolvable (`NU1202`) for
+consumers on the older framework. Existing targets are only dropped in a MAJOR release, and
+no earlier than that framework's end of support.
 
 ## Build
 - Run: `dotnet build`
@@ -13,7 +30,8 @@ Below are specifics for the oras-dotnet project:
 ## Tests and Coverage
 - Changes in a pull request should include relevant tests.
 - Patch test coverage requirement: at least 80%.
-- Run tests: `dotnet test`
+- Run tests: `dotnet test` (runs every target framework)
+- Run tests for a single target framework: `dotnet test --framework net8.0`
 
 ## Linting
 - It's recommended to run `dotnet format` before pushing the commit, to avoid linting errors.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,6 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.400" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/OrasProject.Oras.sln
+++ b/OrasProject.Oras.sln
@@ -12,6 +12,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrasProject.Oras.Examples.ExternalTokenBroker", "examples\OrasProject.Oras.Examples.ExternalTokenBroker\OrasProject.Oras.Examples.ExternalTokenBroker.csproj", "{443703EE-D73C-4EE3-882D-5DD7DFFD09B6}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrasProject.Oras.Examples.RealmValidation", "examples\OrasProject.Oras.Examples.RealmValidation\OrasProject.Oras.Examples.RealmValidation.csproj", "{667D44C5-0DF2-4FC3-B228-0032CA585002}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -10,6 +10,9 @@
         }
       ],
       "dest": "api",
+      "properties": {
+        "TargetFramework": "net10.0"
+      },
       "includePrivateMembers": false,
       "disableGitFeatures": false,
       "disableDefaultFilter": false,

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/src/OrasProject.Oras/OrasProject.Oras.csproj
+++ b/src/OrasProject.Oras/OrasProject.Oras.csproj
@@ -14,7 +14,7 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<PackageId>OrasProject.Oras</PackageId>
 		<PackageVersion>0.0.0-dev</PackageVersion>
 		<Authors>Oras Project</Authors>
@@ -37,10 +37,13 @@ limitations under the License.
 			<_Parameter1>OrasProject.Oras.Tests</_Parameter1>
 		</AssemblyAttribute>
 	</ItemGroup>
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-		<PackageReference Include="System.Text.Json" Version="8.0.6" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="README.md" Pack="true" PackagePath="/" />

--- a/tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj
+++ b/tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj
@@ -15,7 +15,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj
+++ b/tests/OrasProject.Oras.Tests/OrasProject.Oras.Tests.csproj
@@ -29,10 +29,10 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## What

Adds .NET 10 support by multi-targeting `net8.0;net10.0`.

Closes #426

## Why this does not break .NET 8 consumers

The `net10.0` target is **added**, not swapped in. The published package ships both `lib/net8.0/` and `lib/net10.0/`, and NuGet selects the best folder at or below the consuming project's target framework. A `net8.0` application resolves `lib/net8.0/` exactly as it does today and needs no SDK, runtime, or code change.

Replacing `net8.0` instead would have failed every .NET 8 consumer at restore with `NU1202`.

Dependencies are pinned per target framework, so a net8.0 consumer's dependency closure is unchanged. Without that split, net8.0 consumers would have been silently moved onto 10.0.x dependencies.

`net9.0` is intentionally excluded: it reaches end of support the same day as .NET 8 (Nov 10, 2026), so it would add CI cost for no coverage gain.

## Changes

- **`src/OrasProject.Oras`**: `TargetFrameworks=net8.0;net10.0`; `PackageReference`s split into per-TFM conditional `ItemGroup`s.
- **`tests/OrasProject.Oras.Tests`**: matching target frameworks.
- **`global.json`** (new): pins SDK `10.0.100`, `rollForward: latestFeature`, `allowPrerelease: false`. Building a `net10.0` target requires the .NET 10 SDK, so this turns an obscure `NETSDK1045` into a clear "install 10.0.100". Prerelease is disabled so a preview feature band cannot silently become the release compiler under `TreatWarningsAsErrors`.
- **`System.Text.Json` reference removed**: it is provided by the shared framework on net8.0+, and the .NET 10 SDK reports it as a prunable reference (`NU1510`), which is an error under this repo's `TreatWarningsAsErrors`. Per [Microsoft guidance](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/nu1510-pruned-references) the correct fix is to remove it; the framework-provided assembly is what actually loads at runtime either way, and runtime patching remains the correct CVE mitigation.
- **`.github/workflows/build.yml`**: matrix is now over target framework rather than SDK version, and installs both SDKs. Adds a `package-compat` job that packs the library, asserts both `lib/` folders exist, and builds a real net8.0 console app against the packed `.nupkg` using the .NET 8 SDK — so the compatibility claim above is verified in CI rather than assumed.
- **Other workflows**: install both SDKs.
- **`docs/docfx.json`**: pin `TargetFramework` so API docs are deterministic for a multi-targeted project.
- **`OrasProject.Oras.sln`**: add a missing `EndProject` after the ExternalTokenBroker entry. Pre-existing malformation that can break solution parsing and CodeQL autobuild.
- **`.github/dependabot.yml`**: add a `dotnet-sdk` entry so the new `global.json` receives SDK updates.
- **`CONTRIBUTING.md`**: document the .NET 10 SDK build requirement, note the .NET 8 runtime is also needed for the net8.0 test pass, and record the "add, never replace a TFM" policy.

## Verification

Performed locally with SDK 10.0.303 and the .NET 8 runtime installed:

- `dotnet build` succeeds for both target frameworks, 0 warnings.
- `dotnet test` passes **637/637 on net8.0 and 637/637 on net10.0**.
- `dotnet build OrasProject.Oras.sln` succeeds, including all three net8.0 example projects referencing the multi-targeted library.
- The packed `.nupkg` contains `lib/net8.0/OrasProject.Oras.dll` and `lib/net10.0/OrasProject.Oras.dll`, with these nuspec dependency groups:

  ```
  net8.0  -> Microsoft.Extensions.Caching.Abstractions 8.0.0, Microsoft.Extensions.Caching.Memory 8.0.1
  net10.0 -> Microsoft.Extensions.Caching.Abstractions 10.0.0, Microsoft.Extensions.Caching.Memory 10.0.0
  ```

- A fresh `net8.0` console app restored the packed package ("compatible with all the specified frameworks"), compiled against `Descriptor`, and ran successfully.

## Contributor impact

Building the repo now requires the .NET 10 SDK; an older SDK cannot build a newer target framework. Running the full test suite also needs the .NET 8 runtime installed. This is a build-time requirement only and does not affect consumers of the package.

## Versioning

Additive, so a MINOR bump under the SemVer policy in the README. `net8.0` should not be dropped before its Nov 10, 2026 end of support, and then only in a MAJOR release.
